### PR TITLE
fix(signing): use provisioning profile with matching Developer ID cert

### DIFF
--- a/AskMac/ExportOptions.plist
+++ b/AskMac/ExportOptions.plist
@@ -13,7 +13,7 @@
 	<key>provisioningProfiles</key>
 	<dict>
 		<key>com.kevinhill.askmac</key>
-		<string>3d8eba74-9533-4611-a8ca-8daa06284a2c</string>
+		<string>036fee16-227d-478a-a99e-021fe8ec952d</string>
 	</dict>
 </dict>
 </plist>

--- a/AskMac/project.yml
+++ b/AskMac/project.yml
@@ -49,7 +49,7 @@ targets:
         CURRENT_PROJECT_VERSION: "1"
         CODE_SIGN_STYLE: Manual
         CODE_SIGN_IDENTITY: "Developer ID Application: Kevin Hill (B5J28L8ARB)"
-        PROVISIONING_PROFILE_SPECIFIER: "3d8eba74-9533-4611-a8ca-8daa06284a2c"
+        PROVISIONING_PROFILE_SPECIFIER: "036fee16-227d-478a-a99e-021fe8ec952d"
         CODE_SIGN_ENTITLEMENTS: Sources/AskMac/AskMac.entitlements
     dependencies:
       - target: AskMacCore


### PR DESCRIPTION
## Summary
- Update profile UUID to `036fee16` — this profile embeds the Developer ID Application cert (serial `43A63C4023973088`) that matches the build machine's Keychain
- Previous profile UUID (`3d8eba74`) embedded a different cert, causing `xcodebuild archive` to fail with "Provisioning profile doesn't include signing certificate"

🤖 Generated with [Claude Code](https://claude.com/claude-code)