### PR TITLE
fix(build): staple backup/restore, xcodegen, Sparkle key, signing fixes

### DIFF
--- a/.claude/skills/build-pkg-mac/SKILL.md
+++ b/.claude/skills/build-pkg-mac/SKILL.md
@@ -3,31 +3,42 @@ name: build-pkg-mac
 description: Build the AskMac .pkg installer locally — sign, notarize, create DMGs, update appcast, and publish GitHub Release. Run after /release-mac.
 ---
 
-Build, sign, notarize, and publish the AskMac release artifacts by running `scripts/build-release.sh`. This is a local operation — it requires Apple credentials and Developer ID certificates in your Keychain.
+Build, sign, notarize, and publish the AskMac release artifacts by running `scripts/build-release.sh`. This is a local operation requiring Apple credentials and Developer ID certificates in Keychain.
 
 ## Step 1 — Verify prerequisites
 
-Check that all required tools and credentials are in place:
+Run these checks:
 
 ```bash
-# Check required env vars
-for var in APPLE_ID APPLE_ID_PASSWORD APPLE_TEAM_ID; do
-    echo "$var=${!var:-<NOT SET>}"
-done
+# Tools
+command -v create-dmg && echo "create-dmg: OK" || echo "MISSING: brew install create-dmg"
+command -v xcodegen && echo "xcodegen: OK"   || echo "MISSING: brew install xcodegen"
+command -v gh && echo "gh: OK"               || echo "MISSING: brew install gh"
+gh auth status 2>&1 | head -2
 
-# Check required tools
-command -v create-dmg && echo "create-dmg: OK" || echo "create-dmg: MISSING (brew install create-dmg)"
-command -v gh && echo "gh: OK" || echo "gh: MISSING (brew install gh)"
-gh auth status 2>&1 | head -3
+# Sparkle signing tool
+ls sparkle/bin/sign_update 2>/dev/null && echo "sign_update: OK" || echo "MISSING — see note below"
 
-# Check Sparkle signing tool
-ls sparkle/bin/sign_update 2>/dev/null && echo "sign_update: OK" || echo "sign_update: MISSING"
+# Apple credentials (loaded automatically from Keychain by the build script)
+security find-generic-password -a "$USER" -s APPLE_ID -w &>/dev/null && echo "APPLE_ID: OK" || echo "MISSING"
+security find-generic-password -a "$USER" -s APPLE_ID_PASSWORD -w &>/dev/null && echo "APPLE_ID_PASSWORD: OK" || echo "MISSING"
+security find-generic-password -a "$USER" -s APPLE_TEAM_ID -w &>/dev/null && echo "APPLE_TEAM_ID: OK" || echo "MISSING"
 
-# Check Developer ID certs
-security find-identity -v -p codesigning | grep -E "Developer ID (Application|Installer)" || echo "No Developer ID certs found"
+# Developer ID certs
+security find-identity -v -p codesigning | grep "Developer ID Application" || echo "MISSING"
+security find-identity -v | grep "Developer ID Installer" || echo "MISSING"
 ```
 
-If any prerequisite is missing, stop and tell the user what to fix. Do not proceed until all are satisfied.
+**If Sparkle tools are missing:** Download `Sparkle-{version}.tar.xz` from github.com/sparkle-project/Sparkle/releases and extract to `sparkle/` in the repo root. Then run `./sparkle/bin/generate_keys` once — it stores the private key in Keychain and prints the public key. Add the public key to `AskMac/Sources/AskMac/Info.plist` as `SUPublicEDKey`.
+
+**If Developer ID certs are missing:** Open Xcode → Settings → Accounts → your Apple ID → Manage Certificates → `+` → Developer ID Application + Developer ID Installer.
+
+**If Apple credentials are missing:** Store them in Keychain (use an app-specific password from appleid.apple.com, not your account password):
+```bash
+security add-generic-password -a "$USER" -s APPLE_ID -w "your@apple.id"
+security add-generic-password -a "$USER" -s APPLE_ID_PASSWORD -w "xxxx-xxxx-xxxx-xxxx"
+security add-generic-password -a "$USER" -s APPLE_TEAM_ID -w "B5J28L8ARB"
+```
 
 ## Step 2 — Read the current version
 
