### PR TITLE
fix(appcast): extract EdDSA signature value from sign_update output

### DIFF
--- a/docs/appcast.xml
+++ b/docs/appcast.xml
@@ -6,31 +6,5 @@
     <description>AskMac release history</description>
     <language>en</language>
     <!-- Release entries are prepended here by the release pipeline -->
-    <item>
-      <title>Version 0.7.0</title>
-      <sparkle:version>1775134728</sparkle:version>
-      <sparkle:shortVersionString>0.7.0</sparkle:shortVersionString>
-      <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
-      <pubDate>Thu, 02 Apr 2026 13:02:07 +0000</pubDate>
-      <enclosure
-        url="https://github.com/Gr8Gatsby/ask/releases/download/v0.7.0/AskMac-0.7.0.dmg"
-        length="2412358"
-        type="application/octet-stream"
-        sparkle:edSignature="sparkle:edSignature="rZDIwORJqVcXbJuRo77hZJ2uv5ZXxjGbsEfWXve9D3lie+hXJJp22D2AErre8vII7SBJrZr/KJhwZLM2ExthDQ==" length="2412358""
-      />
-    </item>
-    <item>
-      <title>Version 0.7.0</title>
-      <sparkle:version>1775132196</sparkle:version>
-      <sparkle:shortVersionString>0.7.0</sparkle:shortVersionString>
-      <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
-      <pubDate>Thu, 02 Apr 2026 12:20:08 +0000</pubDate>
-      <enclosure
-        url="https://github.com/Gr8Gatsby/ask/releases/download/v0.7.0/AskMac-0.7.0.dmg"
-        length="2418324"
-        type="application/octet-stream"
-        sparkle:edSignature="sparkle:edSignature="yg8O/MCyy4Z9YaOUAcqaVH09Z4yfP6HYxP79fUtwSmEEuKbbSJhe61mU/zHISnghvk0Fxd/KWyCqXZUtPHnDCw==" length="2418324""
-      />
-    </item>
   </channel>
 </rss>

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -264,7 +264,10 @@ staple_with_retry "$SPARKLE_DMG"
 
 # ── Sparkle signature ─────────────────────────────────────────────────────────
 echo "==> Generating Sparkle EdDSA signature…"
-SIGNATURE=$("$SPARKLE_SIGN" "$SPARKLE_DMG")
+# sign_update outputs: sparkle:edSignature="BASE64" length="SIZE"
+# Extract just the base64 signature value for embedding in appcast XML.
+SIGN_OUTPUT=$("$SPARKLE_SIGN" "$SPARKLE_DMG")
+SIGNATURE=$(echo "$SIGN_OUTPUT" | sed 's/.*edSignature="\([^"]*\)".*/\1/')
 FILE_SIZE=$(stat -f%z "$SPARKLE_DMG")
 
 # ── Update appcast ────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Fix malformed `sparkle:edSignature` in appcast.xml — `sign_update` outputs the full attribute string (`sparkle:edSignature="..." length="..."`) but the script was embedding it as the *value* of another `sparkle:edSignature="..."`, double-wrapping it
- Extract just the base64 signature with `sed` before embedding
- Clear two malformed v0.7.0 entries from prior builds

## Test plan
- [ ] Build completes, appcast.xml has a single v0.7.0 entry with valid XML
- [ ] `sparkle:edSignature` contains only the base64 value

🤖 Generated with [Claude Code](https://claude.com/claude-code)