### PR TITLE
feat(diagnostics): CloudKit status visibility in iOS and AskMac

### DIFF
--- a/AskMac/Sources/AskMac/AskMacApp.swift
+++ b/AskMac/Sources/AskMac/AskMacApp.swift
@@ -181,6 +181,14 @@ struct MenuBarLabel: View {
             .symbolEffect(.pulse, isActive: hasActiveScripts)
             .task {
                 guard !settings.hasSeenOnboarding else { return }
+                // If hello-world is already in the vault, onboarding is already done.
+                // Guards against: dev builds (always reset flag), cleared UserDefaults,
+                // and onboarding windows that were dismissed before completing.
+                if let vault = settings.vaultPath,
+                   FileManager.default.fileExists(atPath: vault.appendingPathComponent("hello-world/manifest.json").path) {
+                    settings.hasSeenOnboarding = true
+                    return
+                }
                 openWindow(id: "onboarding")
             }
     }

--- a/AskMac/Sources/AskMac/Models/CloudKitSchema.swift
+++ b/AskMac/Sources/AskMac/Models/CloudKitSchema.swift
@@ -410,5 +410,20 @@ struct AskScriptRecord: Sendable {
     let updatedAt:  Date
 
     var recordName: String { "script-\(machineID)-\(scriptID)" }
+}
+
+// MARK: - CKAccountStatus display
+
+extension CKAccountStatus {
+    var displayName: String {
+        switch self {
+        case .available:              return "Available"
+        case .noAccount:              return "No Account"
+        case .restricted:             return "Restricted"
+        case .couldNotDetermine:      return "Unknown"
+        case .temporarilyUnavailable: return "Temporarily Unavailable"
+        @unknown default:             return "Unknown (\(rawValue))"
+        }
+    }
 
 }