@@ -35,7 +46,7 @@ If any prerequisite is missing, stop and tell the user what to fix. Do not proce
 grep 'MARKETING_VERSION' AskMac/project.yml | head -1
 ```
 
-Extract the version string (e.g. `1.3.0`).
+Extract the version string (e.g. `0.7.0`).
 
 ## Step 3 — Confirm with the user
 
@@ -44,18 +55,21 @@ Show:
 Ready to build AskMac v{version}
 
 This will run scripts/build-release.sh which:
-  1. Archive + export AskMac.app via xcodebuild
-  2. Bundle scripts from ask/scripts/
-  3. Re-sign the app
-  4. Build component PKGs (app + each script)
-  5. Build distribution PKG (AskMac-{version}.pkg)
-  6. Notarize + staple PKG
-  7. Create installer DMG (AskMac-{version}-installer.dmg)
-  8. Create Sparkle update DMG (AskMac-{version}.dmg)
-  9. Notarize + staple Sparkle DMG
-  10. Update docs/appcast.xml and push to main
-  11. Create GitHub Release with both DMGs attached
+  1. Generate AskMac.xcodeproj from project.yml (xcodegen)
+  2. Archive + export AskMac.app via xcodebuild
+  3. Bundle scripts from ask/scripts/ (excluding .build/ dirs)
+  4. Sign any Mach-O binaries in bundled scripts with Developer ID
+  5. Re-sign the app with Developer ID Application
+  6. Build component PKGs (app + each script)
+  7. Build distribution PKG (AskMac-{version}.pkg)
+  8. Notarize + staple PKG
+  9. Create installer DMG (AskMac-{version}-installer.dmg)
+  10. Create Sparkle update DMG (AskMac-{version}.dmg)
+  11. Notarize + staple Sparkle DMG
+  12. Update docs/appcast.xml and push to main
+  13. Create GitHub Release with both DMGs attached
 
+Apple credentials are loaded automatically from Keychain.
 This takes 10–20 minutes. Proceed? (yes/no)
 ```
 
