### PR TITLE
fix(github): remove ~/Documents root from scan — eliminates 'access data from other apps' TCC prompt

### DIFF
--- a/ask/scripts/github/main.sh
+++ b/ask/scripts/github/main.sh
@@ -17,9 +17,10 @@ BLOCK_CONFIRM="git-confirm"
 # Directories that should never be entered during repo scanning.
 PRUNE_NAMES="Library|node_modules|.Trash|Pods|DerivedData|.build|build|dist|vendor|venv|.venv|.cache|.npm|.yarn|__pycache__|target|Volumes|.Spotlight-V100|.fseventsd"
 
-# Developer-focused candidate roots. Scanning only these avoids macOS TCC prompts
-# that fire when find traverses ~/Library, ~/Desktop, ~/Downloads, etc.
-# Directories are added in priority order; all that exist are searched.
+# Developer-focused candidate roots. Scanning only these avoids macOS TCC prompts.
+# ~/Documents and ~/Desktop are NOT listed as roots — on iCloud Drive setups macOS
+# treats broad Documents access as "access data from other apps" (a different TCC
+# category). Instead we list common developer subdirectory names under Documents.
 SCAN_CANDIDATES=(
     "$HOME/Developer"
     "$HOME/developer"
@@ -32,8 +33,17 @@ SCAN_CANDIDATES=(
     "$HOME/workspace"
     "$HOME/git"
     "$HOME/dev"
-    "$HOME/Documents"
-    "$HOME/Desktop"
+    "$HOME/Documents/code"
+    "$HOME/Documents/Code"
+    "$HOME/Documents/dev"
+    "$HOME/Documents/Dev"
+    "$HOME/Documents/projects"
+    "$HOME/Documents/Projects"
+    "$HOME/Documents/repos"
+    "$HOME/Documents/src"
+    "$HOME/Documents/Developer"
+    "$HOME/Documents/developer"
+    "$HOME/Documents/workspace"
 )
 
 ID=0

--- a/ask/scripts/github/manifest.json
+++ b/ask/scripts/github/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "github",
   "name": "Git Repos",
-  "version": "3.3",
+  "version": "3.4",
   "description": "Monitor local git repos and push/pull changes from iPhone",
   "entry": "main.sh",
   "icon": "arrow.triangle.branch",


### PR DESCRIPTION
## Summary
- On iCloud Drive setups, scanning `~/Documents` as a scan root triggers the **"access data from other apps"** TCC prompt (a different, more alarming category than the expected "Documents folder" prompt)
- Replaced `$HOME/Documents` and `$HOME/Desktop` with explicit developer subdirectory names under Documents: `Documents/code`, `Documents/dev`, `Documents/projects`, `Documents/repos`, `Documents/src`, `Documents/Developer`, `Documents/workspace`
- These specific subdirectories will only trigger a targeted TCC check for that exact folder, not a broad Documents-level prompt
- Bumped to v3.4

## Test plan
- [ ] Restart AskMac — no "access data from other apps" prompt should appear
- [ ] Repos under `~/Documents/code/` are still discovered in the scan
- [ ] Repos under standard locations (`~/code`, `~/Developer`, etc.) still found

🤖 Generated with [Claude Code](https://claude.com/claude-code)