### PR TITLE
fix(ios): replace .accent with Color.accentColor for release build

### DIFF
--- a/ask/ask/HomeView.swift
+++ b/ask/ask/HomeView.swift
@@ -1401,7 +1401,7 @@ private struct OnboardingStep: View {
                 Text("\(number)")
                     .font(.subheadline)
                     .fontWeight(.semibold)
-                    .foregroundStyle(.accent)
+                    .foregroundStyle(Color.accentColor)
             }
             VStack(alignment: .leading, spacing: 3) {
                 Text(title)
@@ -1416,7 +1416,7 @@ private struct OnboardingStep: View {
                 Button(action: action) {
                     Image(systemName: "arrow.up.right")
                         .font(.caption)
-                        .foregroundStyle(.accent)
+                        .foregroundStyle(Color.accentColor)
                 }
                 .buttonStyle(.plain)
             }

--- a/docs/appcast.xml
+++ b/docs/appcast.xml
@@ -7,6 +7,19 @@
     <language>en</language>
     <!-- Release entries are prepended here by the release pipeline -->
     <item>
+      <title>Version 0.9.1</title>
+      <sparkle:version>1776816086</sparkle:version>
+      <sparkle:shortVersionString>0.9.1</sparkle:shortVersionString>
+      <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
+      <pubDate>Wed, 22 Apr 2026 00:04:06 +0000</pubDate>
+      <enclosure
+        url="https://github.com/Gr8Gatsby/ask/releases/download/v0.9.1/AskMac-0.9.1.dmg"
+        length="3763884"
+        type="application/octet-stream"
+        sparkle:edSignature="KrzBu78t2mc2oWyI2tvLa0Ft0kJTBa49C44r4S7+6HkFTZY3LCXeVRANOyCs5yyrvTp64CFbQAwTWIoSP7xnBg=="
+      />
+    </item>
+    <item>
       <title>Version 0.9.0</title>
       <sparkle:version>1776468582</sparkle:version>
       <sparkle:shortVersionString>0.9.0</sparkle:shortVersionString>


### PR DESCRIPTION
 on  fails in release builds.  is the correct cross-version equivalent.