@@ -67,13 +81,15 @@ Wait for explicit confirmation before continuing.
 ./scripts/build-release.sh
 ```
 
-Stream output to the user. Do not run it in the background — the user needs to see progress.
+Do not run in the background — stream output so the user can see progress.
 
-If it fails, show the error and stop. Common failures:
-- **Code signing error** — cert not in Keychain or expired
-- **Notarization timeout** — Apple servers slow; can retry
-- **`APP_PATH not found`** — xcodebuild archive failed; check scheme name in AskMac/project.yml
-- **`sign_update` not found** — Sparkle bin missing; download from GitHub releases
+**Known: stapling warning** — The build may print "Could not validate ticket / WARNING: stapler failed" and continue. This is a known macOS Tahoe issue where `xcrun stapler` modifies the file on failure, changing its hash. The build script guards against this with backup/restore. The artifacts are fully notarized and pass Gatekeeper with internet access at first launch.
+
+**Other common failures:**
+- **Notarization rejected (Invalid)** — fetch the detailed log: `xcrun notarytool log {submission-id} --apple-id ... --password ... --team-id ...`
+- **`AskMac.xcodeproj does not exist`** — xcodegen not installed: `brew install xcodegen`
+- **`sign_update: Signing key not found`** — run `./sparkle/bin/generate_keys`, add `SUPublicEDKey` to Info.plist
+- **`AskMacCore.framework: bundle format unrecognized`** — project.yml has `AskMacCore` as `library.static`, not `framework`; regenerate with xcodegen
 
 ## Step 5 — Report
 

--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ __pycache__/
 *.p12
 *.mobileprovision
 AuthKey_*.p8
+AskMac/AskMac.xcodeproj

--- a/AskMac/ExportOptions.plist
+++ b/AskMac/ExportOptions.plist
@@ -7,7 +7,9 @@
 	<key>teamID</key>
 	<string>B5J28L8ARB</string>
 	<key>signingStyle</key>
-	<string>automatic</string>
+	<string>manual</string>
+	<key>signingCertificate</key>
+	<string>Developer ID Application</string>
 	<key>stripSwiftSymbols</key>
 	<true/>
 </dict>

--- a/AskMac/Sources/AskMac/Info.plist
+++ b/AskMac/Sources/AskMac/Info.plist
@@ -31,6 +31,6 @@
 
 	<!-- Sparkle EdDSA public key — replace PLACEHOLDER with output of Sparkle's generate_keys tool -->
 	<key>SUPublicEDKey</key>
-	<string>SPARKLE_PUBLIC_KEY_PLACEHOLDER</string>
+	<string>jbCfz3kJ7jtaLmJd5HTmZc1o0I5nLB+JBxTPbdqfFyQ=</string>
 </dict>
 </plist>

--- a/AskMac/project.yml
+++ b/AskMac/project.yml
@@ -20,7 +20,7 @@ settings:
 
 targets:
   AskMacCore:
-    type: framework
+    type: library.static
     platform: macOS
     sources:
       - path: Sources/AskMacCore
@@ -28,8 +28,6 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.kevinhill.askmaccore
         SKIP_INSTALL: YES
-        CODE_SIGN_STYLE: Automatic
-        DEFINES_MODULE: YES
     scheme:
       testTargets:
         - AskMacTests
@@ -49,15 +47,16 @@ targets:
         INFOPLIST_FILE: Sources/AskMac/Info.plist
         MARKETING_VERSION: "0.7.0"
         CURRENT_PROJECT_VERSION: "1"
-        CODE_SIGN_STYLE: Automatic
-        CODE_SIGN_IDENTITY: "Developer ID Application"
         CODE_SIGN_ENTITLEMENTS: Sources/AskMac/AskMac.entitlements
       configs:
+        Debug:
+          CODE_SIGN_STYLE: Automatic
+          CODE_SIGN_IDENTITY: "Apple Development"
         Release:
+          CODE_SIGN_STYLE: Manual
           CODE_SIGN_IDENTITY: "Developer ID Application"
     dependencies:
       - target: AskMacCore
-        embed: true
       - package: Sparkle
         product: Sparkle
 
@@ -74,7 +73,6 @@ schemes:
     build:
       targets:
         AskMac: all
-        AskMacCore: [build]
         AskMacTests: [test]
     archive:
       config: Release

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -26,6 +26,26 @@ SPARKLE_SIGN="$REPO_ROOT/sparkle/bin/sign_update"
 SIGN_APP="Developer ID Application"
 SIGN_PKG="Developer ID Installer"
 
+# Staple with backup/restore to prevent xcrun stapler from corrupting the file
+# on failure (it modifies the file even when it fails, invalidating the hash).
+# Retries up to 3 times with 15s delay for CDN propagation. Warns but continues
+# on persistent failure — notarization alone is sufficient for Gatekeeper.
+staple_with_retry() {
+    local file="$1"
+    local backup="${file}.pre-staple-backup"
+    cp "$file" "$backup"
+    for i in 1 2 3; do
+        cp "$backup" "$file"
+        xcrun stapler staple "$file" && rm -f "$backup" && return 0
+        echo "    Staple attempt $i failed, retrying in 15s…"
+        sleep 15
+    done
+    cp "$backup" "$file"
+    rm -f "$backup"
+    echo "WARNING: stapler failed for $(basename "$file") — file restored to pre-staple state."
+    echo "         Notarization was accepted; Gatekeeper will verify online at first launch."
+}
+
 # ── Version ────────────────────────────────────────────────────────────────────
 VERSION="${1:-}"
 if [[ -z "$VERSION" ]]; then
@@ -71,6 +91,37 @@ fi
 rm -rf "$BUILD_DIR"
 mkdir -p "$BUILD_DIR/pkgs"
 
+# ── Generate Xcode project ────────────────────────────────────────────────────
+echo "==> Generating Xcode project from project.yml…"
+if ! command -v xcodegen &>/dev/null; then
+    echo "ERROR: xcodegen not found. Run: brew install xcodegen"; exit 1
+fi
+(cd "$ASKMAC_DIR" && xcodegen generate)
+
+# Guard: xcodegen can overwrite entitlements with an empty file if run in certain states.
+ENTITLEMENTS="$ASKMAC_DIR/Sources/AskMac/AskMac.entitlements"
+if ! grep -q "icloud-container-identifiers" "$ENTITLEMENTS"; then
+    echo "ERROR: xcodegen overwrote AskMac.entitlements — restoring CloudKit entitlements."
+    cat > "$ENTITLEMENTS" << 'ENTEOF'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.icloud-container-identifiers</key>
+	<array>
+		<string>iCloud.simple.ask</string>
+	</array>
+	<key>com.apple.developer.icloud-services</key>
+	<array>
+		<string>CloudKit</string>
+	</array>
+	<key>com.apple.security.network.client</key>
+	<true/>
+</dict>
+</plist>
+ENTEOF
+fi
+
 # ── Archive + export app ──────────────────────────────────────────────────────
 echo "==> Archiving…"
 xcodebuild archive \
@@ -95,7 +146,20 @@ echo "==> Bundling scripts into app…"
 BUNDLE_SCRIPTS="$APP_PATH/Contents/Resources/Scripts"
 mkdir -p "$BUNDLE_SCRIPTS"
 for script_dir in "$SCRIPTS_SRC"/*/; do
-    cp -r "$script_dir" "$BUNDLE_SCRIPTS/$(basename "$script_dir")"
+    dest="$BUNDLE_SCRIPTS/$(basename "$script_dir")"
+    rsync -a --exclude='.build' --exclude='*.xcodeproj' "$script_dir" "$dest/"
+done
+
+echo "==> Signing bundled binaries…"
+find "$BUNDLE_SCRIPTS" -type f | while read -r bin; do
+    if file "$bin" | grep -q "Mach-O"; then
+        echo "    Signing $bin"
+        codesign --force \
+            --sign "$SIGN_APP" \
+            --timestamp \
+            --options runtime \
+            "$bin"
+    fi
 done
 
 echo "==> Re-signing app after adding resources…"
@@ -158,7 +222,7 @@ xcrun notarytool submit "$PKG_PATH" \
     --password "$APPLE_ID_PASSWORD" \
     --team-id "$APPLE_TEAM_ID" \
     --wait
-xcrun stapler staple "$PKG_PATH"
+staple_with_retry "$PKG_PATH"
 
 # ── Installer DMG ─────────────────────────────────────────────────────────────
 echo "==> Creating installer DMG…"
@@ -196,7 +260,7 @@ xcrun notarytool submit "$SPARKLE_DMG" \
     --password "$APPLE_ID_PASSWORD" \
     --team-id "$APPLE_TEAM_ID" \
     --wait
-xcrun stapler staple "$SPARKLE_DMG"
+staple_with_retry "$SPARKLE_DMG"
 
 # ── Sparkle signature ─────────────────────────────────────────────────────────
 echo "==> Generating Sparkle EdDSA signature…"


### PR DESCRIPTION
## Summary
- **Stapling fix**: `staple_with_retry` now backs up the file before each attempt and restores on failure — prevents `xcrun stapler` from corrupting the file hash when it fails on macOS Tahoe
- **xcodegen**: Added `xcodegen generate` step to `build-release.sh` (required since `AskMac.xcodeproj` is gitignored and generated from `project.yml`)
- **xcodegen entitlements guard**: Detects and restores CloudKit entitlements if xcodegen overwrites them with an empty file
- **Sparkle EdDSA key**: Added `SUPublicEDKey` to `Info.plist` (generated with `./sparkle/bin/generate_keys`)
- **Signing config**: Fixed `project.yml` (Manual signing for Release, Automatic for Debug) and `ExportOptions.plist` (manual + Developer ID Application) to resolve signing conflicts
- **Script bundling**: Excludes `.build/` dirs and signs Mach-O binaries before PKG build
- **Keychain credentials**: `build-release.sh` auto-loads `APPLE_ID`, `APPLE_ID_PASSWORD`, `APPLE_TEAM_ID` from Keychain
- **Updated `build-pkg-mac` skill** with accurate prerequisites, known issues, and troubleshooting steps

## Test plan
- [ ] Merge PR
- [ ] Run `/build-pkg-mac` on a clean build to verify stapling behavior
- [ ] Confirm GitHub Release artifacts are created successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)