### PR TITLE
fix(build): archive unsigned to bypass iCloud provisioning profile requirement

### DIFF
--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -123,20 +123,24 @@ ENTEOF
 fi
 
 # ── Archive + export app ──────────────────────────────────────────────────────
-echo "==> Archiving…"
+# Archive without code signing to bypass Xcode's provisioning profile
+# requirement for iCloud/CloudKit entitlements. We sign manually with codesign
+# after export, which correctly embeds entitlements for Developer ID distribution.
+echo "==> Archiving (unsigned)…"
 xcodebuild archive \
     -project "$ASKMAC_DIR/AskMac.xcodeproj" \
     -scheme AskMac \
     -configuration Release \
     -archivePath "$BUILD_DIR/AskMac.xcarchive" \
+    CODE_SIGNING_REQUIRED=NO \
+    CODE_SIGNING_ALLOWED=NO \
+    CODE_SIGN_IDENTITY="" \
     CURRENT_PROJECT_VERSION="$BUILD_NUMBER" \
     MARKETING_VERSION="$VERSION"
 
-echo "==> Exporting app bundle…"
-xcodebuild -exportArchive \
-    -archivePath "$BUILD_DIR/AskMac.xcarchive" \
-    -exportPath "$BUILD_DIR/export" \
-    -exportOptionsPlist "$ASKMAC_DIR/ExportOptions.plist"
+echo "==> Extracting app bundle from archive…"
+mkdir -p "$BUILD_DIR/export"
+cp -R "$BUILD_DIR/AskMac.xcarchive/Products/Applications/AskMac.app" "$BUILD_DIR/export/"
 
 APP_PATH="$BUILD_DIR/export/AskMac.app"
 [[ -d "$APP_PATH" ]] || { echo "ERROR: $APP_PATH not found"; exit 1; }


### PR DESCRIPTION
## Summary
- Archive with `CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO` to skip Xcode's provisioning profile check
- Copy `.app` directly from `AskMac.xcarchive/Products/Applications/` instead of using `xcodebuild -exportArchive`
- The existing `codesign --deep --entitlements` step already correctly signs the app with Developer ID + CloudKit entitlements

**Root cause:** Xcode mandates a provisioning profile for apps with iCloud capability even in Manual signing mode. For macOS Developer ID distribution, provisioning profiles are not required at runtime — the entitlements are validated from the code signature + App ID registration at developer.apple.com.

## Test plan
- [ ] Run `/build-pkg-mac` — archive step should succeed
- [ ] `codesign -dvvv build/export/AskMac.app` shows Developer ID Application signature with CloudKit entitlements
- [ ] Notarization succeeds
- [ ] Install PKG on another Mac, app launches and CloudKit sync works

🤖 Generated with [Claude Code](https://claude.com/claude-code)