### PR TITLE
feat(catalog): show SVG icons for uninstalled scripts

### DIFF
--- a/AskMac/Sources/AskMac/Views/ScriptCatalogView.swift
+++ b/AskMac/Sources/AskMac/Views/ScriptCatalogView.swift
@@ -366,14 +366,14 @@ struct CatalogEntryRow: View {
         HStack(spacing: 12) {
             // Icon
             Group {
-                if let img = installedScript?.iconImage {
+                if let img = installedScript?.iconImage ?? catalogIconImage {
                     Image(nsImage: img)
                         .resizable()
                         .scaledToFit()
                         .grayscale(isInstalled && !hasUpdate ? 0.6 : 0)
                         .opacity(isInstalled && !hasUpdate ? 0.5 : 1)
                 } else {
-                    Image(systemName: "shippingbox")
+                    Image(systemName: entry.icon ?? "shippingbox")
                         .font(.title2)
                         .foregroundStyle(isInstalled && !hasUpdate ? Color.secondary.opacity(0.4) : .secondary)
                 }
@@ -456,6 +456,11 @@ struct CatalogEntryRow: View {
         }
         .padding(.horizontal, 16)
         .padding(.vertical, 10)
+    }
+
+    private var catalogIconImage: NSImage? {
+        guard let svg = entry.svg, let data = svg.data(using: .utf8) else { return nil }
+        return NSImage(data: data)
     }
 
     private var typeBadge: some View {

--- a/AskMac/Sources/AskMacCore/CatalogEntry.swift
+++ b/AskMac/Sources/AskMacCore/CatalogEntry.swift
@@ -19,6 +19,8 @@ public struct CatalogEntry: Identifiable, Decodable {
     public let version: String
     public let description: String
     public let icon: String?
+    /// Raw SVG markup embedded from the script's icon_file, if present.
+    public let svg: String?
     public let type: String?
     public let changelog: String?
     public let downloadURL: URL
@@ -30,18 +32,19 @@ public struct CatalogEntry: Identifiable, Decodable {
     public let requires: [CatalogRequirement]?
 
     public enum CodingKeys: String, CodingKey {
-        case id, name, version, description, icon, type, changelog, permissions, requires
+        case id, name, version, description, icon, svg, type, changelog, permissions, requires
         case downloadURL = "download_url"
     }
 
     public init(id: String, name: String, version: String, description: String,
-                icon: String?, type: String?, changelog: String?, downloadURL: URL,
+                icon: String?, svg: String? = nil, type: String?, changelog: String?, downloadURL: URL,
                 permissions: [String]? = nil, requires: [CatalogRequirement]? = nil) {
         self.id = id
         self.name = name
         self.version = version
         self.description = description
         self.icon = icon
+        self.svg = svg
         self.type = type
         self.changelog = changelog
         self.downloadURL = downloadURL


### PR DESCRIPTION
## Summary
- Adds `svg` field to `CatalogEntry` (inline SVG markup from the script's `icon_file`)
- `CatalogEntryRow` renders the SVG via `NSImage(data:)` for uninstalled scripts
- Falls back to SF Symbol `icon` name if no SVG is present
- Release script updated to embed SVG content in `catalog.json`

## Test plan
- [ ] Browse catalog → scripts with SVG icons show them (Claude Code, Homebrew, etc.)
- [ ] Scripts without SVG (Hello World, Task Demo) show their SF Symbol icon
- [ ] Installed scripts continue to show their locally-loaded icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)