### PR TITLE
chore: bump version to 0.9.2

### DIFF
--- a/AskMac/project.yml
+++ b/AskMac/project.yml
@@ -68,7 +68,7 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.kevinhill.askmac
-        MARKETING_VERSION: "0.9.1"
+        MARKETING_VERSION: "0.9.2"
         CURRENT_PROJECT_VERSION: "1"
         CODE_SIGN_STYLE: Manual
         CODE_SIGN_IDENTITY: "Developer ID Application: Kevin Hill (B5J28L8ARB)"

--- a/docs/appcast.xml
+++ b/docs/appcast.xml
@@ -8,15 +8,15 @@
     <!-- Release entries are prepended here by the release pipeline -->
     <item>
       <title>Version 0.9.1</title>
-      <sparkle:version>1776816086</sparkle:version>
+      <sparkle:version>1776873308</sparkle:version>
       <sparkle:shortVersionString>0.9.1</sparkle:shortVersionString>
       <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
-      <pubDate>Wed, 22 Apr 2026 00:04:06 +0000</pubDate>
+      <pubDate>Wed, 22 Apr 2026 15:57:52 +0000</pubDate>
       <enclosure
         url="https://github.com/Gr8Gatsby/ask/releases/download/v0.9.1/AskMac-0.9.1.dmg"
-        length="3763884"
+        length="3799471"
         type="application/octet-stream"
-        sparkle:edSignature="KrzBu78t2mc2oWyI2tvLa0Ft0kJTBa49C44r4S7+6HkFTZY3LCXeVRANOyCs5yyrvTp64CFbQAwTWIoSP7xnBg=="
+        sparkle:edSignature="BFMeuTrDGaWWHqYwDyu8r1LUy/99J/RPVfa5ATXS6e7RtvtN7Zoq/sAybE3PTSs+5FOxe0gs1fHQS3lr4+GsAA=="
       />
     </item>
     <item>


### PR DESCRIPTION
Bump MARKETING_VERSION in project.yml to 0.9.2 for the patch release.