### PR TITLE
fix(signing): update to Developer ID profile with iCloud container

### DIFF
--- a/AskMac/ExportOptions.plist
+++ b/AskMac/ExportOptions.plist
@@ -13,7 +13,7 @@
 	<key>provisioningProfiles</key>
 	<dict>
 		<key>com.kevinhill.askmac</key>
-		<string>bfd14ab6-5e47-4f32-a4e3-6b4a5a589025</string>
+		<string>3d8eba74-9533-4611-a8ca-8daa06284a2c</string>
 	</dict>
 </dict>
 </plist>

--- a/AskMac/project.yml
+++ b/AskMac/project.yml
@@ -49,7 +49,7 @@ targets:
         CURRENT_PROJECT_VERSION: "1"
         CODE_SIGN_STYLE: Manual
         CODE_SIGN_IDENTITY: "Developer ID Application: Kevin Hill (B5J28L8ARB)"
-        PROVISIONING_PROFILE_SPECIFIER: "bfd14ab6-5e47-4f32-a4e3-6b4a5a589025"
+        PROVISIONING_PROFILE_SPECIFIER: "3d8eba74-9533-4611-a8ca-8daa06284a2c"
         CODE_SIGN_ENTITLEMENTS: Sources/AskMac/AskMac.entitlements
     dependencies:
       - target: AskMacCore


### PR DESCRIPTION
## Summary
- Update `PROVISIONING_PROFILE_SPECIFIER` to `3d8eba74` — the new Developer ID Application profile that includes the Developer ID cert and `iCloud.simple.ask` container
- Update `ExportOptions.plist` to match

**Previous profile** (`bfd14ab6`) was missing both the Developer ID cert and the iCloud container identifier.  
**New profile** (`3d8eba74`) has both, resolving the two archive errors.

## Test plan
- [ ] Archive succeeds
- [ ] App launches on another Mac
- [ ] CloudKit sync works

🤖 Generated with [Claude Code](https://claude.com/claude-code)