### PR TITLE
fix: multi-terminal message routing (iTerm2, Ghostty, Warp, and more)

### DIFF
--- a/.claude/skills/release-scripts/SKILL.md
+++ b/.claude/skills/release-scripts/SKILL.md
@@ -44,7 +44,7 @@ For each directory in `ask/scripts/` that contains a `manifest.json`:
 ls ask/scripts/
 ```
 
-Read each `ask/scripts/<id>/manifest.json` and extract: `id`, `name`, `version`, `description`, `icon`, `icon_file`, `type`, `permissions`, `requires`.
+Read each `ask/scripts/<id>/manifest.json` and extract: `id`, `name`, `version`, `description`, `icon`, `icon_file`, `type`, `permissions`, `requires`, `script_dependencies`.
 
 Skip any directory without a `manifest.json`.
 
@@ -73,7 +73,8 @@ Construct `catalog.json` with this structure:
           "check": "<shell command that exits 0 when dep is present>",
           "install_url": "<url or null>"
         }
-      ]
+      ],
+      "script_dependencies": ["<script-id>", ...]
     }
   ]
 }
@@ -81,6 +82,7 @@ Construct `catalog.json` with this structure:
 
 Omit `permissions` if the manifest has none (empty array or missing field).
 Omit `requires` if the manifest has none.
+Omit `script_dependencies` if the manifest has none.
 
 Write to a temp location: `/tmp/ask-scripts-release/catalog.json`
 

--- a/AskMac/AskMac.xcodeproj/project.pbxproj
+++ b/AskMac/AskMac.xcodeproj/project.pbxproj
@@ -7,66 +7,61 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		AA1B2C3D4E5F6789ABCD0003 /* AskMacUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1B2C3D4E5F6789ABCD0002 /* AskMacUITests.swift */; };
-		AA1B2C3D4E5F6789ABCD0005 /* MacUITestingSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1B2C3D4E5F6789ABCD0004 /* MacUITestingSupport.swift */; };
+		000F4A980B0414BE0CC8C4FF /* PermissionConsentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AE817B39CB7F2A53FCDA7CB /* PermissionConsentView.swift */; };
+		0038B1D02FF68672B1F0C367 /* MacFeedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9B898B8784054153152350B /* MacFeedView.swift */; };
 		0675DD58EE11FCC5FB9C0FE9 /* MCPConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D62BC3ACCF548A6926C83A4 /* MCPConnection.swift */; };
-		06C485A3E2C74E3C9F1A0001 /* TaskService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06C485A3E2C74E3C9F1A0000 /* TaskService.swift */; };
-		06C485A3E2C74E3C9F1A0003 /* TaskRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06C485A3E2C74E3C9F1A0002 /* TaskRegistry.swift */; };
 		0D696DD556936DCEC1997BEB /* TerminalMonitorServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F05D2937205C7D5DED51EEA /* TerminalMonitorServiceTests.swift */; };
 		2A8C999FCCA1DDA22786079F /* BlockService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 944903959A55B26822A4701D /* BlockService.swift */; };
-		2A8C999FCCA1DDA22786079E /* BlockStateManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 944903959A55B26822A4701E /* BlockStateManager.swift */; };
 		2DDF70E89F94833C7837389B /* KeychainService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 504764CE87B4791BDD3ABFD8 /* KeychainService.swift */; };
 		318C46CF42445B388B5E6739 /* libAskMacCore.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 52C75A2FE8B8444D42AF146A /* libAskMacCore.a */; };
-		CC000006CATALOG00ENTRY000 /* CatalogEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000001CATALOG00ENTRY000 /* CatalogEntry.swift */; };
-		CC000007INSTALLED0SCRIPT0 /* InstalledScript.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000002INSTALLED0SCRIPT0 /* InstalledScript.swift */; };
-		CC000008CATALOG0SERVICE00 /* ScriptCatalogService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D24A318DEBECC653846BFA7 /* ScriptCatalogService.swift */; };
-		CC000009TERMINAL0MONITOR0 /* TerminalMonitorService.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFD416A6077DEA3848608AB1 /* TerminalMonitorService.swift */; };
-		CC000010VERSION0COMPARE00 /* VersionComparison.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F2A338EFC99F8D874DB40EE /* VersionComparison.swift */; };
 		337B871BCC56D6AD61869B87 /* MenuBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E4D0C6DDB6891CB03EA9572 /* MenuBarView.swift */; };
 		3654DDECAB92F2C7B7678F90 /* AskMacApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = F70F6904917CF419EF961332 /* AskMacApp.swift */; };
 		44001CADDFE8D87EC9DC698D /* MessageWatcherService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 834313B9757B652D0DB8E349 /* MessageWatcherService.swift */; };
+		49EE75B9FA1320C6CBACB7B0 /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FBE58AD4319A750AC8132F6 /* OnboardingView.swift */; };
 		4FC5952095062C336D1CA67F /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 468C8037AACD02ADA46B757B /* Assets.xcassets */; };
 		58854C8E2F0F81A7D7A40B80 /* BlockPreviewViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 406DAAC6415E06CCCF55B8BB /* BlockPreviewViews.swift */; };
-		BP0001HELPERSBUILDF00001 /* BlockPreviewHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = BP0001HELPERSFILEREF0001 /* BlockPreviewHelpers.swift */; };
-		BP0002INTERACTIVEBUILD001 /* BlockPreviewInteractive.swift in Sources */ = {isa = PBXBuildFile; fileRef = BP0002INTERACTIVEFILEREF1 /* BlockPreviewInteractive.swift */; };
-		BP0003STATUSBUILDF000001 /* BlockPreviewStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = BP0003STATUSFILEREF00001 /* BlockPreviewStatus.swift */; };
-		BP0004CONTENTBUILDF00001 /* BlockPreviewContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = BP0004CONTENTFILEREF0001 /* BlockPreviewContent.swift */; };
-		BP0005SESSIONBUILDF00001 /* BlockPreviewSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = BP0005SESSIONFILEREF0001 /* BlockPreviewSession.swift */; };
+		5B61E54CE9843A9A5C0AD50E /* ScriptCatalogView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B00637FB853892DA9991BBF /* ScriptCatalogView.swift */; };
 		5ECA9EF4288A77DE66393903 /* ActionHistoryService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83069E78F01A6ACCC68DA445 /* ActionHistoryService.swift */; };
+		63CA74CD980B73A3625E4A42 /* CatalogEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 511159CACA895A8F81CD7F01 /* CatalogEntry.swift */; };
+		64532E0B6F9F3D17C45F536A /* ScriptCatalogService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59391DEC75269D029ADC07D3 /* ScriptCatalogService.swift */; };
 		68ECD65ACEAFD3360C586C86 /* FeedScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE84811356D534B4D8E86AB8 /* FeedScheduler.swift */; };
+		6B72EE49DF6636DE0B0B7098 /* ScriptDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AEB210A6E3AED0E763F5EFA /* ScriptDetailView.swift */; };
 		6F24BAB0E82A7694C50B439F /* HistoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FBA2522655384EA7091AA8C /* HistoryView.swift */; };
 		6FF5F3CD40995F704A970F21 /* HeartbeatService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B65A981DB44C661C02FF9312 /* HeartbeatService.swift */; };
 		7A4B52614E8031E1D2E8710F /* ResponsePoller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4067387D7D1B4F65BAB0B74F /* ResponsePoller.swift */; };
+		8B154777BD5CBACF5561A998 /* BlockPreviewHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FB18E6D1590306C5E9169FA /* BlockPreviewHelpers.swift */; };
 		8B9F7C8632ECBE36C84A369E /* ScriptManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA1CC49C770BDCD1EB75B351 /* ScriptManager.swift */; };
+		8C30E811B8346325809717AD /* TaskServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8C66FCA9A17628445E9ECCA /* TaskServiceTests.swift */; };
+		8D1B5B2F3B2AD30DC3450B73 /* VersionComparison.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E900B371D21D4580D767EBA /* VersionComparison.swift */; };
 		8FE46F69A0823A2188C24DB4 /* ScriptManagerFilteringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A9E4EFAF553CA1CD22DA58A /* ScriptManagerFilteringTests.swift */; };
-		9A384768FE320AC25F231F48 /* MacMessagesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B82E4BC0B8C01489502831A9 /* MacMessagesView.swift */; };
 		A302F5F593A0983FFEE135A9 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28BCC8842C2E63700381890C /* SettingsView.swift */; };
-		AA0000002VIEW0HELPERS00 /* ViewHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0000001VIEW0HELPERS00 /* ViewHelpers.swift */; };
-		AA0000004SCRIPTDETAIL00 /* ScriptDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0000003SCRIPTDETAIL00 /* ScriptDetailView.swift */; };
-		AA0000006SCRIPTCATALOG0 /* ScriptCatalogView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0000005SCRIPTCATALOG0 /* ScriptCatalogView.swift */; };
-		AA0000008MACFEEDVIEW000 /* MacFeedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0000007MACFEEDVIEW000 /* MacFeedView.swift */; };
-		A3A4405290AAE7B21855BEE9 /* VersionComparison.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F2A338EFC99F8D874DB40EE /* VersionComparison.swift */; };
+		AF43483C7B2B14F044025386 /* LocalHTTPServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE8BBC3775C0DEBB0665BF8A /* LocalHTTPServer.swift */; };
 		AFA75A68E946CD8E2CAE7BBE /* libAskMacCore.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 52C75A2FE8B8444D42AF146A /* libAskMacCore.a */; };
+		B0E1449E476C1EC21C08AB8E /* BlockPreviewSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 944A4DCFCCDB25464859E84A /* BlockPreviewSession.swift */; };
 		B5760E42FDC4626B6A2AD8D9 /* CloudKitService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42EC5BBB34D453B2F332AF00 /* CloudKitService.swift */; };
 		BAE4E67E06F337A2A3722087 /* TerminalMonitorService.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFD416A6077DEA3848608AB1 /* TerminalMonitorService.swift */; };
-		BB000001CATALOG0SERVICE00 /* ScriptCatalogService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D24A318DEBECC653846BFA7 /* ScriptCatalogService.swift */; };
-		BB000002VERSION0COMPARE00 /* VersionComparison.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F2A338EFC99F8D874DB40EE /* VersionComparison.swift */; };
-		BB000003CATALOG0ENTRY0000 /* CatalogEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000001CATALOG00ENTRY000 /* CatalogEntry.swift */; };
-		BB000004INSTALLED0SCRIPT0 /* InstalledScript.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000002INSTALLED0SCRIPT0 /* InstalledScript.swift */; };
+		BB95A9FB5143C6CE6E3D4CD3 /* InstalledScript.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AF213161B330FC04561C69E /* InstalledScript.swift */; };
 		BF0B435F00BDDA9C64E86B06 /* TooltipSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53C1EA5DC0ECBB374F1FCF5B /* TooltipSupport.swift */; };
 		C2FCC42025E190C3F0BA4152 /* SystemScriptConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3012DFF4EC7CA529C10E374 /* SystemScriptConnection.swift */; };
 		C4A094A8937C7FDEF0021ADC /* CloudKitSchema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70A72093BE81EDF980E0B65F /* CloudKitSchema.swift */; };
+		C6AC124B00FCBF51126E1CD4 /* BlockStateManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B2DAA8286B2D3B719A182D8 /* BlockStateManager.swift */; };
 		C99AE720C0F4BDEEC032237B /* VersionComparisonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBB97B6BC873D01755AE3B01 /* VersionComparisonTests.swift */; };
 		CB275270E3CF93DD24F84506 /* AppUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8A9A572F12084AD9797F8B1 /* AppUpdater.swift */; };
 		D0C0EC092421E3FE9F41EB89 /* AppSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA7C37B37BDE67ED30528117 /* AppSettings.swift */; };
 		D867C4A0F3AC8C6C77C16CC6 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = C42185CDB89CDF057E91C2A6 /* Sparkle */; };
+		D8C56B58F83FC0A72B93B0F9 /* BlockPreviewInteractive.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75AE94E49F8A69D9D86A1821 /* BlockPreviewInteractive.swift */; };
+		DA1696677CAF3AD1A1633669 /* TaskRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 394A7868696C7CA0D1CF57D1 /* TaskRegistry.swift */; };
+		DA268BB52919770AB2F3E41E /* ViewHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 246E4BBF06F630784496A69E /* ViewHelpers.swift */; };
 		DA6EADD0D5A75CED02E56F5C /* ScriptInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDBAEE7F7B9B1616758FEDE2 /* ScriptInstaller.swift */; };
+		DAA69300555DC6A6182D64DD /* ScriptDependencyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B2C7957AA31DE73EE832ABD /* ScriptDependencyTests.swift */; };
+		E1FEABE93A364BCBB97A2D9F /* TaskService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B509F84BEA100E6E2E40C0C2 /* TaskService.swift */; };
+		E615CA321AB7F86AD7D082FA /* MacUITestingSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 085A360289ADA253977E3755 /* MacUITestingSupport.swift */; };
 		EFD8390B0162CA00B1B3144E /* ScriptCatalogServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F0BACCC7986B8E27CD6B9A8 /* ScriptCatalogServiceTests.swift */; };
-		F18233C4B5A2ADE4AD502C52 /* ScriptCatalogService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D24A318DEBECC653846BFA7 /* ScriptCatalogService.swift */; };
 		F47B199A3425DC6C05AC0480 /* ScriptInstallerRollbackTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAB5EAD55DFF07DA5ECE953A /* ScriptInstallerRollbackTests.swift */; };
 		F4A65B11697EF409F84B5886 /* ScriptUpdateService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 125B8BABE336DAA2EEDBC261 /* ScriptUpdateService.swift */; };
 		F6670C71B1ACAA3861CBE8B5 /* BlocksBuilderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78ADB28BB3AA3C89FB164C5F /* BlocksBuilderView.swift */; };
-		AA000010LOCALHTTPSERVER00 /* LocalHTTPServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000011LOCALHTTPSERVER00 /* LocalHTTPServer.swift */; };
+		F731AD25577DEF6697BFE1A8 /* BlockPreviewContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FA01F4EBBCEE5682DC62048 /* BlockPreviewContent.swift */; };
+		FF0F953A573F6C0C5AFB2D2A /* BlockPreviewStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 402957444B4A25CFEA7F3BBC /* BlockPreviewStatus.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -91,59 +86,54 @@
 			remoteGlobalIDString = E59CE13E0F81B53C77683FB1;
 			remoteInfo = AskMac;
 		};
-		AA1B2C3D4E5F6789ABCD0013 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = B36075E18F257B51F15F8871 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = E59CE13E0F81B53C77683FB1;
-			remoteInfo = AskMac;
-		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		AA1B2C3D4E5F6789ABCD0001 /* AskMacUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AskMacUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		AA1B2C3D4E5F6789ABCD0002 /* AskMacUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AskMacUITests.swift; sourceTree = "<group>"; };
-		AA1B2C3D4E5F6789ABCD0004 /* MacUITestingSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacUITestingSupport.swift; sourceTree = "<group>"; };
 		00C7F95F08E74502C870234D /* AskMacTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AskMacTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		085A360289ADA253977E3755 /* MacUITestingSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacUITestingSupport.swift; sourceTree = "<group>"; };
 		0D62BC3ACCF548A6926C83A4 /* MCPConnection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MCPConnection.swift; sourceTree = "<group>"; };
-		06C485A3E2C74E3C9F1A0000 /* TaskService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskService.swift; sourceTree = "<group>"; };
-		06C485A3E2C74E3C9F1A0002 /* TaskRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskRegistry.swift; sourceTree = "<group>"; };
 		125B8BABE336DAA2EEDBC261 /* ScriptUpdateService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScriptUpdateService.swift; sourceTree = "<group>"; };
+		1AE817B39CB7F2A53FCDA7CB /* PermissionConsentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionConsentView.swift; sourceTree = "<group>"; };
+		1FBE58AD4319A750AC8132F6 /* OnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingView.swift; sourceTree = "<group>"; };
+		246E4BBF06F630784496A69E /* ViewHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewHelpers.swift; sourceTree = "<group>"; };
 		28BCC8842C2E63700381890C /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
-		AA0000001VIEW0HELPERS00 /* ViewHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewHelpers.swift; sourceTree = "<group>"; };
-		AA0000003SCRIPTDETAIL00 /* ScriptDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScriptDetailView.swift; sourceTree = "<group>"; };
-		AA0000005SCRIPTCATALOG0 /* ScriptCatalogView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScriptCatalogView.swift; sourceTree = "<group>"; };
-		AA0000007MACFEEDVIEW000 /* MacFeedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacFeedView.swift; sourceTree = "<group>"; };
 		2E4D0C6DDB6891CB03EA9572 /* MenuBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarView.swift; sourceTree = "<group>"; };
+		394A7868696C7CA0D1CF57D1 /* TaskRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskRegistry.swift; sourceTree = "<group>"; };
 		3A9E4EFAF553CA1CD22DA58A /* ScriptManagerFilteringTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScriptManagerFilteringTests.swift; sourceTree = "<group>"; };
-		3D24A318DEBECC653846BFA7 /* ScriptCatalogService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScriptCatalogService.swift; sourceTree = "<group>"; };
-		AA000001CATALOG00ENTRY000 /* CatalogEntry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CatalogEntry.swift; sourceTree = "<group>"; };
-		AA000002INSTALLED0SCRIPT0 /* InstalledScript.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstalledScript.swift; sourceTree = "<group>"; };
+		3B00637FB853892DA9991BBF /* ScriptCatalogView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScriptCatalogView.swift; sourceTree = "<group>"; };
 		3F05D2937205C7D5DED51EEA /* TerminalMonitorServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalMonitorServiceTests.swift; sourceTree = "<group>"; };
-		3F2A338EFC99F8D874DB40EE /* VersionComparison.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VersionComparison.swift; sourceTree = "<group>"; };
+		402957444B4A25CFEA7F3BBC /* BlockPreviewStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockPreviewStatus.swift; sourceTree = "<group>"; };
 		4067387D7D1B4F65BAB0B74F /* ResponsePoller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResponsePoller.swift; sourceTree = "<group>"; };
 		406DAAC6415E06CCCF55B8BB /* BlockPreviewViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockPreviewViews.swift; sourceTree = "<group>"; };
-		BP0001HELPERSFILEREF0001 /* BlockPreviewHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockPreviewHelpers.swift; sourceTree = "<group>"; };
-		BP0002INTERACTIVEFILEREF1 /* BlockPreviewInteractive.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockPreviewInteractive.swift; sourceTree = "<group>"; };
-		BP0003STATUSFILEREF00001 /* BlockPreviewStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockPreviewStatus.swift; sourceTree = "<group>"; };
-		BP0004CONTENTFILEREF0001 /* BlockPreviewContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockPreviewContent.swift; sourceTree = "<group>"; };
-		BP0005SESSIONFILEREF0001 /* BlockPreviewSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockPreviewSession.swift; sourceTree = "<group>"; };
 		42EC5BBB34D453B2F332AF00 /* CloudKitService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudKitService.swift; sourceTree = "<group>"; };
 		468C8037AACD02ADA46B757B /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		4AF213161B330FC04561C69E /* InstalledScript.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstalledScript.swift; sourceTree = "<group>"; };
+		4B2DAA8286B2D3B719A182D8 /* BlockStateManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockStateManager.swift; sourceTree = "<group>"; };
+		4E900B371D21D4580D767EBA /* VersionComparison.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VersionComparison.swift; sourceTree = "<group>"; };
 		504764CE87B4791BDD3ABFD8 /* KeychainService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainService.swift; sourceTree = "<group>"; };
+		511159CACA895A8F81CD7F01 /* CatalogEntry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CatalogEntry.swift; sourceTree = "<group>"; };
 		52C75A2FE8B8444D42AF146A /* libAskMacCore.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libAskMacCore.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		53C1EA5DC0ECBB374F1FCF5B /* TooltipSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TooltipSupport.swift; sourceTree = "<group>"; };
+		59391DEC75269D029ADC07D3 /* ScriptCatalogService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScriptCatalogService.swift; sourceTree = "<group>"; };
 		6A9CBCABF50128C52895B960 /* AskMac.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = AskMac.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		6FBA2522655384EA7091AA8C /* HistoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryView.swift; sourceTree = "<group>"; };
 		70A72093BE81EDF980E0B65F /* CloudKitSchema.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudKitSchema.swift; sourceTree = "<group>"; };
+		75AE94E49F8A69D9D86A1821 /* BlockPreviewInteractive.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockPreviewInteractive.swift; sourceTree = "<group>"; };
 		78ADB28BB3AA3C89FB164C5F /* BlocksBuilderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlocksBuilderView.swift; sourceTree = "<group>"; };
 		7F0BACCC7986B8E27CD6B9A8 /* ScriptCatalogServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScriptCatalogServiceTests.swift; sourceTree = "<group>"; };
+		7FB18E6D1590306C5E9169FA /* BlockPreviewHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockPreviewHelpers.swift; sourceTree = "<group>"; };
 		83069E78F01A6ACCC68DA445 /* ActionHistoryService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionHistoryService.swift; sourceTree = "<group>"; };
 		834313B9757B652D0DB8E349 /* MessageWatcherService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageWatcherService.swift; sourceTree = "<group>"; };
 		944903959A55B26822A4701D /* BlockService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockService.swift; sourceTree = "<group>"; };
-		944903959A55B26822A4701E /* BlockStateManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockStateManager.swift; sourceTree = "<group>"; };
+		944A4DCFCCDB25464859E84A /* BlockPreviewSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockPreviewSession.swift; sourceTree = "<group>"; };
+		9AEB210A6E3AED0E763F5EFA /* ScriptDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScriptDetailView.swift; sourceTree = "<group>"; };
+		9B2C7957AA31DE73EE832ABD /* ScriptDependencyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScriptDependencyTests.swift; sourceTree = "<group>"; };
+		9FA01F4EBBCEE5682DC62048 /* BlockPreviewContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockPreviewContent.swift; sourceTree = "<group>"; };
+		A9B898B8784054153152350B /* MacFeedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacFeedView.swift; sourceTree = "<group>"; };
+		AE8BBC3775C0DEBB0665BF8A /* LocalHTTPServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalHTTPServer.swift; sourceTree = "<group>"; };
+		B509F84BEA100E6E2E40C0C2 /* TaskService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskService.swift; sourceTree = "<group>"; };
 		B65A981DB44C661C02FF9312 /* HeartbeatService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeartbeatService.swift; sourceTree = "<group>"; };
-		B82E4BC0B8C01489502831A9 /* MacMessagesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacMessagesView.swift; sourceTree = "<group>"; };
+		C8C66FCA9A17628445E9ECCA /* TaskServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskServiceTests.swift; sourceTree = "<group>"; };
 		CA1CC49C770BDCD1EB75B351 /* ScriptManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScriptManager.swift; sourceTree = "<group>"; };
 		CA7C37B37BDE67ED30528117 /* AppSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSettings.swift; sourceTree = "<group>"; };
 		CFD416A6077DEA3848608AB1 /* TerminalMonitorService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalMonitorService.swift; sourceTree = "<group>"; };
@@ -154,17 +144,9 @@
 		F70F6904917CF419EF961332 /* AskMacApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AskMacApp.swift; sourceTree = "<group>"; };
 		FBB97B6BC873D01755AE3B01 /* VersionComparisonTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VersionComparisonTests.swift; sourceTree = "<group>"; };
 		FE84811356D534B4D8E86AB8 /* FeedScheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedScheduler.swift; sourceTree = "<group>"; };
-		AA000011LOCALHTTPSERVER00 /* LocalHTTPServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalHTTPServer.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		AA1B2C3D4E5F6789ABCD0007 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		85CE620F6FAB25D9E93BB0D9 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -205,21 +187,21 @@
 			children = (
 				83069E78F01A6ACCC68DA445 /* ActionHistoryService.swift */,
 				944903959A55B26822A4701D /* BlockService.swift */,
-				944903959A55B26822A4701E /* BlockStateManager.swift */,
+				4B2DAA8286B2D3B719A182D8 /* BlockStateManager.swift */,
 				42EC5BBB34D453B2F332AF00 /* CloudKitService.swift */,
 				FE84811356D534B4D8E86AB8 /* FeedScheduler.swift */,
 				B65A981DB44C661C02FF9312 /* HeartbeatService.swift */,
 				504764CE87B4791BDD3ABFD8 /* KeychainService.swift */,
-				AA1B2C3D4E5F6789ABCD0004 /* MacUITestingSupport.swift */,
+				AE8BBC3775C0DEBB0665BF8A /* LocalHTTPServer.swift */,
+				085A360289ADA253977E3755 /* MacUITestingSupport.swift */,
 				0D62BC3ACCF548A6926C83A4 /* MCPConnection.swift */,
 				834313B9757B652D0DB8E349 /* MessageWatcherService.swift */,
 				4067387D7D1B4F65BAB0B74F /* ResponsePoller.swift */,
-				06C485A3E2C74E3C9F1A0000 /* TaskService.swift */,
 				DDBAEE7F7B9B1616758FEDE2 /* ScriptInstaller.swift */,
 				CA1CC49C770BDCD1EB75B351 /* ScriptManager.swift */,
-				AA000011LOCALHTTPSERVER00 /* LocalHTTPServer.swift */,
 				125B8BABE336DAA2EEDBC261 /* ScriptUpdateService.swift */,
 				F3012DFF4EC7CA529C10E374 /* SystemScriptConnection.swift */,
+				B509F84BEA100E6E2E40C0C2 /* TaskService.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -228,8 +210,10 @@
 			isa = PBXGroup;
 			children = (
 				7F0BACCC7986B8E27CD6B9A8 /* ScriptCatalogServiceTests.swift */,
+				9B2C7957AA31DE73EE832ABD /* ScriptDependencyTests.swift */,
 				EAB5EAD55DFF07DA5ECE953A /* ScriptInstallerRollbackTests.swift */,
 				3A9E4EFAF553CA1CD22DA58A /* ScriptManagerFilteringTests.swift */,
+				C8C66FCA9A17628445E9ECCA /* TaskServiceTests.swift */,
 				3F05D2937205C7D5DED51EEA /* TerminalMonitorServiceTests.swift */,
 				FBB97B6BC873D01755AE3B01 /* VersionComparisonTests.swift */,
 			);
@@ -245,22 +229,12 @@
 			path = Settings;
 			sourceTree = "<group>";
 		};
-		AA1B2C3D4E5F6789ABCD0008 /* AskMacUITests */ = {
-			isa = PBXGroup;
-			children = (
-				AA1B2C3D4E5F6789ABCD0002 /* AskMacUITests.swift */,
-			);
-			name = AskMacUITests;
-			path = Tests/AskMacUITests;
-			sourceTree = "<group>";
-		};
 		7D85D3CDB2B9B6173CFB83F9 = {
 			isa = PBXGroup;
 			children = (
 				193160741783FAD848251CCB /* AskMac */,
 				C684A63C98AF3DBF68A15174 /* AskMacCore */,
 				68C19D81F1E89782D63E471F /* AskMacTests */,
-				AA1B2C3D4E5F6789ABCD0008 /* AskMacUITests */,
 				FB0D7985181B5E1A4D8FBDA2 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -268,22 +242,23 @@
 		A2E07FB35B1F8AB22AB98A99 /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				9FA01F4EBBCEE5682DC62048 /* BlockPreviewContent.swift */,
+				7FB18E6D1590306C5E9169FA /* BlockPreviewHelpers.swift */,
+				75AE94E49F8A69D9D86A1821 /* BlockPreviewInteractive.swift */,
+				944A4DCFCCDB25464859E84A /* BlockPreviewSession.swift */,
+				402957444B4A25CFEA7F3BBC /* BlockPreviewStatus.swift */,
 				406DAAC6415E06CCCF55B8BB /* BlockPreviewViews.swift */,
-				BP0001HELPERSFILEREF0001 /* BlockPreviewHelpers.swift */,
-				BP0002INTERACTIVEFILEREF1 /* BlockPreviewInteractive.swift */,
-				BP0003STATUSFILEREF00001 /* BlockPreviewStatus.swift */,
-				BP0004CONTENTFILEREF0001 /* BlockPreviewContent.swift */,
-				BP0005SESSIONFILEREF0001 /* BlockPreviewSession.swift */,
 				78ADB28BB3AA3C89FB164C5F /* BlocksBuilderView.swift */,
 				6FBA2522655384EA7091AA8C /* HistoryView.swift */,
-				B82E4BC0B8C01489502831A9 /* MacMessagesView.swift */,
+				A9B898B8784054153152350B /* MacFeedView.swift */,
 				2E4D0C6DDB6891CB03EA9572 /* MenuBarView.swift */,
+				1FBE58AD4319A750AC8132F6 /* OnboardingView.swift */,
+				1AE817B39CB7F2A53FCDA7CB /* PermissionConsentView.swift */,
+				3B00637FB853892DA9991BBF /* ScriptCatalogView.swift */,
+				9AEB210A6E3AED0E763F5EFA /* ScriptDetailView.swift */,
 				28BCC8842C2E63700381890C /* SettingsView.swift */,
-				AA0000001VIEW0HELPERS00 /* ViewHelpers.swift */,
-				AA0000003SCRIPTDETAIL00 /* ScriptDetailView.swift */,
-				AA0000005SCRIPTCATALOG0 /* ScriptCatalogView.swift */,
-				AA0000007MACFEEDVIEW000 /* MacFeedView.swift */,
 				53C1EA5DC0ECBB374F1FCF5B /* TooltipSupport.swift */,
+				246E4BBF06F630784496A69E /* ViewHelpers.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -291,12 +266,12 @@
 		C684A63C98AF3DBF68A15174 /* AskMacCore */ = {
 			isa = PBXGroup;
 			children = (
-				AA000001CATALOG00ENTRY000 /* CatalogEntry.swift */,
-				AA000002INSTALLED0SCRIPT0 /* InstalledScript.swift */,
-				3D24A318DEBECC653846BFA7 /* ScriptCatalogService.swift */,
-				06C485A3E2C74E3C9F1A0002 /* TaskRegistry.swift */,
+				511159CACA895A8F81CD7F01 /* CatalogEntry.swift */,
+				4AF213161B330FC04561C69E /* InstalledScript.swift */,
+				59391DEC75269D029ADC07D3 /* ScriptCatalogService.swift */,
+				394A7868696C7CA0D1CF57D1 /* TaskRegistry.swift */,
 				CFD416A6077DEA3848608AB1 /* TerminalMonitorService.swift */,
-				3F2A338EFC99F8D874DB40EE /* VersionComparison.swift */,
+				4E900B371D21D4580D767EBA /* VersionComparison.swift */,
 			);
 			name = AskMacCore;
 			path = Sources/AskMacCore;
@@ -315,7 +290,6 @@
 			children = (
 				6A9CBCABF50128C52895B960 /* AskMac.app */,
 				00C7F95F08E74502C870234D /* AskMacTests.xctest */,
-				AA1B2C3D4E5F6789ABCD0001 /* AskMacUITests.xctest */,
 				52C75A2FE8B8444D42AF146A /* libAskMacCore.a */,
 			);
 			name = Products;
@@ -324,23 +298,6 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
-		AA1B2C3D4E5F6789ABCD0009 /* AskMacUITests */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = AA1B2C3D4E5F6789ABCD0012 /* Build configuration list for PBXNativeTarget "AskMacUITests" */;
-			buildPhases = (
-				AA1B2C3D4E5F6789ABCD0006 /* Sources */,
-				AA1B2C3D4E5F6789ABCD0007 /* Frameworks */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				AA1B2C3D4E5F6789ABCD0014 /* PBXTargetDependency */,
-			);
-			name = AskMacUITests;
-			productName = AskMacUITests;
-			productReference = AA1B2C3D4E5F6789ABCD0001 /* AskMacUITests.xctest */;
-			productType = "com.apple.product-type.bundle.ui-testing";
-		};
 		170C9A2D6ECAA9D5B00CB20D /* AskMacTests */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 68A439BDF7AB7FF4038496B6 /* Build configuration list for PBXNativeTarget "AskMacTests" */;
@@ -412,9 +369,6 @@
 					170C9A2D6ECAA9D5B00CB20D = {
 						DevelopmentTeam = B5J28L8ARB;
 					};
-					AA1B2C3D4E5F6789ABCD0009 = {
-						DevelopmentTeam = B5J28L8ARB;
-					};
 					B5A9CAFDC0F194D4B590DD08 = {
 						DevelopmentTeam = B5J28L8ARB;
 					};
@@ -444,7 +398,6 @@
 				E59CE13E0F81B53C77683FB1 /* AskMac */,
 				B5A9CAFDC0F194D4B590DD08 /* AskMacCore */,
 				170C9A2D6ECAA9D5B00CB20D /* AskMacTests */,
-				AA1B2C3D4E5F6789ABCD0009 /* AskMacUITests */,
 			);
 		};
 /* End PBXProject section */
@@ -480,21 +433,15 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
-		AA1B2C3D4E5F6789ABCD0006 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				AA1B2C3D4E5F6789ABCD0003 /* AskMacUITests.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		464C2CE2637CA99678E445FA /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 				EFD8390B0162CA00B1B3144E /* ScriptCatalogServiceTests.swift in Sources */,
+				DAA69300555DC6A6182D64DD /* ScriptDependencyTests.swift in Sources */,
 				F47B199A3425DC6C05AC0480 /* ScriptInstallerRollbackTests.swift in Sources */,
 				8FE46F69A0823A2188C24DB4 /* ScriptManagerFilteringTests.swift in Sources */,
+				8C30E811B8346325809717AD /* TaskServiceTests.swift in Sources */,
 				0D696DD556936DCEC1997BEB /* TerminalMonitorServiceTests.swift in Sources */,
 				C99AE720C0F4BDEEC032237B /* VersionComparisonTests.swift in Sources */,
 			);
@@ -508,14 +455,14 @@
 				D0C0EC092421E3FE9F41EB89 /* AppSettings.swift in Sources */,
 				CB275270E3CF93DD24F84506 /* AppUpdater.swift in Sources */,
 				3654DDECAB92F2C7B7678F90 /* AskMacApp.swift in Sources */,
+				F731AD25577DEF6697BFE1A8 /* BlockPreviewContent.swift in Sources */,
+				8B154777BD5CBACF5561A998 /* BlockPreviewHelpers.swift in Sources */,
+				D8C56B58F83FC0A72B93B0F9 /* BlockPreviewInteractive.swift in Sources */,
+				B0E1449E476C1EC21C08AB8E /* BlockPreviewSession.swift in Sources */,
+				FF0F953A573F6C0C5AFB2D2A /* BlockPreviewStatus.swift in Sources */,
 				58854C8E2F0F81A7D7A40B80 /* BlockPreviewViews.swift in Sources */,
-				BP0001HELPERSBUILDF00001 /* BlockPreviewHelpers.swift in Sources */,
-				BP0002INTERACTIVEBUILD001 /* BlockPreviewInteractive.swift in Sources */,
-				BP0003STATUSBUILDF000001 /* BlockPreviewStatus.swift in Sources */,
-				BP0004CONTENTBUILDF00001 /* BlockPreviewContent.swift in Sources */,
-				BP0005SESSIONBUILDF00001 /* BlockPreviewSession.swift in Sources */,
 				2A8C999FCCA1DDA22786079F /* BlockService.swift in Sources */,
-				2A8C999FCCA1DDA22786079E /* BlockStateManager.swift in Sources */,
+				C6AC124B00FCBF51126E1CD4 /* BlockStateManager.swift in Sources */,
 				F6670C71B1ACAA3861CBE8B5 /* BlocksBuilderView.swift in Sources */,
 				C4A094A8937C7FDEF0021ADC /* CloudKitSchema.swift in Sources */,
 				B5760E42FDC4626B6A2AD8D9 /* CloudKitService.swift in Sources */,
@@ -523,28 +470,25 @@
 				6FF5F3CD40995F704A970F21 /* HeartbeatService.swift in Sources */,
 				6F24BAB0E82A7694C50B439F /* HistoryView.swift in Sources */,
 				2DDF70E89F94833C7837389B /* KeychainService.swift in Sources */,
-				AA1B2C3D4E5F6789ABCD0005 /* MacUITestingSupport.swift in Sources */,
+				AF43483C7B2B14F044025386 /* LocalHTTPServer.swift in Sources */,
 				0675DD58EE11FCC5FB9C0FE9 /* MCPConnection.swift in Sources */,
+				0038B1D02FF68672B1F0C367 /* MacFeedView.swift in Sources */,
+				E615CA321AB7F86AD7D082FA /* MacUITestingSupport.swift in Sources */,
 				337B871BCC56D6AD61869B87 /* MenuBarView.swift in Sources */,
 				44001CADDFE8D87EC9DC698D /* MessageWatcherService.swift in Sources */,
+				49EE75B9FA1320C6CBACB7B0 /* OnboardingView.swift in Sources */,
+				000F4A980B0414BE0CC8C4FF /* PermissionConsentView.swift in Sources */,
 				7A4B52614E8031E1D2E8710F /* ResponsePoller.swift in Sources */,
-				06C485A3E2C74E3C9F1A0001 /* TaskService.swift in Sources */,
-				CC000006CATALOG00ENTRY000 /* CatalogEntry.swift in Sources */,
-				CC000007INSTALLED0SCRIPT0 /* InstalledScript.swift in Sources */,
-				CC000008CATALOG0SERVICE00 /* ScriptCatalogService.swift in Sources */,
-				CC000009TERMINAL0MONITOR0 /* TerminalMonitorService.swift in Sources */,
-				CC000010VERSION0COMPARE00 /* VersionComparison.swift in Sources */,
+				5B61E54CE9843A9A5C0AD50E /* ScriptCatalogView.swift in Sources */,
+				6B72EE49DF6636DE0B0B7098 /* ScriptDetailView.swift in Sources */,
 				DA6EADD0D5A75CED02E56F5C /* ScriptInstaller.swift in Sources */,
 				8B9F7C8632ECBE36C84A369E /* ScriptManager.swift in Sources */,
-				AA000010LOCALHTTPSERVER00 /* LocalHTTPServer.swift in Sources */,
 				F4A65B11697EF409F84B5886 /* ScriptUpdateService.swift in Sources */,
 				A302F5F593A0983FFEE135A9 /* SettingsView.swift in Sources */,
-				AA0000002VIEW0HELPERS00 /* ViewHelpers.swift in Sources */,
-				AA0000004SCRIPTDETAIL00 /* ScriptDetailView.swift in Sources */,
-				AA0000006SCRIPTCATALOG0 /* ScriptCatalogView.swift in Sources */,
-				AA0000008MACFEEDVIEW000 /* MacFeedView.swift in Sources */,
 				C2FCC42025E190C3F0BA4152 /* SystemScriptConnection.swift in Sources */,
+				E1FEABE93A364BCBB97A2D9F /* TaskService.swift in Sources */,
 				BF0B435F00BDDA9C64E86B06 /* TooltipSupport.swift in Sources */,
+				DA268BB52919770AB2F3E41E /* ViewHelpers.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -552,23 +496,18 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BB000003CATALOG0ENTRY0000 /* CatalogEntry.swift in Sources */,
-				BB000004INSTALLED0SCRIPT0 /* InstalledScript.swift in Sources */,
-				BB000001CATALOG0SERVICE00 /* ScriptCatalogService.swift in Sources */,
-				06C485A3E2C74E3C9F1A0003 /* TaskRegistry.swift in Sources */,
+				63CA74CD980B73A3625E4A42 /* CatalogEntry.swift in Sources */,
+				BB95A9FB5143C6CE6E3D4CD3 /* InstalledScript.swift in Sources */,
+				64532E0B6F9F3D17C45F536A /* ScriptCatalogService.swift in Sources */,
+				DA1696677CAF3AD1A1633669 /* TaskRegistry.swift in Sources */,
 				BAE4E67E06F337A2A3722087 /* TerminalMonitorService.swift in Sources */,
-				BB000002VERSION0COMPARE00 /* VersionComparison.swift in Sources */,
+				8D1B5B2F3B2AD30DC3450B73 /* VersionComparison.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		AA1B2C3D4E5F6789ABCD0014 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = E59CE13E0F81B53C77683FB1 /* AskMac */;
-			targetProxy = AA1B2C3D4E5F6789ABCD0013 /* PBXContainerItemProxy */;
-		};
 		153BF4E6B2701CCC64C50410 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = B5A9CAFDC0F194D4B590DD08 /* AskMacCore */;
@@ -753,7 +692,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.8.0;
+				MARKETING_VERSION = 0.9.1;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -761,7 +700,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.kevinhill.askmac;
 				PROVISIONING_PROFILE_SPECIFIER = "036fee16-227d-478a-a99e-021fe8ec952d";
 				SDKROOT = macosx;
-				SWIFT_INCLUDE_PATHS = "$(BUILT_PRODUCTS_DIR)";
 			};
 			name = Release;
 		};
@@ -790,26 +728,25 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CLOUDKIT_ENVIRONMENT = DEVELOPMENT;
-				CODE_SIGN_ENTITLEMENTS = Sources/AskMac/AskMacDev.entitlements;
-				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				CLOUDKIT_ENVIRONMENT = PRODUCTION;
+				CODE_SIGN_ENTITLEMENTS = Sources/AskMac/AskMac.entitlements;
+				CODE_SIGN_IDENTITY = "Developer ID Application: Kevin Hill (B5J28L8ARB)";
+				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = B5J28L8ARB;
 				INFOPLIST_FILE = Sources/AskMac/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.8.0;
+				MARKETING_VERSION = 0.9.1;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.kevinhill.askmac;
+				PROVISIONING_PROFILE_SPECIFIER = "036fee16-227d-478a-a99e-021fe8ec952d";
 				SDKROOT = macosx;
-				SWIFT_INCLUDE_PATHS = "$(BUILT_PRODUCTS_DIR)";
 			};
 			name = Debug;
 		};
@@ -834,42 +771,6 @@
 			};
 			name = Debug;
 		};
-		AA1B2C3D4E5F6789ABCD0010 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				COMBINE_HIDPI_IMAGES = YES;
-				GENERATE_INFOPLIST_FILE = YES;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/../Frameworks",
-					"@loader_path/../Frameworks",
-				);
-				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.kevinhill.AskMacUITests;
-				SDKROOT = macosx;
-				SWIFT_VERSION = 5.10;
-				TEST_TARGET_NAME = AskMac;
-			};
-			name = Debug;
-		};
-		AA1B2C3D4E5F6789ABCD0011 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				COMBINE_HIDPI_IMAGES = YES;
-				GENERATE_INFOPLIST_FILE = YES;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/../Frameworks",
-					"@loader_path/../Frameworks",
-				);
-				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.kevinhill.AskMacUITests;
-				SDKROOT = macosx;
-				SWIFT_VERSION = 5.10;
-				TEST_TARGET_NAME = AskMac;
-			};
-			name = Release;
-		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -887,15 +788,6 @@
 			buildConfigurations = (
 				7799AB0228C91D865E0193EB /* Debug */,
 				592FA27071A764C2716E13E3 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Debug;
-		};
-		AA1B2C3D4E5F6789ABCD0012 /* Build configuration list for PBXNativeTarget "AskMacUITests" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				AA1B2C3D4E5F6789ABCD0010 /* Debug */,
-				AA1B2C3D4E5F6789ABCD0011 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;

--- a/AskMac/AskMac.xcodeproj/project.pbxproj
+++ b/AskMac/AskMac.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		8B154777BD5CBACF5561A998 /* BlockPreviewHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FB18E6D1590306C5E9169FA /* BlockPreviewHelpers.swift */; };
 		8B9F7C8632ECBE36C84A369E /* ScriptManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA1CC49C770BDCD1EB75B351 /* ScriptManager.swift */; };
 		8C30E811B8346325809717AD /* TaskServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8C66FCA9A17628445E9ECCA /* TaskServiceTests.swift */; };
+		8CB066949DA102A4AFC0B76E /* ScriptDependencyInstallTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 976DD80CB6CE2881A37201BC /* ScriptDependencyInstallTests.swift */; };
 		8D1B5B2F3B2AD30DC3450B73 /* VersionComparison.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E900B371D21D4580D767EBA /* VersionComparison.swift */; };
 		8FE46F69A0823A2188C24DB4 /* ScriptManagerFilteringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A9E4EFAF553CA1CD22DA58A /* ScriptManagerFilteringTests.swift */; };
 		A302F5F593A0983FFEE135A9 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28BCC8842C2E63700381890C /* SettingsView.swift */; };
@@ -126,6 +127,7 @@
 		834313B9757B652D0DB8E349 /* MessageWatcherService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageWatcherService.swift; sourceTree = "<group>"; };
 		944903959A55B26822A4701D /* BlockService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockService.swift; sourceTree = "<group>"; };
 		944A4DCFCCDB25464859E84A /* BlockPreviewSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockPreviewSession.swift; sourceTree = "<group>"; };
+		976DD80CB6CE2881A37201BC /* ScriptDependencyInstallTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScriptDependencyInstallTests.swift; sourceTree = "<group>"; };
 		9AEB210A6E3AED0E763F5EFA /* ScriptDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScriptDetailView.swift; sourceTree = "<group>"; };
 		9B2C7957AA31DE73EE832ABD /* ScriptDependencyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScriptDependencyTests.swift; sourceTree = "<group>"; };
 		9FA01F4EBBCEE5682DC62048 /* BlockPreviewContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockPreviewContent.swift; sourceTree = "<group>"; };
@@ -210,6 +212,7 @@
 			isa = PBXGroup;
 			children = (
 				7F0BACCC7986B8E27CD6B9A8 /* ScriptCatalogServiceTests.swift */,
+				976DD80CB6CE2881A37201BC /* ScriptDependencyInstallTests.swift */,
 				9B2C7957AA31DE73EE832ABD /* ScriptDependencyTests.swift */,
 				EAB5EAD55DFF07DA5ECE953A /* ScriptInstallerRollbackTests.swift */,
 				3A9E4EFAF553CA1CD22DA58A /* ScriptManagerFilteringTests.swift */,
@@ -438,6 +441,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				EFD8390B0162CA00B1B3144E /* ScriptCatalogServiceTests.swift in Sources */,
+				8CB066949DA102A4AFC0B76E /* ScriptDependencyInstallTests.swift in Sources */,
 				DAA69300555DC6A6182D64DD /* ScriptDependencyTests.swift in Sources */,
 				F47B199A3425DC6C05AC0480 /* ScriptInstallerRollbackTests.swift in Sources */,
 				8FE46F69A0823A2188C24DB4 /* ScriptManagerFilteringTests.swift in Sources */,

--- a/AskMac/AskMac.xcodeproj/project.pbxproj
+++ b/AskMac/AskMac.xcodeproj/project.pbxproj
@@ -696,7 +696,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.9.1;
+				MARKETING_VERSION = 0.9.2;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -743,7 +743,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.9.1;
+				MARKETING_VERSION = 0.9.2;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",

--- a/AskMac/Sources/AskMac/Services/ScriptInstaller.swift
+++ b/AskMac/Sources/AskMac/Services/ScriptInstaller.swift
@@ -4,6 +4,19 @@ import AskMacCore
 import Foundation
 import SwiftUI
 
+// MARK: - ScriptInstallTarget
+
+/// The subset of ScriptManager that ScriptInstaller needs — extracted so tests can inject a mock.
+protocol ScriptInstallTarget: AnyObject {
+    var scripts: [ManagedScript] { get }
+    func beginInstall()
+    func endInstall()
+    func stopScriptForUpdate(id: String)
+    func markInstalledByUser(ids: [String])
+}
+
+extension ScriptManager: ScriptInstallTarget {}
+
 // MARK: - ScriptInstaller
 
 @Observable
@@ -267,13 +280,13 @@ final class ScriptInstaller {
 
     // MARK: - Installation
 
-    func install(to vaultURL: URL, scriptManager: ScriptManager,
+    func install(to vaultURL: URL, scriptManager: any ScriptInstallTarget,
                  catalog: ScriptCatalogService? = nil) {
         Task { await doInstall(to: vaultURL, scriptManager: scriptManager, catalog: catalog) }
     }
 
     @MainActor
-    private func doInstall(to vaultURL: URL, scriptManager: ScriptManager,
+    private func doInstall(to vaultURL: URL, scriptManager: any ScriptInstallTarget,
                            catalog: ScriptCatalogService? = nil) async {
         phase = .installing
         showSheet = false
@@ -375,7 +388,7 @@ final class ScriptInstaller {
     /// Extract a zip and install all valid scripts found inside it, used for silent dep installs.
     @MainActor
     private func installFromZip(zipURL: URL, vaultURL: URL,
-                                scriptManager: ScriptManager, label: String) async {
+                                scriptManager: any ScriptInstallTarget, label: String) async {
         let tmp = FileManager.default.temporaryDirectory
             .appendingPathComponent("ask-dep-\(UUID().uuidString)")
         defer { try? FileManager.default.removeItem(at: tmp) }

--- a/AskMac/Sources/AskMac/Services/ScriptInstaller.swift
+++ b/AskMac/Sources/AskMac/Services/ScriptInstaller.swift
@@ -31,6 +31,7 @@ final class ScriptInstaller {
         let installKind: InstallKind
         let existingVersion: String?
         let warnings: [String]       // non-blocking issues surfaced in the sheet
+        let scriptDependencies: [String]  // other script IDs required before this one runs
     }
 
     struct SkippedScript: Identifiable {
@@ -245,6 +246,8 @@ final class ScriptInstaller {
             warnings.append("Name '\(name)' is already used by script '\(conflicting.id)' — both will appear in the sidebar")
         }
 
+        let scriptDeps = manifest["script_dependencies"] as? [String] ?? []
+
         return .success(PendingScript(
             id: id,
             name: name,
@@ -257,21 +260,53 @@ final class ScriptInstaller {
             sourceDir: dir,
             installKind: installKind,
             existingVersion: existingVersion,
-            warnings: warnings
+            warnings: warnings,
+            scriptDependencies: scriptDeps
         ))
     }
 
     // MARK: - Installation
 
-    func install(to vaultURL: URL, scriptManager: ScriptManager) {
-        Task { await doInstall(to: vaultURL, scriptManager: scriptManager) }
+    func install(to vaultURL: URL, scriptManager: ScriptManager,
+                 catalog: ScriptCatalogService? = nil) {
+        Task { await doInstall(to: vaultURL, scriptManager: scriptManager, catalog: catalog) }
     }
 
     @MainActor
-    private func doInstall(to vaultURL: URL, scriptManager: ScriptManager) async {
+    private func doInstall(to vaultURL: URL, scriptManager: ScriptManager,
+                           catalog: ScriptCatalogService? = nil) async {
         phase = .installing
         showSheet = false
         scriptManager.beginInstall()
+
+        // Resolve script dependencies: install any missing deps silently before main scripts.
+        if let catalog {
+            let installedIDs = Set(scriptManager.scripts.map(\.id))
+            let neededDepIDs = Set(pending.flatMap(\.scriptDependencies))
+                .subtracting(installedIDs)
+                .subtracting(Set(pending.map(\.id)))  // also being installed this run
+
+            for depID in neededDepIDs {
+                guard let depEntry = catalog.allEntries.first(where: { $0.id == depID }) else {
+                    skipped.append(SkippedScript(
+                        folderName: depID,
+                        reason: "Required dependency '\(depID)' not found in catalog — install it manually"
+                    ))
+                    continue
+                }
+                installProgressLabel = "Installing dependency: \(depEntry.name)…"
+                do {
+                    let zipURL = try await catalog.downloadZip(for: depEntry)
+                    await installFromZip(zipURL: zipURL, vaultURL: vaultURL,
+                                         scriptManager: scriptManager, label: depEntry.name)
+                } catch {
+                    skipped.append(SkippedScript(
+                        folderName: depID,
+                        reason: "Could not download dependency '\(depID)': \(error.localizedDescription)"
+                    ))
+                }
+            }
+        }
 
         let fm = FileManager.default
         var installationErrors: [SkippedScript] = []
@@ -336,6 +371,49 @@ final class ScriptInstaller {
     }
 
     // MARK: - Helpers
+
+    /// Extract a zip and install all valid scripts found inside it, used for silent dep installs.
+    @MainActor
+    private func installFromZip(zipURL: URL, vaultURL: URL,
+                                scriptManager: ScriptManager, label: String) async {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ask-dep-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: tmp) }
+        do {
+            try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+            let exitCode = await Task.detached(priority: .userInitiated) {
+                let proc = Process()
+                proc.executableURL = URL(fileURLWithPath: "/usr/bin/unzip")
+                proc.arguments = ["-o", zipURL.path, "-d", tmp.path]
+                proc.standardOutput = Pipe(); proc.standardError = Pipe()
+                try? proc.run(); proc.waitUntilExit()
+                return proc.terminationStatus
+            }.value
+            guard exitCode == 0 else { return }
+            let dirs = (try? findScriptDirs(in: tmp)) ?? []
+            let fm = FileManager.default
+            for dir in dirs {
+                guard case .success(let ps) = validate(dir: dir, existingScripts: scriptManager.scripts) else { continue }
+                let destDir = vaultURL.appendingPathComponent(ps.id)
+                if fm.fileExists(atPath: destDir.path) {
+                    scriptManager.stopScriptForUpdate(id: ps.id)
+                    let oldSetup = destDir.appendingPathComponent("setup.py")
+                    if fm.fileExists(atPath: oldSetup.path) {
+                        await runSetup(scriptPath: oldSetup, scriptDir: destDir, argument: "--uninstall")
+                    }
+                    let backup = vaultURL.appendingPathComponent("\(ps.id).previous")
+                    try? fm.removeItem(at: backup)
+                    try? fm.moveItem(at: destDir, to: backup)
+                }
+                try fm.copyItem(at: ps.sourceDir, to: destDir)
+                let setup = destDir.appendingPathComponent("setup.py")
+                if fm.fileExists(atPath: setup.path) {
+                    await runSetup(scriptPath: setup, scriptDir: destDir, argument: "--install")
+                }
+                scriptManager.markInstalledByUser(ids: [ps.id])
+            }
+        } catch {}
+    }
 
     /// Run `setup.py --install` or `setup.py --uninstall` with a 5-minute timeout.
     private func runSetup(scriptPath: URL, scriptDir: URL, argument: String) async {

--- a/AskMac/Sources/AskMac/Views/OnboardingView.swift
+++ b/AskMac/Sources/AskMac/Views/OnboardingView.swift
@@ -150,7 +150,7 @@ struct OnboardingView: View {
         }
 
         installer.showSheet = false
-        installer.install(to: vault, scriptManager: scriptManager)
+        installer.install(to: vault, scriptManager: scriptManager, catalog: scriptCatalog)
 
         var installWaits = 0
         while installer.phase != .idle, installWaits < 600 {

--- a/AskMac/Sources/AskMac/Views/ScriptCatalogView.swift
+++ b/AskMac/Sources/AskMac/Views/ScriptCatalogView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 struct AddScriptsView: View {
     @Environment(AppSettings.self) private var settings
     @Environment(ScriptManager.self) private var scriptManager
+    @Environment(ScriptCatalogService.self) private var catalog
 
     @State private var installer = ScriptInstaller()
 
@@ -20,7 +21,8 @@ struct AddScriptsView: View {
                     scriptManager: scriptManager,
                     vaultURL: settings.vaultPath
                         ?? FileManager.default.homeDirectoryForCurrentUser
-                            .appendingPathComponent(".ask/scripts")
+                            .appendingPathComponent(".ask/scripts"),
+                    catalog: catalog
                 )
             }
     }
@@ -190,7 +192,8 @@ struct ScriptCatalogView: View {
                 installer: installer,
                 scriptManager: scriptManager,
                 vaultURL: settings.vaultPath ?? FileManager.default.homeDirectoryForCurrentUser
-                    .appendingPathComponent(".ask/scripts")
+                    .appendingPathComponent(".ask/scripts"),
+                catalog: catalog
             )
         }
         .task {

--- a/AskMac/Sources/AskMac/Views/SettingsView.swift
+++ b/AskMac/Sources/AskMac/Views/SettingsView.swift
@@ -1411,7 +1411,8 @@ private struct ScriptsTabView: View {
             }
             .sheet(isPresented: $installer.showSheet) {
                 ScriptInstallSheet(installer: installer, scriptManager: scriptManager,
-                                   vaultURL: settings.vaultPath ?? FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".ask/scripts"))
+                                   vaultURL: settings.vaultPath ?? FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".ask/scripts"),
+                                   catalog: catalog)
             }
         } detail: {
             if showCatalog {
@@ -2375,6 +2376,7 @@ struct ScriptInstallSheet: View {
     @Bindable var installer: ScriptInstaller
     let scriptManager: ScriptManager
     let vaultURL: URL
+    let catalog: ScriptCatalogService
 
     var body: some View {
         VStack(spacing: 0) {
@@ -2470,7 +2472,7 @@ struct ScriptInstallSheet: View {
                     .buttonStyle(.bordered)
                     Spacer()
                     Button(installButtonLabel) {
-                        installer.install(to: vaultURL, scriptManager: scriptManager)
+                        installer.install(to: vaultURL, scriptManager: scriptManager, catalog: catalog)
                     }
                     .buttonStyle(.borderedProminent)
                     .disabled(installer.phase != .ready)

--- a/AskMac/Sources/AskMacCore/CatalogEntry.swift
+++ b/AskMac/Sources/AskMacCore/CatalogEntry.swift
@@ -30,15 +30,19 @@ public struct CatalogEntry: Identifiable, Decodable {
     /// Prerequisite checks from the script's manifest requires array.
     /// Optional — nil when the catalog was generated without this field.
     public let requires: [CatalogRequirement]?
+    /// Other script IDs that must be installed before this script runs.
+    public let scriptDependencies: [String]?
 
     public enum CodingKeys: String, CodingKey {
         case id, name, version, description, icon, svg, type, changelog, permissions, requires
         case downloadURL = "download_url"
+        case scriptDependencies = "script_dependencies"
     }
 
     public init(id: String, name: String, version: String, description: String,
                 icon: String?, svg: String? = nil, type: String?, changelog: String?, downloadURL: URL,
-                permissions: [String]? = nil, requires: [CatalogRequirement]? = nil) {
+                permissions: [String]? = nil, requires: [CatalogRequirement]? = nil,
+                scriptDependencies: [String]? = nil) {
         self.id = id
         self.name = name
         self.version = version
@@ -50,6 +54,7 @@ public struct CatalogEntry: Identifiable, Decodable {
         self.downloadURL = downloadURL
         self.permissions = permissions
         self.requires = requires
+        self.scriptDependencies = scriptDependencies
     }
 }
 

--- a/AskMac/Tests/AskMacTests/ScriptDependencyInstallTests.swift
+++ b/AskMac/Tests/AskMacTests/ScriptDependencyInstallTests.swift
@@ -1,0 +1,212 @@
+import Testing
+import Foundation
+@testable import AskMac
+#if canImport(AskMacCore)
+import AskMacCore
+#endif
+
+// MARK: - Mock
+
+/// Minimal ScriptInstallTarget for testing — tracks what was installed, starts with no scripts.
+@MainActor
+final class MockScriptManager: ScriptInstallTarget {
+    var scripts: [ManagedScript] = []
+    private(set) var markedInstalledIDs: [String] = []
+
+    func beginInstall() {}
+    func endInstall() {}
+    func stopScriptForUpdate(id: String) {}
+    func markInstalledByUser(ids: [String]) { markedInstalledIDs.append(contentsOf: ids) }
+}
+
+// MARK: - Helpers
+
+private func repoRoot() -> URL {
+    // Test bundle is deep inside DerivedData; walk up to find the repo root by
+    // looking for the ask/scripts directory.
+    var url = URL(fileURLWithPath: #filePath)
+    while url.path != "/" {
+        if FileManager.default.fileExists(
+            atPath: url.appendingPathComponent("ask/scripts").path) {
+            return url
+        }
+        url = url.deletingLastPathComponent()
+    }
+    preconditionFailure("Could not find repo root from \(#filePath)")
+}
+
+/// Zip a script directory from the repo into a temp file and return the zip URL.
+private func zipScript(id: String, repoRoot: URL) throws -> URL {
+    let scriptDir = repoRoot.appendingPathComponent("ask/scripts/\(id)")
+    guard FileManager.default.fileExists(atPath: scriptDir.path) else {
+        throw TestError("Script directory not found: \(scriptDir.path)")
+    }
+    let zipURL = FileManager.default.temporaryDirectory
+        .appendingPathComponent("\(id)-test-\(UUID().uuidString).zip")
+    let proc = Process()
+    proc.executableURL = URL(fileURLWithPath: "/usr/bin/zip")
+    proc.arguments = ["-r", zipURL.path, id,
+                      "--exclude", "\(id)/__pycache__/*",
+                      "--exclude", "\(id)/*.pyc"]
+    proc.currentDirectoryURL = repoRoot.appendingPathComponent("ask/scripts")
+    proc.standardOutput = Pipe(); proc.standardError = Pipe()
+    try proc.run(); proc.waitUntilExit()
+    guard proc.terminationStatus == 0 else {
+        throw TestError("zip failed for \(id)")
+    }
+    return zipURL
+}
+
+private struct TestError: Error, CustomStringConvertible {
+    let description: String
+    init(_ msg: String) { description = msg }
+}
+
+// MARK: - Integration tests
+
+@Suite("Script dependency install integration")
+struct ScriptDependencyInstallTests {
+
+    /// Core scenario: install claudecode-controller with an empty vault.
+    /// Expects terminal-manager to be auto-installed as a dependency.
+    @Test func installsTerminalManagerWhenClaudeCodeControllerInstalled() async throws {
+        let repo = repoRoot()
+
+        // 1. Build local zips
+        let controllerZip = try zipScript(id: "claudecode-controller", repoRoot: repo)
+        let tmZip         = try zipScript(id: "terminal-manager",       repoRoot: repo)
+        defer {
+            try? FileManager.default.removeItem(at: controllerZip)
+            try? FileManager.default.removeItem(at: tmZip)
+        }
+
+        // 2. Temp vault — starts empty (no terminal-manager)
+        let vault = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ask-dep-integ-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: vault, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: vault) }
+
+        // 3. Catalog seeded with terminal-manager entry pointing to local file:// zip
+        let tmEntry = CatalogEntry(
+            id: "terminal-manager",
+            name: "Terminal Manager",
+            version: "1.6.0",
+            description: "test",
+            icon: nil,
+            type: "system",
+            changelog: nil,
+            downloadURL: tmZip
+        )
+        let catalog = await MainActor.run { ScriptCatalogService(entries: [tmEntry]) }
+
+        // 4. Mock manager — no scripts installed
+        let manager = await MockScriptManager()
+
+        // 5. Installer — parse claudecode-controller zip
+        let installer = await ScriptInstaller()
+        await MainActor.run { installer.load(zipURL: controllerZip, existingScripts: []) }
+
+        // Wait for parsing to start, then complete
+        var waited = 0
+        while await installer.phase == .idle, waited < 50 {
+            try await Task.sleep(for: .milliseconds(50))
+            waited += 1
+        }
+        while await installer.phase == .parsing, waited < 200 {
+            try await Task.sleep(for: .milliseconds(100))
+            waited += 1
+        }
+        let phase = await installer.phase
+        #expect(phase == .ready, "installer should reach .ready, got \(phase)")
+
+        // 6. Run the install with the catalog (dep resolution fires here)
+        await MainActor.run {
+            installer.showSheet = false
+            installer.install(to: vault, scriptManager: manager, catalog: catalog)
+        }
+
+        // Wait for install to finish
+        waited = 0
+        while await installer.phase != .idle, waited < 300 {
+            try await Task.sleep(for: .milliseconds(100))
+            waited += 1
+        }
+
+        // 7. Assert both scripts landed in the vault
+        let fm = FileManager.default
+        let controllerInVault = vault.appendingPathComponent("claudecode-controller")
+        let tmInVault         = vault.appendingPathComponent("terminal-manager")
+
+        #expect(fm.fileExists(atPath: controllerInVault.path),
+                "claudecode-controller should be in vault after install")
+        #expect(fm.fileExists(atPath: tmInVault.path),
+                "terminal-manager should be auto-installed as a dependency")
+
+        // 8. Both should have been marked as installed
+        let marked = await manager.markedInstalledIDs
+        #expect(marked.contains("terminal-manager"),
+                "terminal-manager should be marked installed by user")
+    }
+
+    /// Regression: if terminal-manager is already present, it should NOT be reinstalled.
+    @Test func skipsDepInstallWhenAlreadyPresent() async throws {
+        let repo = repoRoot()
+        let controllerZip = try zipScript(id: "claudecode-controller", repoRoot: repo)
+        let tmZip         = try zipScript(id: "terminal-manager",       repoRoot: repo)
+        defer {
+            try? FileManager.default.removeItem(at: controllerZip)
+            try? FileManager.default.removeItem(at: tmZip)
+        }
+
+        let vault = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ask-dep-integ-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: vault, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: vault) }
+
+        let tmEntry = CatalogEntry(
+            id: "terminal-manager", name: "Terminal Manager", version: "1.6.0",
+            description: "test", icon: nil, type: "system", changelog: nil, downloadURL: tmZip
+        )
+        let catalog = await MainActor.run { ScriptCatalogService(entries: [tmEntry]) }
+
+        // terminal-manager is already installed — inject as existing script
+        let existingTM = ManagedScript(
+            id: "terminal-manager", name: "Terminal Manager",
+            version: "1.6.0", description: "test",
+            icon: nil, iconImage: nil, svgString: nil,
+            status: .running, isEnabled: true
+        )
+        let manager = await MockScriptManager()
+        await MainActor.run { manager.scripts = [existingTM] }
+
+        let installer = await ScriptInstaller()
+        await MainActor.run { installer.load(zipURL: controllerZip, existingScripts: [existingTM]) }
+
+        var waited = 0
+        while await installer.phase == .idle, waited < 50 {
+            try await Task.sleep(for: .milliseconds(50))
+            waited += 1
+        }
+        while await installer.phase == .parsing, waited < 200 {
+            try await Task.sleep(for: .milliseconds(100))
+            waited += 1
+        }
+
+        await MainActor.run {
+            installer.showSheet = false
+            installer.install(to: vault, scriptManager: manager, catalog: catalog)
+        }
+
+        waited = 0
+        while await installer.phase != .idle, waited < 300 {
+            try await Task.sleep(for: .milliseconds(100))
+            waited += 1
+        }
+
+        // terminal-manager should NOT be in the vault (it was already there, we didn't re-copy)
+        // and it should NOT be re-marked as installed
+        let marked = await manager.markedInstalledIDs
+        #expect(!marked.contains("terminal-manager"),
+                "terminal-manager should not be re-installed if already present")
+    }
+}

--- a/AskMac/Tests/AskMacTests/ScriptDependencyInstallTests.swift
+++ b/AskMac/Tests/AskMacTests/ScriptDependencyInstallTests.swift
@@ -1,3 +1,6 @@
+// Integration tests that require Xcode's test-host app (AskMac.app) to link
+// against Sparkle and SwiftUI. Excluded from `swift test` (SPM) via the guard.
+#if !SWIFT_PACKAGE
 import Testing
 import Foundation
 @testable import AskMac
@@ -210,3 +213,4 @@ struct ScriptDependencyInstallTests {
                 "terminal-manager should not be re-installed if already present")
     }
 }
+#endif // !SWIFT_PACKAGE

--- a/AskMac/Tests/AskMacTests/ScriptDependencyTests.swift
+++ b/AskMac/Tests/AskMacTests/ScriptDependencyTests.swift
@@ -1,0 +1,173 @@
+import Testing
+import Foundation
+
+/// Tests for script_dependencies resolution in ScriptInstaller.
+///
+/// We test the PendingScript parsing and the dependency-collection logic directly
+/// against temp directories — no network, no AppKit, no CloudKit required.
+@Suite("Script dependencies")
+struct ScriptDependencyTests {
+
+    // MARK: - Helpers
+
+    private func makeTempDir() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ask-dep-test-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    /// Write a minimal manifest.json into dir and return the dir URL.
+    private func makeScriptDir(in vault: URL, id: String,
+                               scriptDeps: [String] = []) throws -> URL {
+        let dir = vault.appendingPathComponent(id)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        var manifest: [String: Any] = [
+            "id": id,
+            "name": id,
+            "version": "1.0",
+            "entry": "main.py",
+        ]
+        if !scriptDeps.isEmpty {
+            manifest["script_dependencies"] = scriptDeps
+        }
+        let data = try JSONSerialization.data(withJSONObject: manifest)
+        try data.write(to: dir.appendingPathComponent("manifest.json"))
+        // Create a stub entry file so validation passes
+        try "".write(to: dir.appendingPathComponent("main.py"), atomically: true, encoding: .utf8)
+        return dir
+    }
+
+    // MARK: - manifest.json parsing
+
+    @Test func manifestWithNoDepsHasEmptyDependencies() throws {
+        let tmp = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+        let dir = try makeScriptDir(in: tmp, id: "hello-world", scriptDeps: [])
+
+        let data = try Data(contentsOf: dir.appendingPathComponent("manifest.json"))
+        let manifest = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+        let deps = manifest["script_dependencies"] as? [String] ?? []
+        #expect(deps.isEmpty)
+    }
+
+    @Test func manifestWithDepsRoundTrips() throws {
+        let tmp = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+        let dir = try makeScriptDir(in: tmp, id: "claudecode-controller",
+                                    scriptDeps: ["terminal-manager"])
+
+        let data = try Data(contentsOf: dir.appendingPathComponent("manifest.json"))
+        let manifest = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+        let deps = manifest["script_dependencies"] as? [String] ?? []
+        #expect(deps == ["terminal-manager"])
+    }
+
+    @Test func manifestWithMultipleDepsRoundTrips() throws {
+        let tmp = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+        let dir = try makeScriptDir(in: tmp, id: "multi-dep",
+                                    scriptDeps: ["terminal-manager", "another-dep"])
+
+        let data = try Data(contentsOf: dir.appendingPathComponent("manifest.json"))
+        let manifest = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+        let deps = manifest["script_dependencies"] as? [String] ?? []
+        #expect(deps.count == 2)
+        #expect(deps.contains("terminal-manager"))
+        #expect(deps.contains("another-dep"))
+    }
+
+    // MARK: - Dependency resolution logic (pure logic tests)
+
+    /// Reproduce the dep-resolution filter from doInstall:
+    ///   neededDepIDs = declared deps − already installed − also being installed this run
+    private func resolveNeededDeps(
+        declaredDeps: [String],
+        installedIDs: Set<String>,
+        pendingIDs: Set<String>
+    ) -> Set<String> {
+        Set(declaredDeps)
+            .subtracting(installedIDs)
+            .subtracting(pendingIDs)
+    }
+
+    @Test func depAlreadyInstalledIsNotNeeded() {
+        let needed = resolveNeededDeps(
+            declaredDeps: ["terminal-manager"],
+            installedIDs: ["terminal-manager"],
+            pendingIDs: []
+        )
+        #expect(needed.isEmpty)
+    }
+
+    @Test func missingDepIsNeeded() {
+        let needed = resolveNeededDeps(
+            declaredDeps: ["terminal-manager"],
+            installedIDs: [],
+            pendingIDs: []
+        )
+        #expect(needed == ["terminal-manager"])
+    }
+
+    @Test func depBeingInstalledInSameRunIsNotNeeded() {
+        let needed = resolveNeededDeps(
+            declaredDeps: ["terminal-manager"],
+            installedIDs: [],
+            pendingIDs: ["terminal-manager"]
+        )
+        #expect(needed.isEmpty)
+    }
+
+    @Test func onlyMissingDepsAreNeeded() {
+        let needed = resolveNeededDeps(
+            declaredDeps: ["terminal-manager", "other-dep"],
+            installedIDs: ["other-dep"],
+            pendingIDs: []
+        )
+        #expect(needed == ["terminal-manager"])
+    }
+
+    @Test func noDepsDeclairedMeansNothingNeeded() {
+        let needed = resolveNeededDeps(
+            declaredDeps: [],
+            installedIDs: [],
+            pendingIDs: []
+        )
+        #expect(needed.isEmpty)
+    }
+
+    // MARK: - CatalogEntry decoding
+
+    @Test func catalogEntryDecodesScriptDependencies() throws {
+        let json = """
+        {
+          "id": "claudecode-controller",
+          "name": "Claude Code",
+          "version": "2.27.0",
+          "description": "desc",
+          "download_url": "https://example.com/claudecode-controller.zip",
+          "script_dependencies": ["terminal-manager"]
+        }
+        """.data(using: .utf8)!
+
+        let obj = try JSONSerialization.jsonObject(with: json) as! [String: Any]
+        let deps = obj["script_dependencies"] as? [String] ?? []
+        #expect(deps == ["terminal-manager"])
+    }
+
+    @Test func catalogEntryWithNoDepsFieldDecodesAsNil() throws {
+        let json = """
+        {
+          "id": "hello-world",
+          "name": "Hello World",
+          "version": "1.0",
+          "description": "desc",
+          "download_url": "https://example.com/hello-world.zip"
+        }
+        """.data(using: .utf8)!
+
+        let obj = try JSONSerialization.jsonObject(with: json) as! [String: Any]
+        let deps = obj["script_dependencies"] as? [String]
+        #expect(deps == nil)
+    }
+}

--- a/ask/scripts/claudecode-controller/main.py
+++ b/ask/scripts/claudecode-controller/main.py
@@ -1829,6 +1829,7 @@ class MCPClient:
 set targetTTY to "{safe_tty}"
 set didFocus to false
 
+-- Terminal.app: match by TTY
 if application "Terminal" is running then
     tell application "Terminal"
         repeat with w in every window
@@ -1845,9 +1846,41 @@ if application "Terminal" is running then
             end repeat
             if didFocus then exit repeat
         end repeat
-        if not didFocus then activate
     end tell
-    set didFocus to true
+end if
+
+-- iTerm2: match by TTY
+if not didFocus and application "iTerm2" is running then
+    tell application "iTerm2"
+        repeat with w in windows
+            repeat with tb in tabs of w
+                repeat with s in sessions of tb
+                    try
+                        if tty of s is targetTTY then
+                            select tb
+                            set index of w to 1
+                            activate
+                            set didFocus to true
+                            exit repeat
+                        end if
+                    end try
+                end repeat
+                if didFocus then exit repeat
+            end repeat
+            if didFocus then exit repeat
+        end repeat
+    end tell
+end if
+
+-- Generic fallback: activate any known running terminal
+if not didFocus then
+    repeat with appName in {{"Ghostty", "Warp", "Alacritty", "WezTerm", "kitty", "Hyper"}}
+        if application appName is running then
+            tell application appName to activate
+            set didFocus to true
+            exit repeat
+        end if
+    end repeat
 end if
 
 delay 0.4
@@ -1868,6 +1901,7 @@ end tell
 set pathFragment to "{safe_path}"
 set didFocus to false
 
+-- Terminal.app: match by window name
 if application "Terminal" is running then
     tell application "Terminal"
         repeat with w in every window
@@ -1880,9 +1914,18 @@ if application "Terminal" is running then
                 end if
             end try
         end repeat
-        if not didFocus then activate
     end tell
-    set didFocus to true
+end if
+
+-- Generic fallback: activate any known running terminal
+if not didFocus then
+    repeat with appName in {{"iTerm2", "Ghostty", "Warp", "Alacritty", "WezTerm", "kitty"}}
+        if application appName is running then
+            tell application appName to activate
+            set didFocus to true
+            exit repeat
+        end if
+    end repeat
 end if
 
 delay 0.4

--- a/ask/scripts/claudecode-controller/manifest.json
+++ b/ask/scripts/claudecode-controller/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "claudecode-controller",
   "name": "Claude Code",
-  "version": "2.26.0",
+  "version": "2.27.0",
   "setup": "setup.py",
   "description": "Claude Code session supervisor \u2014 routes permissions and notifications to iPhone",
   "entry": "main.py",

--- a/ask/scripts/claudecode-controller/manifest.json
+++ b/ask/scripts/claudecode-controller/manifest.json
@@ -4,6 +4,7 @@
   "version": "2.27.0",
   "setup": "setup.py",
   "description": "Claude Code session supervisor \u2014 routes permissions and notifications to iPhone",
+  "script_dependencies": ["terminal-manager"],
   "entry": "main.py",
   "icon": "sparkles",
   "icon_file": "icon.svg",

--- a/ask/scripts/terminal-manager/main.py
+++ b/ask/scripts/terminal-manager/main.py
@@ -53,6 +53,9 @@ KEY_MAP = {
     'ctrl_u':  (None, 'C-u'),
 }
 
+# Terminal apps we know how to address by name, in detection priority order
+TERMINAL_APP_NAMES = ['Terminal', 'iTerm2', 'Ghostty', 'Warp', 'Alacritty', 'WezTerm', 'kitty', 'Hyper']
+
 
 # ---------------------------------------------------------------------------
 # Logging
@@ -72,6 +75,82 @@ def _log(msg: str, level: str = 'INFO'):
 
 def _dbg(msg: str):
     _log(msg, 'DEBUG')
+
+
+# ---------------------------------------------------------------------------
+# AppleScript helpers
+# ---------------------------------------------------------------------------
+
+def _as_applescript_str(s: str) -> str:
+    """Convert a Python string to an AppleScript string expression, escaping non-ASCII chars."""
+    if not s:
+        return '""'
+    parts, buf = [], ''
+    for ch in s:
+        code = ord(ch)
+        if 32 <= code <= 126 and ch not in ('"', '\\'):
+            buf += ch
+        else:
+            if buf:
+                parts.append(f'"{buf}"')
+                buf = ''
+            parts.append(f'(ASCII character {code})')
+    if buf:
+        parts.append(f'"{buf}"')
+    return ' & '.join(parts) if parts else '""'
+
+
+# ---------------------------------------------------------------------------
+# Terminal app detection
+# ---------------------------------------------------------------------------
+
+async def _detect_terminal_for_tty(tty: str) -> str:
+    """Walk the process tree for the TTY to find which terminal app owns it.
+
+    Returns a name from TERMINAL_APP_NAMES (e.g. 'Terminal', 'iTerm2') or 'unknown'.
+    """
+    short = tty.replace('/dev/', '')
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            'ps', '-t', short, '-o', 'pid=',
+            stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.DEVNULL,
+        )
+        stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=3)
+        pids = [int(x) for x in stdout.decode().split() if x.strip().isdigit()]
+    except Exception as e:
+        _log(f'_detect_terminal_for_tty ps failed: {e}', 'WARN')
+        return 'unknown'
+
+    checked: set = set()
+    to_check = list(pids)
+    while to_check:
+        pid = to_check.pop(0)
+        if pid in checked or pid <= 1:
+            continue
+        checked.add(pid)
+        if len(checked) > 40:
+            break
+        try:
+            r = subprocess.run(
+                ['ps', '-p', str(pid), '-o', 'comm=,ppid='],
+                capture_output=True, text=True, timeout=1,
+            )
+            parts = r.stdout.strip().split()
+            if not parts:
+                continue
+            comm = parts[0].split('/')[-1]
+            for app in TERMINAL_APP_NAMES:
+                if comm.lower() == app.lower() or comm.lower().startswith(app.lower()):
+                    _dbg(f'  [detect_terminal] tty={tty} → {app} (pid={pid} comm={comm!r})')
+                    return app
+            ppid = int(parts[-1]) if len(parts) >= 2 and parts[-1].isdigit() else 0
+            if ppid > 1:
+                to_check.append(ppid)
+        except Exception:
+            pass
+
+    _dbg(f'  [detect_terminal] tty={tty} → unknown (checked {len(checked)} pids)')
+    return 'unknown'
 
 
 # ---------------------------------------------------------------------------
@@ -608,27 +687,7 @@ async def _terminal_inject_tty(tty: str, text: str) -> bool:
     full = _tty_to_full(tty)
     safe = full.replace('"', '\\"')
 
-    # Convert Python string to an AppleScript expression.
-    # Non-printable chars (like ESC = 0x1B) become (ASCII character N).
-    # do script appends Enter automatically, so ESC[B sequences navigate without extra Enter.
-    def _as_str(s: str) -> str:
-        if not s:
-            return '""'
-        parts, buf = [], ''
-        for ch in s:
-            code = ord(ch)
-            if 32 <= code <= 126 and ch not in ('"', '\\'):
-                buf += ch
-            else:
-                if buf:
-                    parts.append(f'"{buf}"')
-                    buf = ''
-                parts.append(f'(ASCII character {code})')
-        if buf:
-            parts.append(f'"{buf}"')
-        return ' & '.join(parts) if parts else '""'
-
-    as_text = _as_str(text)
+    as_text = _as_applescript_str(text)
 
     # Use Terminal.app's do script to send text + Enter to the running process's stdin.
     # No Accessibility permission needed — Terminal.app handles it internally.
@@ -734,6 +793,240 @@ return true'''
 
 
 # ---------------------------------------------------------------------------
+# I/O — iTerm2 via AppleScript
+# ---------------------------------------------------------------------------
+
+async def _iterm2_inject_tty(tty: str, text: str) -> bool:
+    """Inject text into an iTerm2 session by TTY — no window focus needed."""
+    safe = _tty_to_full(tty).replace('"', '\\"')
+    as_text = _as_applescript_str(text)
+    script = f'''tell application "iTerm2"
+    repeat with w in windows
+        repeat with tb in tabs of w
+            repeat with s in sessions of tb
+                try
+                    if tty of s is "{safe}" then
+                        write text {as_text} to s
+                        return true
+                    end if
+                end try
+            end repeat
+        end repeat
+    end repeat
+    return false
+end tell'''
+    result = await _run_script(script)
+    ok = result.strip() == 'true'
+    _dbg(f'  [iterm2_inject_tty] text={text!r} tty={tty} ok={ok}')
+    if not ok:
+        _log(f'iterm2_inject_tty: session not found for {tty}', 'WARN')
+    return ok
+
+
+async def _iterm2_send_text(tty: str, text: str) -> bool:
+    """Focus iTerm2 session by TTY and type text via System Events."""
+    safe_tty = _tty_to_full(tty).replace('"', '\\"')
+    safe_text = text.replace('\\', '\\\\').replace('"', '\\"')
+    script = f'''set targetTTY to "{safe_tty}"
+set foundSession to false
+if application "iTerm2" is running then
+    tell application "iTerm2"
+        repeat with w in windows
+            repeat with tb in tabs of w
+                repeat with s in sessions of tb
+                    try
+                        if tty of s is targetTTY then
+                            select tb
+                            set index of w to 1
+                            activate
+                            set foundSession to true
+                            exit repeat
+                        end if
+                    end try
+                end repeat
+                if foundSession then exit repeat
+            end repeat
+            if foundSession then exit repeat
+        end repeat
+    end tell
+end if
+if not foundSession then return false
+delay 0.3
+tell application "System Events"
+    keystroke "u" using {{control down}}
+    delay 0.1
+    keystroke "{safe_text}"
+    delay 0.05
+    key code 36
+end tell
+return true'''
+    result = await _run_script(script)
+    ok = result.strip() == 'true'
+    _dbg(f'  [iterm2_send_text] text={text!r} tty={tty} ok={ok}')
+    return ok
+
+
+async def _iterm2_send_key(tty: str, key: str) -> bool:
+    """Focus iTerm2 session by TTY and send a named key via System Events."""
+    key_code, _ = KEY_MAP.get(key, (None, None))
+    safe_tty = _tty_to_full(tty).replace('"', '\\"')
+    if key == 'ctrl_c':
+        action = 'keystroke "c" using {control down}'
+    elif key == 'ctrl_u':
+        action = 'keystroke "u" using {control down}'
+    elif key_code is not None:
+        action = f'key code {key_code}'
+    else:
+        _log(f'Unknown key for iTerm2: {key!r}', 'WARN')
+        return False
+    script = f'''set targetTTY to "{safe_tty}"
+set foundSession to false
+if application "iTerm2" is running then
+    tell application "iTerm2"
+        repeat with w in windows
+            repeat with tb in tabs of w
+                repeat with s in sessions of tb
+                    try
+                        if tty of s is targetTTY then
+                            select tb
+                            set index of w to 1
+                            activate
+                            set foundSession to true
+                            exit repeat
+                        end if
+                    end try
+                end repeat
+                if foundSession then exit repeat
+            end repeat
+            if foundSession then exit repeat
+        end repeat
+    end tell
+end if
+if not foundSession then return false
+delay 0.3
+tell application "System Events"
+    {action}
+end tell
+return true'''
+    result = await _run_script(script)
+    ok = result.strip() == 'true'
+    _dbg(f'  [iterm2_send_key] key={key!r} tty={tty} ok={ok}')
+    return ok
+
+
+async def _iterm2_focus(tty: str) -> bool:
+    """Bring the iTerm2 window/tab hosting this TTY to the front."""
+    safe = _tty_to_full(tty).replace('"', '\\"')
+    script = f'''set targetTTY to "{safe}"
+set found to false
+if application "iTerm2" is running then
+    tell application "iTerm2"
+        repeat with w in windows
+            repeat with tb in tabs of w
+                repeat with s in sessions of tb
+                    try
+                        if tty of s is targetTTY then
+                            select tb
+                            set index of w to 1
+                            activate
+                            set found to true
+                            exit repeat
+                        end if
+                    end try
+                end repeat
+                if found then exit repeat
+            end repeat
+            if found then exit repeat
+        end repeat
+    end tell
+end if
+return found'''
+    result = await _run_script(script)
+    ok = result.strip() == 'true'
+    _dbg(f'  [iterm2_focus] tty={tty} ok={ok}')
+    return ok
+
+
+# ---------------------------------------------------------------------------
+# I/O — Generic (Ghostty, Warp, Alacritty, etc.)
+# ---------------------------------------------------------------------------
+
+async def _generic_send_text(app_name: str, text: str) -> bool:
+    """Activate the named terminal app and send text using clipboard + keyboard.
+
+    Used for terminals without TTY-based window lookup. Activates the app (bringing
+    its last-focused window to front) then pastes via Ctrl+U, Cmd+V, Enter.
+    """
+    safe_app = app_name.replace('"', '\\"')
+    try:
+        subprocess.run(['pbcopy'], input=text.encode('utf-8'), timeout=2, check=True)
+    except Exception as e:
+        _log(f'_generic_send_text pbcopy failed: {e}', 'WARN')
+        return False
+    script = f'''if application "{safe_app}" is running then
+    tell application "{safe_app}" to activate
+else
+    return false
+end if
+delay 0.4
+tell application "System Events"
+    keystroke "u" using {{control down}}
+    delay 0.1
+    keystroke "v" using command down
+    delay 0.1
+    key code 36
+end tell
+return true'''
+    result = await _run_script(script)
+    ok = result.strip() == 'true'
+    _dbg(f'  [generic_send_text] app={app_name!r} ok={ok}')
+    return ok
+
+
+async def _generic_send_key(app_name: str, key: str) -> bool:
+    """Activate the named app and send a key via System Events."""
+    key_code, _ = KEY_MAP.get(key, (None, None))
+    safe_app = app_name.replace('"', '\\"')
+    if key == 'ctrl_c':
+        action = 'keystroke "c" using {control down}'
+    elif key == 'ctrl_u':
+        action = 'keystroke "u" using {control down}'
+    elif key_code is not None:
+        action = f'key code {key_code}'
+    else:
+        _log(f'Unknown key for generic: {key!r}', 'WARN')
+        return False
+    script = f'''if application "{safe_app}" is running then
+    tell application "{safe_app}" to activate
+else
+    return false
+end if
+delay 0.4
+tell application "System Events"
+    {action}
+end tell
+return true'''
+    result = await _run_script(script)
+    ok = result.strip() == 'true'
+    _dbg(f'  [generic_send_key] app={app_name!r} key={key!r} ok={ok}')
+    return ok
+
+
+async def _generic_focus(app_name: str) -> bool:
+    """Activate the named app, bringing its last-focused window to front."""
+    safe = app_name.replace('"', '\\"')
+    script = f'''if application "{safe}" is running then
+    tell application "{safe}" to activate
+    return true
+end if
+return false'''
+    result = await _run_script(script)
+    ok = result.strip() == 'true'
+    _dbg(f'  [generic_focus] app={app_name!r} ok={ok}')
+    return ok
+
+
+# ---------------------------------------------------------------------------
 # I/O — tmux
 # ---------------------------------------------------------------------------
 
@@ -827,13 +1120,15 @@ async def _tmux_send_text(target: str, text: str) -> bool:
 
 class Session:
     def __init__(self, session_id: str, app_id: str, tty: str = '',
-                 tmux_target: str = '', hook: dict = None, read_mode: str = 'history'):
+                 tmux_target: str = '', hook: dict = None, read_mode: str = 'history',
+                 terminal_app: str = ''):
         self.session_id = session_id
         self.app_id = app_id
         self.tty = tty
         self.tmux_target = tmux_target
         self.hook = hook or {}
         self.read_mode = read_mode  # 'history' or 'contents'
+        self.terminal_app = terminal_app  # 'Terminal', 'iTerm2', 'Ghostty', etc.
         self.session_type = 'tmux' if tmux_target else 'terminal_app'
 
     def to_dict(self) -> dict:
@@ -843,6 +1138,7 @@ class Session:
             'type':         self.session_type,
             'tty':          self.tty,
             'tmux_target':  self.tmux_target,
+            'terminal_app': self.terminal_app,
             'has_hook':     bool(self.hook),
         }
 
@@ -942,6 +1238,9 @@ class TerminalManager:
             raise ValueError('tty or tmux_target required')
 
         read_mode = args.get('read_mode', 'history')
+        terminal_app = ''
+        if tty and not tmux:
+            terminal_app = await _detect_terminal_for_tty(tty)
         session = Session(
             session_id=sid,
             app_id=args.get('app_id', 'unknown'),
@@ -949,11 +1248,12 @@ class TerminalManager:
             tmux_target=tmux,
             hook=args.get('hook'),
             read_mode=read_mode,
+            terminal_app=terminal_app,
         )
         self._sessions[sid] = session
         _log(f'Registered session {sid[:12]} type={session.session_type} '
-             f'tty={tty!r} tmux={tmux!r} read_mode={read_mode!r} '
-             f'hook_patterns={len(session.hook.get("patterns", []))}')
+             f'tty={tty!r} tmux={tmux!r} terminal_app={terminal_app!r} '
+             f'read_mode={read_mode!r} hook_patterns={len(session.hook.get("patterns", []))}')
         return {'ok': True, 'session_id': sid, 'type': session.session_type}
 
     async def _tool_unregister_session(self, args: dict) -> dict:
@@ -1091,19 +1391,26 @@ class TerminalManager:
         return {'ok': ok}
 
     async def _tool_inject_tty(self, args: dict) -> dict:
-        """Inject text into the TTY input queue via TIOCSTI — no clipboard, no focus needed."""
+        """Inject text into the TTY input queue — no clipboard, no window focus needed."""
         sid = args.get('session_id', '')
         text = args.get('text', '')
         session = self._sessions.get(sid)
         if not session:
             raise ValueError(f'Unknown session: {sid}')
         if session.session_type == 'tmux':
-            # tmux sessions don't use a TTY device — fall back to send_text
             _log(f'inject_tty {sid[:12]} — tmux session, delegating to send_text')
             ok = await _tmux_send_text(session.tmux_target, text)
         else:
-            _log(f'inject_tty {sid[:12]} tty={session.tty!r}')
-            ok = await _terminal_inject_tty(session.tty, text)
+            app = session.terminal_app or 'Terminal'
+            _log(f'inject_tty {sid[:12]} tty={session.tty!r} terminal={app!r}')
+            if app == 'iTerm2':
+                ok = await _iterm2_inject_tty(session.tty, text)
+            elif app in ('Terminal', 'unknown', ''):
+                ok = await _terminal_inject_tty(session.tty, text)
+            else:
+                # Ghostty, Warp, etc.: no direct inject — signal caller to use send_text
+                _log(f'inject_tty: {app!r} has no native inject, returning false', 'WARN')
+                ok = False
         return {'ok': ok}
 
     async def _tool_focus_window(self, args: dict) -> dict:
@@ -1127,8 +1434,14 @@ class TerminalManager:
                 _log(f'focus_window tmux error: {e}', 'WARN')
                 return {'ok': False}
         else:
-            _log(f'focus_window {sid[:12]} tty={session.tty!r}')
-            ok = await _terminal_focus(session.tty)
+            app = session.terminal_app or 'Terminal'
+            _log(f'focus_window {sid[:12]} tty={session.tty!r} terminal={app!r}')
+            if app == 'iTerm2':
+                ok = await _iterm2_focus(session.tty)
+            elif app in ('Terminal', 'unknown', ''):
+                ok = await _terminal_focus(session.tty)
+            else:
+                ok = await _generic_focus(app)
             return {'ok': ok}
 
     async def _tool_wait_for_idle(self, args: dict) -> dict:
@@ -1220,14 +1533,24 @@ class TerminalManager:
     async def _send_key(self, session: Session, key: str) -> bool:
         if session.session_type == 'tmux':
             return await _tmux_send_key(session.tmux_target, key)
-        else:
+        app = session.terminal_app or 'Terminal'
+        if app == 'iTerm2':
+            return await _iterm2_send_key(session.tty, key)
+        elif app in ('Terminal', 'unknown', ''):
             return await _terminal_send_key(session.tty, key)
+        else:
+            return await _generic_send_key(app, key)
 
     async def _send_text(self, session: Session, text: str) -> bool:
         if session.session_type == 'tmux':
             return await _tmux_send_text(session.tmux_target, text)
-        else:
+        app = session.terminal_app or 'Terminal'
+        if app == 'iTerm2':
+            return await _iterm2_send_text(session.tty, text)
+        elif app in ('Terminal', 'unknown', ''):
             return await _terminal_send_text(session.tty, text)
+        else:
+            return await _generic_send_text(app, text)
 
     async def _send_raw(self, session: Session, text: str) -> bool:
         if session.session_type == 'tmux':

--- a/ask/scripts/terminal-manager/manifest.json
+++ b/ask/scripts/terminal-manager/manifest.json
@@ -2,7 +2,7 @@
   "id": "terminal-manager",
   "name": "Terminal Manager",
   "type": "system",
-  "version": "1.5.3",
+  "version": "1.6.0",
   "description": "Local terminal session registry and TUI detector. Tools are available to all scripts via AskMac MCP — not exposed to iPhone.",
   "entry": "main.py",
   "tools": [

--- a/ask/scripts/terminal-manager/test_terminal_manager.py
+++ b/ask/scripts/terminal-manager/test_terminal_manager.py
@@ -436,3 +436,204 @@ class TestToolListSessions:
         result = await manager._tool_list_sessions({})
         ids = {s['session_id'] for s in result['sessions']}
         assert ids == {'s1', 's2'}
+
+
+# ---------------------------------------------------------------------------
+# _as_applescript_str
+# ---------------------------------------------------------------------------
+
+class TestAsApplescriptStr:
+    def test_plain_ascii(self):
+        result = tm._as_applescript_str('hello')
+        assert result == '"hello"'
+
+    def test_empty_string(self):
+        assert tm._as_applescript_str('') == '""'
+
+    def test_double_quote_escaped(self):
+        result = tm._as_applescript_str('say "hi"')
+        assert '(ASCII character 34)' in result
+        assert '"say ' in result
+
+    def test_non_printable_esc(self):
+        result = tm._as_applescript_str('\x1b[B')
+        assert '(ASCII character 27)' in result
+
+    def test_escape_arrow_sequence(self):
+        # ESC[B ESC[B — two down arrows
+        result = tm._as_applescript_str('\x1b[B\x1b[B')
+        assert result.count('(ASCII character 27)') == 2
+
+    def test_backslash_escaped(self):
+        result = tm._as_applescript_str('a\\b')
+        assert '(ASCII character 92)' in result
+
+
+# ---------------------------------------------------------------------------
+# Multi-terminal dispatch: inject_tty
+# ---------------------------------------------------------------------------
+
+class TestMultiTerminalInjectTty:
+    async def _register(self, manager, sid, tty, terminal_app):
+        """Register a session with a pre-set terminal_app, bypassing detection."""
+        with patch('terminal_manager_main._detect_terminal_for_tty',
+                   new_callable=AsyncMock, return_value=terminal_app):
+            await manager._tool_register_session(
+                {'session_id': sid, 'app_id': 'test', 'tty': tty}
+            )
+
+    @pytest.mark.asyncio
+    async def test_iterm2_routes_to_iterm2_inject(self):
+        manager = tm.TerminalManager()
+        await self._register(manager, 's1', 'ttys009', 'iTerm2')
+        with patch('terminal_manager_main._iterm2_inject_tty',
+                   new_callable=AsyncMock, return_value=True) as mock:
+            result = await manager._tool_inject_tty({'session_id': 's1', 'text': 'hi'})
+        assert result['ok'] is True
+        mock.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_terminal_app_routes_to_terminal_inject(self):
+        manager = tm.TerminalManager()
+        await self._register(manager, 's1', 'ttys009', 'Terminal')
+        with patch('terminal_manager_main._terminal_inject_tty',
+                   new_callable=AsyncMock, return_value=True) as mock:
+            result = await manager._tool_inject_tty({'session_id': 's1', 'text': 'hi'})
+        assert result['ok'] is True
+        mock.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_ghostty_returns_false_no_native_inject(self):
+        manager = tm.TerminalManager()
+        await self._register(manager, 's1', 'ttys009', 'Ghostty')
+        result = await manager._tool_inject_tty({'session_id': 's1', 'text': 'hi'})
+        assert result['ok'] is False
+
+    @pytest.mark.asyncio
+    async def test_warp_returns_false_no_native_inject(self):
+        manager = tm.TerminalManager()
+        await self._register(manager, 's1', 'ttys009', 'Warp')
+        result = await manager._tool_inject_tty({'session_id': 's1', 'text': 'hi'})
+        assert result['ok'] is False
+
+
+# ---------------------------------------------------------------------------
+# Multi-terminal dispatch: send_text
+# ---------------------------------------------------------------------------
+
+class TestMultiTerminalSendText:
+    async def _register(self, manager, sid, tty, terminal_app):
+        with patch('terminal_manager_main._detect_terminal_for_tty',
+                   new_callable=AsyncMock, return_value=terminal_app):
+            await manager._tool_register_session(
+                {'session_id': sid, 'app_id': 'test', 'tty': tty}
+            )
+
+    @pytest.mark.asyncio
+    async def test_iterm2_routes_to_iterm2_send_text(self):
+        manager = tm.TerminalManager()
+        await self._register(manager, 's1', 'ttys009', 'iTerm2')
+        with patch('terminal_manager_main._iterm2_send_text',
+                   new_callable=AsyncMock, return_value=True) as mock:
+            result = await manager._tool_send_text({'session_id': 's1', 'text': 'hello'})
+        assert result['ok'] is True
+        mock.assert_called_once_with('ttys009', 'hello')
+
+    @pytest.mark.asyncio
+    async def test_terminal_routes_to_terminal_send_text(self):
+        manager = tm.TerminalManager()
+        await self._register(manager, 's1', 'ttys009', 'Terminal')
+        with patch('terminal_manager_main._terminal_send_text',
+                   new_callable=AsyncMock, return_value=True) as mock:
+            result = await manager._tool_send_text({'session_id': 's1', 'text': 'hello'})
+        assert result['ok'] is True
+        mock.assert_called_once_with('ttys009', 'hello')
+
+    @pytest.mark.asyncio
+    async def test_ghostty_routes_to_generic_send_text(self):
+        manager = tm.TerminalManager()
+        await self._register(manager, 's1', 'ttys009', 'Ghostty')
+        with patch('terminal_manager_main._generic_send_text',
+                   new_callable=AsyncMock, return_value=True) as mock:
+            result = await manager._tool_send_text({'session_id': 's1', 'text': 'hello'})
+        assert result['ok'] is True
+        mock.assert_called_once_with('Ghostty', 'hello')
+
+    @pytest.mark.asyncio
+    async def test_warp_routes_to_generic_send_text(self):
+        manager = tm.TerminalManager()
+        await self._register(manager, 's1', 'ttys009', 'Warp')
+        with patch('terminal_manager_main._generic_send_text',
+                   new_callable=AsyncMock, return_value=True) as mock:
+            result = await manager._tool_send_text({'session_id': 's1', 'text': 'hello'})
+        assert result['ok'] is True
+        mock.assert_called_once_with('Warp', 'hello')
+
+
+# ---------------------------------------------------------------------------
+# Multi-terminal dispatch: focus_window
+# ---------------------------------------------------------------------------
+
+class TestMultiTerminalFocusWindow:
+    async def _register(self, manager, sid, tty, terminal_app):
+        with patch('terminal_manager_main._detect_terminal_for_tty',
+                   new_callable=AsyncMock, return_value=terminal_app):
+            await manager._tool_register_session(
+                {'session_id': sid, 'app_id': 'test', 'tty': tty}
+            )
+
+    @pytest.mark.asyncio
+    async def test_iterm2_routes_to_iterm2_focus(self):
+        manager = tm.TerminalManager()
+        await self._register(manager, 's1', 'ttys009', 'iTerm2')
+        with patch('terminal_manager_main._iterm2_focus',
+                   new_callable=AsyncMock, return_value=True) as mock:
+            result = await manager._tool_focus_window({'session_id': 's1'})
+        assert result['ok'] is True
+        mock.assert_called_once_with('ttys009')
+
+    @pytest.mark.asyncio
+    async def test_ghostty_routes_to_generic_focus(self):
+        manager = tm.TerminalManager()
+        await self._register(manager, 's1', 'ttys009', 'Ghostty')
+        with patch('terminal_manager_main._generic_focus',
+                   new_callable=AsyncMock, return_value=True) as mock:
+            result = await manager._tool_focus_window({'session_id': 's1'})
+        assert result['ok'] is True
+        mock.assert_called_once_with('Ghostty')
+
+
+# ---------------------------------------------------------------------------
+# terminal_app stored on session and included in to_dict
+# ---------------------------------------------------------------------------
+
+class TestSessionTerminalApp:
+    @pytest.mark.asyncio
+    async def test_terminal_app_stored_on_session(self):
+        manager = tm.TerminalManager()
+        with patch('terminal_manager_main._detect_terminal_for_tty',
+                   new_callable=AsyncMock, return_value='iTerm2'):
+            await manager._tool_register_session(
+                {'session_id': 's1', 'app_id': 'test', 'tty': 'ttys009'}
+            )
+        assert manager._sessions['s1'].terminal_app == 'iTerm2'
+
+    @pytest.mark.asyncio
+    async def test_terminal_app_in_to_dict(self):
+        manager = tm.TerminalManager()
+        with patch('terminal_manager_main._detect_terminal_for_tty',
+                   new_callable=AsyncMock, return_value='Ghostty'):
+            await manager._tool_register_session(
+                {'session_id': 's1', 'app_id': 'test', 'tty': 'ttys009'}
+            )
+        result = await manager._tool_list_sessions({})
+        session = result['sessions'][0]
+        assert session['terminal_app'] == 'Ghostty'
+
+    @pytest.mark.asyncio
+    async def test_tmux_session_has_no_terminal_app(self):
+        manager = tm.TerminalManager()
+        await manager._tool_register_session(
+            {'session_id': 's1', 'app_id': 'test', 'tmux_target': 'main:0.0'}
+        )
+        assert manager._sessions['s1'].terminal_app == ''


### PR DESCRIPTION
## Summary

- **Root cause**: `terminal-manager` and the `claudecode-controller` pbcopy fallback were both hardcoded to `Terminal.app` via AppleScript. Any other terminal (iTerm2, Ghostty, Warp, Cursor, VS Code, etc.) caused silent failure — messages sent from iOS would be received but never delivered to the Claude Code session.
- **Fix**: Added multi-terminal detection and dispatch at every layer of the routing stack.

## What changed

**terminal-manager v1.6.0**
- `_detect_terminal_for_tty(tty)` — walks the process tree via `ps` to identify which terminal app owns a TTY
- `_iterm2_inject_tty/send_text/send_key/focus` — full iTerm2 AppleScript support using session `.tty` property
- `_generic_send_text/send_key/focus` — clipboard+keyboard approach for Ghostty, Warp, Alacritty, WezTerm, kitty
- `Session.terminal_app` — detected once on registration and cached, avoiding repeated `ps` calls
- All I/O dispatch (`inject_tty`, `send_text`, `send_key`, `focus_window`) now routes by detected terminal

**claudecode-controller v2.27.0**
- pbcopy+osascript last-resort fallback now tries Terminal.app → iTerm2 (by TTY) → any known running terminal before giving up

## Test plan
- [ ] Send a message from iOS to a Claude Code session running in Terminal.app — should still work
- [ ] Send a message from iOS to a Claude Code session running in iTerm2 — should now work
- [ ] Send a message from iOS to a session in Ghostty/Warp — should activate the app and paste
- [ ] Check `~/.ask/logs/terminal-manager.log` to confirm `terminal_app=` shows the correct detected app

🤖 Generated with [Claude Code](https://claude.com/claude-code)