### PR TITLE
chore(release): update appcast for v0.9.2

### DIFF
--- a/docs/appcast.xml
+++ b/docs/appcast.xml
@@ -7,6 +7,19 @@
     <language>en</language>
     <!-- Release entries are prepended here by the release pipeline -->
     <item>
+      <title>Version 0.9.2</title>
+      <sparkle:version>1776873640</sparkle:version>
+      <sparkle:shortVersionString>0.9.2</sparkle:shortVersionString>
+      <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
+      <pubDate>Wed, 22 Apr 2026 16:03:21 +0000</pubDate>
+      <enclosure
+        url="https://github.com/Gr8Gatsby/ask/releases/download/v0.9.2/AskMac-0.9.2.dmg"
+        length="3799503"
+        type="application/octet-stream"
+        sparkle:edSignature="RHZKOYMU03RbDDVWnDDyUSm/hJDKuHYPTgXSZXOfJiHvnW4SUQmeQ1ALE+pEzx3K1I6MbAyNmApIqCNq7aHMCA=="
+      />
+    </item>
+    <item>
       <title>Version 0.9.1</title>
       <sparkle:version>1776873308</sparkle:version>
       <sparkle:shortVersionString>0.9.1</sparkle:shortVersionString>


### PR DESCRIPTION
Appcast.xml update for v0.9.2 Sparkle auto-update entry.