### PR TITLE
fix(release): fix YAML syntax error in staple-release workflow

### DIFF
--- a/.github/workflows/staple-release.yml
+++ b/.github/workflows/staple-release.yml
@@ -166,28 +166,8 @@ jobs:
           NEW_LEN=$(echo "$SIGN_OUTPUT" | sed 's/.*length="\([^"]*\)".*/\1/')
 
           echo "==> Patching appcast.xml (sig=${NEW_SIG:0:20}… len=${NEW_LEN})…"
-          python3 - <<PYEOF
-import re
-with open('docs/appcast.xml', 'r') as f:
-    content = f.read()
-
-# Replace length and edSignature inside the v${VERSION} item block
-def patch_version_item(m):
-    block = m.group(0)
-    block = re.sub(r'length="[^"]*"', f'length="${NEW_LEN}"', block)
-    block = re.sub(r'sparkle:edSignature="[^"]*"', f'sparkle:edSignature="${NEW_SIG}"', block)
-    return block
-
-content = re.sub(
-    r'<item>.*?<sparkle:shortVersionString>${VERSION}</sparkle:shortVersionString>.*?</item>',
-    patch_version_item,
-    content,
-    flags=re.DOTALL
-)
-with open('docs/appcast.xml', 'w') as f:
-    f.write(content)
-print('appcast.xml patched.')
-PYEOF
+          VERSION="$VERSION" NEW_SIG="$NEW_SIG" NEW_LEN="$NEW_LEN" \
+            python3 scripts/patch-appcast-signature.py
 
           git config user.email "actions@github.com"
           git config user.name "GitHub Actions"

--- a/scripts/patch-appcast-signature.py
+++ b/scripts/patch-appcast-signature.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""
+Patch the length and EdDSA signature for a specific version in appcast.xml.
+Used by staple-release.yml after the CI staple workflow modifies the Sparkle DMG.
+
+Usage: VERSION=x.y.z NEW_SIG=... NEW_LEN=... python3 patch-appcast-signature.py
+"""
+import re
+import os
+import sys
+
+version = os.environ["VERSION"]
+new_sig = os.environ["NEW_SIG"]
+new_len = os.environ["NEW_LEN"]
+appcast_path = os.environ.get("APPCAST_PATH", "docs/appcast.xml")
+
+with open(appcast_path) as f:
+    content = f.read()
+
+def patch(m):
+    b = m.group(0)
+    b = re.sub(r'length="[^"]*"', f'length="{new_len}"', b)
+    b = re.sub(r'sparkle:edSignature="[^"]*"', f'sparkle:edSignature="{new_sig}"', b)
+    return b
+
+patched = re.sub(
+    r'<item>.*?<sparkle:shortVersionString>' + re.escape(version) + r'</sparkle:shortVersionString>.*?</item>',
+    patch,
+    content,
+    flags=re.DOTALL,
+)
+
+if patched == content:
+    print(f"WARNING: no entry found for version {version} in {appcast_path}", file=sys.stderr)
+    sys.exit(1)
+
+with open(appcast_path, "w") as f:
+    f.write(patched)
+
+print(f"Patched {appcast_path}: version={version} length={new_len} sig={new_sig[:20]}…")


### PR DESCRIPTION
## Problem

The previous fix embedded multi-line Python code directly inside a YAML `run: |` block. Python code lines that start at column 0 (no indentation) break the YAML block scalar parser — GitHub Actions reported "workflow file issue" and the job failed immediately with 0s duration.

## Fix

- Moved the appcast patching logic into `scripts/patch-appcast-signature.py`
- The workflow step now calls the script via `python3 scripts/patch-appcast-signature.py` with env vars

## Test plan
- [ ] Workflow parses successfully (no immediate failure on push)
- [ ] After merge, trigger `staple-release` manually for `v0.9.0` to verify end-to-end