### PR TITLE
fix(release): prevent stale appcast signatures after CI staple

### DIFF
--- a/.github/workflows/staple-release.yml
+++ b/.github/workflows/staple-release.yml
@@ -130,6 +130,73 @@ jobs:
             $UPLOAD_LIST
           echo "✅ Uploaded: $UPLOAD_LIST"
 
+      - name: Update appcast signature for stapled Sparkle DMG
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ steps.tag.outputs.tag }}"
+          VERSION="${{ steps.tag.outputs.version }}"
+          STAPLED="${{ steps.staple.outputs.stapled }}"
+
+          # Only update appcast if the Sparkle DMG was actually stapled
+          SPARKLE_DMG=""
+          for f in $STAPLED; do
+            [[ "$f" == *"AskMac-${VERSION}.dmg" ]] && SPARKLE_DMG="$f"
+          done
+          if [[ -z "$SPARKLE_DMG" ]]; then
+            echo "Sparkle DMG was not stapled — skipping appcast update."
+            exit 0
+          fi
+
+          echo "==> Signing stapled Sparkle DMG for appcast…"
+          # Checkout repo so we can update appcast.xml
+          git clone --depth=1 "https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git" repo
+          cd repo
+
+          # Download Sparkle sign_update tool
+          SPARKLE_VERSION=$(grep -r 'sparkle-project/Sparkle' AskMac/project.yml 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || echo "2.9.1")
+          SPARKLE_URL="https://github.com/sparkle-project/Sparkle/releases/download/${SPARKLE_VERSION}/Sparkle-${SPARKLE_VERSION}.tar.xz"
+          echo "Downloading Sparkle ${SPARKLE_VERSION}…"
+          curl -fsSL "$SPARKLE_URL" -o /tmp/sparkle.tar.xz
+          mkdir -p sparkle && tar -xf /tmp/sparkle.tar.xz -C sparkle
+
+          SIGN_OUTPUT=$(./sparkle/bin/sign_update "../$SPARKLE_DMG")
+          echo "sign_update output: $SIGN_OUTPUT"
+          NEW_SIG=$(echo "$SIGN_OUTPUT" | sed 's/.*edSignature="\([^"]*\)".*/\1/')
+          NEW_LEN=$(echo "$SIGN_OUTPUT" | sed 's/.*length="\([^"]*\)".*/\1/')
+
+          echo "==> Patching appcast.xml (sig=${NEW_SIG:0:20}… len=${NEW_LEN})…"
+          python3 - <<PYEOF
+import re
+with open('docs/appcast.xml', 'r') as f:
+    content = f.read()
+
+# Replace length and edSignature inside the v${VERSION} item block
+def patch_version_item(m):
+    block = m.group(0)
+    block = re.sub(r'length="[^"]*"', f'length="${NEW_LEN}"', block)
+    block = re.sub(r'sparkle:edSignature="[^"]*"', f'sparkle:edSignature="${NEW_SIG}"', block)
+    return block
+
+content = re.sub(
+    r'<item>.*?<sparkle:shortVersionString>${VERSION}</sparkle:shortVersionString>.*?</item>',
+    patch_version_item,
+    content,
+    flags=re.DOTALL
+)
+with open('docs/appcast.xml', 'w') as f:
+    f.write(content)
+print('appcast.xml patched.')
+PYEOF
+
+          git config user.email "actions@github.com"
+          git config user.name "GitHub Actions"
+          git add docs/appcast.xml
+          git diff --cached --quiet && echo "No appcast changes needed." && exit 0
+          git commit -m "fix(appcast): update v${VERSION} EdDSA signature after CI staple"
+          git push origin main
+          echo "✅ appcast.xml updated with stapled DMG signature."
+
       - name: Report
         run: |
           if [[ -n "${{ steps.staple.outputs.stapled }}" ]]; then

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -376,10 +376,13 @@ PUB_DATE=$(date -u '+%a, %d %b %Y %H:%M:%S +0000')
 DMG_NAME="AskMac-${VERSION}.dmg"
 
 python3 - <<PYEOF
+import re
 channel = "${CHANNEL}"
 channel_tag = f"\n      <sparkle:channel>{channel}</sparkle:channel>" if channel != "stable" else ""
 with open('docs/appcast.xml', 'r') as f:
     content = f.read()
+# Remove any existing entries for this version before inserting to avoid duplicates
+content = re.sub(r'\s*<item>\s*<title>Version ${VERSION}</title>.*?</item>', '', content, flags=re.DOTALL)
 new_item = f"""    <item>
       <title>Version ${VERSION}</title>
       <sparkle:version>${BUILD_NUMBER}</sparkle:version>


### PR DESCRIPTION
## Problem

Two gaps in the release pipeline caused the v0.9.0 Sparkle \"improperly signed\" update error:

1. **Duplicate appcast entries** — re-running `build-release.sh` prepended a second entry for the same version without removing the first
2. **Stale signature after stapling** — `staple-release.yml` re-uploaded a modified (stapled) DMG but never updated the `length` or `sparkle:edSignature` in `appcast.xml`, so Sparkle verified against the wrong hash

## Fix

**`build-release.sh`** — strip any existing `<item>` blocks for the target version before inserting the new one

**`staple-release.yml`** — add a step after re-upload that:
- Downloads Sparkle `sign_update` matching the project's Sparkle version
- Re-signs the stapled DMG
- Patches `appcast.xml` with the new `length` + `edSignature`
- Commits and pushes to `main`

## Test plan
- [ ] Run `build-release.sh` twice for the same version — appcast should have exactly one entry
- [ ] After `staple-release` workflow runs, appcast signature should match the stapled DMG on GitHub