### PR TITLE
feat(claudecode-controller): declare permissions in manifest (v2.26.0)

### DIFF
--- a/ask/scripts/claudecode-controller/manifest.json
+++ b/ask/scripts/claudecode-controller/manifest.json
@@ -1,12 +1,17 @@
 {
   "id": "claudecode-controller",
   "name": "Claude Code",
-  "version": "2.25.5",
+  "version": "2.26.0",
   "setup": "setup.py",
   "description": "Claude Code session supervisor \u2014 routes permissions and notifications to iPhone",
   "entry": "main.py",
   "icon": "sparkles",
   "icon_file": "icon.svg",
+  "permissions": [
+    "shell",
+    "home_directory",
+    "network"
+  ],
   "tools": [
     {
       "name": "reply",


### PR DESCRIPTION
## Summary
- Adds `"permissions": ["shell", "home_directory", "network"]` to the claudecode-controller manifest
- Bumps version to 2.26.0
- Without this field, the script permission consent flow never fired for claudecode-controller even though it runs the Claude Code CLI (shell), reads/writes to the home directory, and makes network calls

## Test plan
- [ ] Reset script permissions for claudecode-controller in AskMac Settings
- [ ] Re-enable the script — consent sheet should appear listing shell, home_directory, network
- [ ] Approve and verify the script resumes normally
- [ ] Run `/release-scripts` to publish the updated catalog

🤖 Generated with [Claude Code](https://claude.com/claude-code)