### PR TITLE
feat(permissions): surface macOS TCC status + targeted crash messaging

### DIFF
--- a/AskMac/Sources/AskMac/Services/ScriptManager.swift
+++ b/AskMac/Sources/AskMac/Services/ScriptManager.swift
@@ -1042,6 +1042,14 @@ final class ScriptManager: @unchecked Sendable {
             if let m = manifests[manifest.id]?.manifest {
                 publishScript(m, status: "crashed", lastRunAt: Date())
             }
+            let allLines = conn?.allStderrLines ?? []
+            let stderrText = allLines.joined(separator: "\n").lowercased()
+            let isTCCDenial = stderrText.contains("operation not permitted") ||
+                              stderrText.contains("permission denied") ||
+                              stderrText.contains(": eperm")
+            if let idx = scripts.firstIndex(where: { $0.id == manifest.id }) {
+                scripts[idx].lastError = isTCCDenial ? "__system_permission_denied__" : stderr
+            }
             let feedIconData  = manifests[manifest.id]?.icon.flatMap { ScriptManager.iconPNGBase64($0) }
             let feedSvgString = manifests[manifest.id]?.svgString
             Task {
@@ -1072,9 +1080,18 @@ final class ScriptManager: @unchecked Sendable {
         connections.removeValue(forKey: manifest.id)
         blockStateManager.clearAll(forScript: manifest.id)
 
-        // Surface the last error line in the Mac UI
-        if let error = errorSummary, let idx = scripts.firstIndex(where: { $0.id == manifest.id }) {
-            scripts[idx].lastError = error
+        // Surface the last error line in the Mac UI.
+        // Detect macOS TCC denial specifically so the UI can show a targeted fix path.
+        if let idx = scripts.firstIndex(where: { $0.id == manifest.id }) {
+            let stderrText = allStderrLines.joined(separator: "\n").lowercased()
+            let isTCCDenial = stderrText.contains("operation not permitted") ||
+                              stderrText.contains("permission denied") ||
+                              stderrText.contains(": eperm")
+            if isTCCDenial {
+                scripts[idx].lastError = "__system_permission_denied__"
+            } else if let error = errorSummary {
+                scripts[idx].lastError = error
+            }
         }
 
         actionHistory.recordScriptCrash(

--- a/AskMac/Sources/AskMac/Views/ScriptDetailView.swift
+++ b/AskMac/Sources/AskMac/Views/ScriptDetailView.swift
@@ -1748,25 +1748,38 @@ struct ScriptDetailView: View {
     }
 
     private func crashBanner(_ error: String) -> some View {
-        HStack(alignment: .top, spacing: 8) {
-            Image(systemName: "exclamationmark.triangle.fill")
-                .foregroundStyle(.red)
+        let isTCCDenial = error == "__system_permission_denied__"
+        return HStack(alignment: .top, spacing: 8) {
+            Image(systemName: isTCCDenial ? "lock.trianglebadge.exclamationmark.fill" : "exclamationmark.triangle.fill")
+                .foregroundStyle(isTCCDenial ? .orange : .red)
                 .font(.caption)
                 .padding(.top, 1)
             VStack(alignment: .leading, spacing: 4) {
-                Text("Script crashed")
+                Text(isTCCDenial ? "macOS blocked file access" : "Script crashed")
                     .font(.caption)
                     .fontWeight(.medium)
-                    .foregroundStyle(.red)
-                Text(error)
+                    .foregroundStyle(isTCCDenial ? .orange : .red)
+                if isTCCDenial {
+                    Text("macOS denied this script access to a protected folder (Documents, Desktop, or similar). Ask already approved it — this is a separate system-level grant.")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                    Button("Fix in Privacy & Security Settings →") {
+                        NSWorkspace.shared.open(URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_FilesAndFolders")!)
+                    }
+                    .buttonStyle(.plain)
                     .font(.caption2)
-                    .foregroundStyle(.secondary)
-                    .lineLimit(4)
+                    .foregroundStyle(.orange)
+                } else {
+                    Text(error)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(4)
+                }
             }
         }
         .padding(10)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .background(Color.red.opacity(0.07))
+        .background(isTCCDenial ? Color.orange.opacity(0.07) : Color.red.opacity(0.07))
         .clipShape(RoundedRectangle(cornerRadius: 8))
     }
 }

--- a/AskMac/Sources/AskMac/Views/SettingsView.swift
+++ b/AskMac/Sources/AskMac/Views/SettingsView.swift
@@ -1778,21 +1778,23 @@ struct SetupOutputSheet: View {
 // MARK: - Machine detail view
 
 private enum MachineSection: String, CaseIterable, Identifiable {
-    case cloud    = "Cloud"
-    case devices  = "Devices"
-    case machine  = "Machine"
-    case sessions = "Sessions"
-    case about    = "About"
+    case cloud       = "Cloud"
+    case devices     = "Devices"
+    case machine     = "Machine"
+    case permissions = "Permissions"
+    case sessions    = "Sessions"
+    case about       = "About"
 
     var id: String { rawValue }
 
     var icon: String {
         switch self {
-        case .cloud:    "icloud"
-        case .devices:  "iphone"
-        case .machine:  "desktopcomputer"
-        case .sessions: "cpu"
-        case .about:    "info.circle"
+        case .cloud:       "icloud"
+        case .devices:     "iphone"
+        case .machine:     "desktopcomputer"
+        case .permissions: "lock.shield"
+        case .sessions:    "cpu"
+        case .about:       "info.circle"
         }
     }
 }
@@ -1804,6 +1806,184 @@ private func cloudKitEnvironmentFromEntitlements() -> String {
     guard let task = SecTaskCreateFromSelf(nil) else { return "Development" }
     let value = SecTaskCopyValueForEntitlement(task, "com.apple.developer.icloud-container-environment" as CFString, &error)
     return (value as? String) ?? "Development"
+}
+
+// MARK: - System permissions checker
+
+private struct SystemPermissionItem: Identifiable {
+    let id: String
+    let title: String
+    let description: String
+    let icon: String
+    let path: String?         // nil = Full Disk Access (checked differently)
+    var status: PermStatus = .checking
+
+    enum PermStatus { case checking, allowed, denied, notApplicable }
+}
+
+private struct SystemPermissionsView: View {
+    @State private var items: [SystemPermissionItem] = [
+        SystemPermissionItem(id: "documents", title: "Documents Folder",
+            description: "Scripts that scan ~/Documents for git repos or read files you store there.",
+            icon: "doc.fill", path: FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent("Documents").path),
+        SystemPermissionItem(id: "desktop", title: "Desktop Folder",
+            description: "Scripts that access files saved to your Desktop.",
+            icon: "menubar.dock.rectangle", path: FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent("Desktop").path),
+        SystemPermissionItem(id: "downloads", title: "Downloads Folder",
+            description: "Scripts that read files in your Downloads folder.",
+            icon: "arrow.down.circle.fill", path: FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent("Downloads").path),
+        SystemPermissionItem(id: "fda", title: "Full Disk Access",
+            description: "Required only if scripts need to read files outside your home folder (e.g. system logs, other users).",
+            icon: "internaldrive.fill", path: nil),
+    ]
+
+    var body: some View {
+        Form {
+            Section {
+                Text("These are macOS system-level grants — separate from Ask's own per-script consent. Ask asks for script permission first; macOS may ask once more when a script first touches a protected folder.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Section("Folder Access") {
+                ForEach($items) { $item in
+                    if item.id != "fda" {
+                        permRow(item: $item)
+                    }
+                }
+            }
+
+            Section("Full Disk Access") {
+                if let fda = items.first(where: { $0.id == "fda" }) {
+                    permRow(item: Binding(
+                        get: { fda },
+                        set: { newVal in
+                            if let idx = items.firstIndex(where: { $0.id == "fda" }) {
+                                items[idx] = newVal
+                            }
+                        }
+                    ))
+                }
+                Text("Full Disk Access is only needed for scripts that must read system files outside your home folder. Most scripts work fine without it.")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+
+            Section {
+                Button("Open Privacy & Security Settings") {
+                    NSWorkspace.shared.open(URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_FilesAndFolders")!)
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+            }
+        }
+        .formStyle(.grouped)
+        .navigationTitle("Permissions")
+        .task { await checkAll() }
+    }
+
+    @ViewBuilder
+    private func permRow(item: Binding<SystemPermissionItem>) -> some View {
+        HStack(spacing: 10) {
+            Image(systemName: item.wrappedValue.icon)
+                .font(.body)
+                .foregroundStyle(statusColor(item.wrappedValue.status))
+                .frame(width: 22)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(item.wrappedValue.title)
+                    .font(.subheadline)
+                Text(item.wrappedValue.description)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Spacer()
+
+            statusBadge(item.wrappedValue.status)
+        }
+        .padding(.vertical, 2)
+    }
+
+    @ViewBuilder
+    private func statusBadge(_ status: SystemPermissionItem.PermStatus) -> some View {
+        switch status {
+        case .checking:
+            ProgressView().controlSize(.small)
+        case .allowed:
+            HStack(spacing: 3) {
+                Image(systemName: "checkmark.circle.fill").font(.caption)
+                Text("Allowed").font(.caption).fontWeight(.medium)
+            }
+            .foregroundStyle(.green)
+        case .denied:
+            HStack(spacing: 3) {
+                Image(systemName: "xmark.circle.fill").font(.caption)
+                Text("Denied").font(.caption).fontWeight(.medium)
+            }
+            .foregroundStyle(.orange)
+            .onTapGesture {
+                NSWorkspace.shared.open(URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_FilesAndFolders")!)
+            }
+        case .notApplicable:
+            Text("N/A").font(.caption).foregroundStyle(.tertiary)
+        }
+    }
+
+    private func statusColor(_ status: SystemPermissionItem.PermStatus) -> Color {
+        switch status {
+        case .allowed: .green
+        case .denied:  .orange
+        default:       .secondary
+        }
+    }
+
+    private func checkAll() async {
+        await withTaskGroup(of: (String, SystemPermissionItem.PermStatus).self) { group in
+            for item in items {
+                group.addTask {
+                    let status = await checkItem(item)
+                    return (item.id, status)
+                }
+            }
+            for await (id, status) in group {
+                if let idx = items.firstIndex(where: { $0.id == id }) {
+                    items[idx].status = status
+                }
+            }
+        }
+    }
+
+    private func checkItem(_ item: SystemPermissionItem) async -> SystemPermissionItem.PermStatus {
+        if item.id == "fda" {
+            return checkFullDiskAccess()
+        }
+        guard let path = item.path else { return .notApplicable }
+        let url = URL(fileURLWithPath: path)
+        guard FileManager.default.fileExists(atPath: path) else { return .notApplicable }
+        do {
+            _ = try FileManager.default.contentsOfDirectory(at: url, includingPropertiesForKeys: nil, options: [.skipsHiddenFiles])
+            return .allowed
+        } catch let error as NSError {
+            // NSFileReadNoPermissionError (257) = EPERM — macOS TCC blocked the access
+            if error.code == NSFileReadNoPermissionError || error.code == 257 {
+                return .denied
+            }
+            return .allowed
+        }
+    }
+
+    private func checkFullDiskAccess() -> SystemPermissionItem.PermStatus {
+        // /Library/Application Support is only fully listable with Full Disk Access.
+        // A normal app can open it but can't see protected subdirectories.
+        let testPath = "/Library/Application Support/com.apple.TCC"
+        if FileManager.default.fileExists(atPath: testPath) {
+            return .allowed
+        }
+        // Path not visible — FDA not granted (or not needed)
+        return .notApplicable
+    }
 }
 
 private struct MachineDetailView: View {
@@ -1826,11 +2006,12 @@ private struct MachineDetailView: View {
             .navigationSplitViewColumnWidth(min: 170, ideal: 190)
         } detail: {
             switch selectedSection ?? .cloud {
-            case .cloud:    machineCloudSection
-            case .devices:  machineDevicesSection
-            case .machine:  machineMachineSection
-            case .sessions: machineSessionsSection
-            case .about:    machineAboutSection
+            case .cloud:       machineCloudSection
+            case .devices:     machineDevicesSection
+            case .machine:     machineMachineSection
+            case .permissions: SystemPermissionsView()
+            case .sessions:    machineSessionsSection
+            case .about:       machineAboutSection
             }
         }
         .navigationTitle("Machine")


### PR DESCRIPTION
## Summary

Two improvements to make the permission experience professional and clear rather than opaque.

### Settings → Machine → Permissions (new section)
- Checks Documents, Desktop, Downloads folder access and Full Disk Access in the background on open
- Shows a green **Allowed** / orange **Denied** badge per resource
- Tapping a Denied badge (or the footer button) opens Privacy & Security Settings directly
- Explains that Ask controls per-script consent; macOS separately controls folder-level access

### ScriptDetailView — targeted crash messaging
- On crash, scans stderr for `Operation not permitted` / `Permission denied` / `eperm`
- When detected: shows an orange **"macOS blocked file access"** banner with a plain-English explanation and a **"Fix in Privacy & Security Settings →"** link
- When not detected: existing red crash banner with the raw error line is unchanged

## Test plan
- [ ] Open Machine → Permissions — Documents/Desktop/Downloads show correct status
- [ ] Deny AskMac Documents access in System Settings, re-check — shows Denied badge
- [ ] Run a script that accesses a denied folder — crash banner shows orange TCC message with link
- [ ] Run a script that crashes for another reason — red crash banner still shows

🤖 Generated with [Claude Code](https://claude.com/claude-code)