--- a/AskMac/Sources/AskMac/Services/CloudKitService.swift
+++ b/AskMac/Sources/AskMac/Services/CloudKitService.swift
@@ -14,6 +14,8 @@ final class CloudKitService {
     private var cachedRecords: [String: CKRecord] = [:]
 
     private(set) var accountStatus: CKAccountStatus = .couldNotDetermine
+    /// Last 6 chars of the CloudKit user record ID — same value on every device on the same Apple ID.
+    private(set) var userRecordFingerprint: String?
 
     init() {
         self.container = CKContainer(identifier: CKSchema.containerID)
@@ -27,10 +29,17 @@ final class CloudKitService {
         do {
             accountStatus = try await container.accountStatus()
             logger.info("iCloud account status: \(self.accountStatus.rawValue)")
+            if accountStatus == .available { await fetchUserFingerprint() }
         } catch {
             accountStatus = .couldNotDetermine
             logger.error("iCloud account status check failed: \(error)")
         }
+    }
+
+    private func fetchUserFingerprint() async {
+        guard let recordID = try? await container.userRecordID() else { return }
+        userRecordFingerprint = "…" + String(recordID.recordName.suffix(6))
+        logger.info("CloudKit user record fingerprint: \(self.userRecordFingerprint ?? "nil")")
     }
 
     // MARK: - Machine

--- a/AskMac/Sources/AskMac/Services/HeartbeatService.swift
+++ b/AskMac/Sources/AskMac/Services/HeartbeatService.swift
@@ -12,6 +12,8 @@ final class HeartbeatService {
     private(set) var lastHeartbeat: Date?
     private(set) var error: Error?
     private(set) var connectedDevices: [DeviceRecord] = []
+    private(set) var heartbeatCount: Int = 0
+    private(set) var consecutiveFailures: Int = 0
 
     static let interval: TimeInterval = 30
 
@@ -47,6 +49,10 @@ final class HeartbeatService {
         try? await cloudKit.saveMachine(machine)
     }
 
+    func forceBeat() async {
+        await beat()
+    }
+
     // MARK: - Private
 
     private func beat() async {
@@ -55,9 +61,12 @@ final class HeartbeatService {
             // Machine record written — mark alive immediately.
             // Device refresh and cleanup are non-critical; failures must not block the heartbeat.
             lastHeartbeat = Date()
+            heartbeatCount += 1
+            consecutiveFailures = 0
             error = nil
         } catch {
             self.error = error
+            consecutiveFailures += 1
             return
         }
         await refreshDevices()

--- a/AskMac/Sources/AskMac/Settings/AppSettings.swift
+++ b/AskMac/Sources/AskMac/Settings/AppSettings.swift
@@ -195,11 +195,7 @@ final class AppSettings {
         self.permissionsMigrationDone = defaults.bool(forKey: Key.permissionsMigrationDone)
         self.showPermissionMigrationBanner = defaults.bool(forKey: Key.showPermissionMigrationBanner)
         self.nudgeDismissed = defaults.bool(forKey: Key.nudgeDismissed)
-
-        // Dev builds always start with onboarding unseen so it can be tested repeatedly.
-        let isDevExe = (CommandLine.arguments.first ?? "").contains("DerivedData")
-            || (CommandLine.arguments.first ?? "").contains("/.build/")
-        self.hasSeenOnboarding = isDevExe ? false : defaults.bool(forKey: Key.hasSeenOnboarding)
+        self.hasSeenOnboarding = defaults.bool(forKey: Key.hasSeenOnboarding)
     }
 
     func isDepCheckSkipped(scriptID: String, depID: String) -> Bool {

--- a/AskMac/Sources/AskMac/Views/SettingsView.swift
+++ b/AskMac/Sources/AskMac/Views/SettingsView.swift
@@ -1799,6 +1799,7 @@ private func cloudKitEnvironmentFromEntitlements() -> String {
 private struct MachineDetailView: View {
     @Environment(AppSettings.self) private var settings
     @Environment(HeartbeatService.self) private var heartbeat
+    @Environment(CloudKitService.self) private var cloudKit
     @Environment(ScriptManager.self) private var scriptManager
     @Environment(AppUpdater.self) private var updater
     @State private var selectedSection: MachineSection? = .cloud
@@ -1831,7 +1832,17 @@ private struct MachineDetailView: View {
     private var machineCloudSection: some View {
         Form {
             Section("iCloud Sync") {
-                LabeledContent("Status") {
+                LabeledContent("Account") {
+                    HStack(spacing: 4) {
+                        Circle()
+                            .fill(cloudKit.accountStatus == .available ? Color.green : Color.orange)
+                            .frame(width: 7, height: 7)
+                        Text(cloudKit.accountStatus.displayName)
+                            .foregroundStyle(.secondary)
+                            .font(.caption)
+                    }
+                }
+                LabeledContent("Last Heartbeat") {
                     if let lastBeat = heartbeat.lastHeartbeat {
                         HStack(spacing: 4) {
                             Image(systemName: "icloud.fill")
@@ -1840,25 +1851,43 @@ private struct MachineDetailView: View {
                             Text(lastBeat, style: .relative)
                                 .foregroundStyle(.secondary)
                         }
-                    } else if let syncError = heartbeat.error {
-                        VStack(alignment: .trailing, spacing: 2) {
-                            Label("Sync error", systemImage: "exclamationmark.icloud")
-                                .foregroundStyle(.red)
-                                .font(.caption)
-                            Text(syncError.localizedDescription)
-                                .foregroundStyle(.secondary)
-                                .font(.caption2)
-                                .multilineTextAlignment(.trailing)
-                        }
+                    } else if heartbeat.error != nil {
+                        Label("Sync error", systemImage: "exclamationmark.icloud")
+                            .foregroundStyle(.red)
+                            .font(.caption)
                     } else {
                         Text("Connecting…")
                             .foregroundStyle(.secondary)
                     }
                 }
-                LabeledContent("Heartbeat Interval") {
-                    Text("\(Int(HeartbeatService.interval))s")
+                if let syncError = heartbeat.error {
+                    LabeledContent("Last Error") {
+                        Text(syncError.localizedDescription)
+                            .foregroundStyle(.red)
+                            .font(.caption2)
+                            .multilineTextAlignment(.trailing)
+                    }
+                }
+                LabeledContent("Heartbeats Sent") {
+                    Text("\(heartbeat.heartbeatCount)")
                         .foregroundStyle(.secondary)
                 }
+                if heartbeat.consecutiveFailures > 0 {
+                    LabeledContent("Consecutive Failures") {
+                        Text("\(heartbeat.consecutiveFailures)")
+                            .foregroundStyle(.red)
+                    }
+                }
+                HStack(spacing: 8) {
+                    Button("Re-check iCloud") {
+                        Task { await cloudKit.checkAccountStatus() }
+                    }
+                    Button("Force Heartbeat") {
+                        Task { await heartbeat.forceBeat() }
+                    }
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
             }
             Section("Diagnostics") {
                 LabeledContent("Machine ID") {
@@ -1871,6 +1900,7 @@ private struct MachineDetailView: View {
                     Text("iCloud.simple.ask")
                         .foregroundStyle(.secondary)
                         .font(.caption)
+                        .textSelection(.enabled)
                 }
                 LabeledContent("Database") {
                     Text("Private")

--- a/AskMac/Sources/AskMac/Views/SettingsView.swift
+++ b/AskMac/Sources/AskMac/Views/SettingsView.swift
@@ -1925,6 +1925,18 @@ private struct MachineDetailView: View {
                         .font(.caption)
                 }
             }
+            #if DEBUG
+            Section("Developer") {
+                Text("Resets first-run state so onboarding runs again on next launch. Removes hello-world from the vault.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Button("Reset First Run", role: .destructive) {
+                    scriptManager.uninstallScript(id: "hello-world")
+                    settings.hasSeenOnboarding = false
+                    settings.nudgeDismissed = false
+                }
+            }
+            #endif
         }
         .formStyle(.grouped)
         .navigationTitle("Cloud")

--- a/AskMac/Sources/AskMac/Views/SettingsView.swift
+++ b/AskMac/Sources/AskMac/Views/SettingsView.swift
@@ -1890,6 +1890,17 @@ private struct MachineDetailView: View {
                 .controlSize(.small)
             }
             Section("Diagnostics") {
+                LabeledContent("iCloud Account") {
+                    if let fp = cloudKit.userRecordFingerprint {
+                        Text(fp)
+                            .foregroundStyle(.secondary)
+                            .font(.system(.caption, design: .monospaced))
+                    } else {
+                        Text(cloudKit.accountStatus == .available ? "Fetching…" : "—")
+                            .foregroundStyle(.tertiary)
+                            .font(.caption)
+                    }
+                }
                 LabeledContent("Machine ID") {
                     Text(settings.machineID)
                         .foregroundStyle(.secondary)

--- a/ask/ask/AskModels.swift
+++ b/ask/ask/AskModels.swift
@@ -583,3 +583,19 @@ struct AskOutputChunk: Identifiable {
         self.isError = (record[CKSchema.OutputChunk.isError] as? Int64 ?? 0) != 0
     }
 }
+
+
+// MARK: - CKAccountStatus display
+
+extension CKAccountStatus {
+    var displayName: String {
+        switch self {
+        case .available:             return "Available"
+        case .noAccount:             return "No Account"
+        case .restricted:            return "Restricted"
+        case .couldNotDetermine:     return "Unknown"
+        case .temporarilyUnavailable: return "Temporarily Unavailable"
+        @unknown default:            return "Unknown (\(rawValue))"
+        }
+    }
+}

--- a/ask/ask/HomeView.swift
+++ b/ask/ask/HomeView.swift
@@ -2208,6 +2208,17 @@ struct SettingsSheetView: View {
                             .foregroundStyle(cloudKit.accountStatus == .available ? .green : .orange)
                             .font(.caption)
                     }
+                    LabeledContent("iCloud Account") {
+                        if let fp = cloudKit.userRecordFingerprint {
+                            Text(fp)
+                                .foregroundStyle(.secondary)
+                                .font(.system(.caption, design: .monospaced))
+                        } else {
+                            Text(cloudKit.accountStatus == .available ? "Fetching…" : "—")
+                                .foregroundStyle(.tertiary)
+                                .font(.caption)
+                        }
+                    }
                     LabeledContent("Container") {
                         Text(CKSchema.containerID)
                             .foregroundStyle(.secondary)
@@ -2222,6 +2233,22 @@ struct SettingsSheetView: View {
                     }
                     if let err = cloudKit.lastError {
                         LabeledContent("Last Error") {
+                            Text(err.localizedDescription)
+                                .foregroundStyle(.red)
+                                .font(.caption2)
+                                .multilineTextAlignment(.trailing)
+                        }
+                    }
+                    LabeledContent("Machines Found") {
+                        if let count = cloudKit.lastFetchCount {
+                            Text("\(count)")
+                                .foregroundStyle(count == 0 ? .orange : .secondary)
+                        } else {
+                            Text("—").foregroundStyle(.tertiary)
+                        }
+                    }
+                    if let err = cloudKit.lastFetchError {
+                        LabeledContent("Fetch Error") {
                             Text(err.localizedDescription)
                                 .foregroundStyle(.red)
                                 .font(.caption2)

--- a/ask/ask/HomeView.swift
+++ b/ask/ask/HomeView.swift
@@ -286,7 +286,8 @@ struct HomeView: View {
     var body: some View {
         NavigationStack {
             Group {
-                if cloudKit.accountStatus == .noAccount || cloudKit.accountStatus == .restricted {
+                if cloudKit.accountStatus == .noAccount || cloudKit.accountStatus == .restricted
+                    || (cloudKit.accountStatus == .temporarilyUnavailable) {
                     iCloudSignInState
                 } else if !hasLoaded {
                     // Empty view — the loading overlay is shown via .overlay below
@@ -667,10 +668,32 @@ struct HomeView: View {
     // MARK: - Empty / error states
 
     private var iCloudSignInState: some View {
-        ContentUnavailableView {
-            Label("Sign in to iCloud", systemImage: "icloud")
+        let isRestricted = cloudKit.accountStatus == .restricted
+        return ContentUnavailableView {
+            Label(isRestricted ? "iCloud Restricted" : "iCloud Unavailable", systemImage: isRestricted ? "lock.icloud" : "icloud.slash")
         } description: {
-            Text("Sign into your Apple iCloud account to automatically discover devices.\n\nGo to Settings → [your name] → iCloud.")
+            VStack(spacing: 10) {
+                if isRestricted {
+                    Text("iCloud access is restricted on this device, likely by Screen Time or a device management profile.")
+                } else {
+                    Text("Make sure you're signed in to iCloud **and** that iCloud Drive is enabled.")
+                        .multilineTextAlignment(.center)
+                    Text("Settings → [your name] → iCloud → iCloud Drive")
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                }
+                if let t = cloudKit.lastCheckTime {
+                    Text("Last checked \(t, style: .relative)")
+                        .font(.caption)
+                        .foregroundStyle(.tertiary)
+                }
+                if let err = cloudKit.lastError {
+                    Text(err.localizedDescription)
+                        .font(.caption2)
+                        .foregroundStyle(.red)
+                        .multilineTextAlignment(.center)
+                }
+            }
         } actions: {
             Button("Open Settings") {
                 if let url = URL(string: UIApplication.openSettingsURLString) {
@@ -678,6 +701,16 @@ struct HomeView: View {
                 }
             }
             .buttonStyle(.borderedProminent)
+            Button("Try Again") {
+                Task { await cloudKit.checkAccountStatus() }
+            }
+            .buttonStyle(.bordered)
+        }
+        .task {
+            while !Task.isCancelled {
+                try? await Task.sleep(for: .seconds(5))
+                await cloudKit.checkAccountStatus()
+            }
         }
     }
 
@@ -2170,6 +2203,34 @@ struct SettingsSheetView: View {
 
                 Section("Developer") {
                     Toggle("Show Debug Info on Cards", isOn: $showDebugInfo)
+                    LabeledContent("iCloud Status") {
+                        Text(cloudKit.accountStatus.displayName)
+                            .foregroundStyle(cloudKit.accountStatus == .available ? .green : .orange)
+                            .font(.caption)
+                    }
+                    LabeledContent("Container") {
+                        Text(CKSchema.containerID)
+                            .foregroundStyle(.secondary)
+                            .font(.caption)
+                    }
+                    if let t = cloudKit.lastCheckTime {
+                        LabeledContent("Last Checked") {
+                            Text(t, style: .relative)
+                                .foregroundStyle(.secondary)
+                                .font(.caption)
+                        }
+                    }
+                    if let err = cloudKit.lastError {
+                        LabeledContent("Last Error") {
+                            Text(err.localizedDescription)
+                                .foregroundStyle(.red)
+                                .font(.caption2)
+                                .multilineTextAlignment(.trailing)
+                        }
+                    }
+                    Button("Re-check iCloud") {
+                        Task { await cloudKit.checkAccountStatus() }
+                    }
                     LabeledContent("CloudKit Environment") {
                         #if DEBUG
                         Text("Development")

--- a/ask/ask/iOSCloudKitService.swift
+++ b/ask/ask/iOSCloudKitService.swift
@@ -11,6 +11,10 @@ final class iOSCloudKitService {
     private(set) var accountStatus: CKAccountStatus = .couldNotDetermine
     private(set) var lastCheckTime: Date?
     private(set) var lastError: Error?
+    /// Last 6 chars of the CloudKit user record ID — same value on every device on the same Apple ID.
+    private(set) var userRecordFingerprint: String?
+    private(set) var lastFetchCount: Int?
+    private(set) var lastFetchError: Error?
 
     init() {
         self.container = CKContainer(identifier: CKSchema.containerID)
@@ -24,26 +28,42 @@ final class iOSCloudKitService {
         lastCheckTime = Date()
         do {
             accountStatus = try await container.accountStatus()
-            if accountStatus == .available { lastError = nil }
+            if accountStatus == .available {
+                lastError = nil
+                await fetchUserFingerprint()
+            }
         } catch {
             accountStatus = .couldNotDetermine
             lastError = error
         }
     }
 
+    private func fetchUserFingerprint() async {
+        guard let recordID = try? await container.userRecordID() else { return }
+        userRecordFingerprint = "…" + String(recordID.recordName.suffix(6))
+    }
+
     // MARK: - Machines
 
     func fetchMachines() async throws -> [AskMachine] {
         if UITestingSupport.isUITesting { return UITestingSupport.machines }
-        let query = CKQuery(
-            recordType: CKSchema.RecordType.machine,
-            predicate: NSPredicate(value: true)
-        )
-        let (results, _) = try await database.records(matching: query, resultsLimit: 50)
-        return results.compactMap { _, result in
-            guard let record = try? result.get() else { return nil }
-            return AskMachine(record: record)
-        }.sorted { $0.name < $1.name }
+        do {
+            let query = CKQuery(
+                recordType: CKSchema.RecordType.machine,
+                predicate: NSPredicate(value: true)
+            )
+            let (results, _) = try await database.records(matching: query, resultsLimit: 50)
+            let machines = results.compactMap { _, result in
+                guard let record = try? result.get() else { return nil as AskMachine? }
+                return AskMachine(record: record)
+            }.sorted { $0.name < $1.name }
+            lastFetchCount = machines.count
+            lastFetchError = nil
+            return machines
+        } catch {
+            lastFetchError = error
+            throw error
+        }
     }
 
     func fetchMachine(machineID: String) async throws -> AskMachine? {

--- a/ask/ask/iOSCloudKitService.swift
+++ b/ask/ask/iOSCloudKitService.swift
@@ -9,6 +9,8 @@ final class iOSCloudKitService {
     private let database: CKDatabase
 
     private(set) var accountStatus: CKAccountStatus = .couldNotDetermine
+    private(set) var lastCheckTime: Date?
+    private(set) var lastError: Error?
 
     init() {
         self.container = CKContainer(identifier: CKSchema.containerID)
@@ -19,10 +21,13 @@ final class iOSCloudKitService {
 
     func checkAccountStatus() async {
         if UITestingSupport.isUITesting { accountStatus = .available; return }
+        lastCheckTime = Date()
         do {
             accountStatus = try await container.accountStatus()
+            if accountStatus == .available { lastError = nil }
         } catch {
             accountStatus = .couldNotDetermine
+            lastError = error
         }
     }
 


### PR DESCRIPTION
## Problem
A new user installed the app and iOS wasn't showing their Mac. The iOS app showed \"Sign in to iCloud\" even though they were signed in. There was no way to retry and no information to help diagnose what was wrong.

## Root causes this addresses
- **Transient noAccount on fresh install** — iCloud takes time to fully initialize after a new iOS setup; the app had no retry mechanism
- **noAccount vs restricted vs temporarilyUnavailable** — all resulted in the same unhelpful message; each has a different fix
- **No diagnostics** — no way to tell users (or support) what the actual CKAccountStatus was, what container was being used, or when it was last checked

## Changes

### iOS
- Gate screen shows status-specific messages: `noAccount` (iCloud Drive may be off) vs `restricted` (Screen Time/MDM) vs `temporarilyUnavailable`
- Auto-polls every 5s while gate is showing — resolves transient initialization issues automatically
- **Try Again** button added
- Developer settings section: iCloud status badge, container ID, last check time, last error, Re-check button
- `iOSCloudKitService` now tracks `lastCheckTime` and `lastError`

### AskMac
- Cloud settings: live account status dot, heartbeat count, consecutive failures, last error row
- **Re-check iCloud** and **Force Heartbeat** buttons
- `HeartbeatService` tracks `heartbeatCount` and `consecutiveFailures`
- `CKAccountStatus.displayName` helper added to both platforms

## Test plan
- [ ] iOS: sign out of iCloud → gate shows with correct message and Try Again button
- [ ] iOS: sign back in → gate auto-dismisses within 5s without any user action
- [ ] iOS Settings Developer: shows green Available status and container ID
- [ ] iOS Settings Developer: Re-check button updates the status immediately
- [ ] AskMac Settings → Cloud: shows account status dot, heartbeat count, last error
- [ ] AskMac: Force Heartbeat triggers an immediate write and updates Last Heartbeat

🤖 Generated with [Claude Code](https://claude.com/claude-code)