### PR TITLE
fix(scripts): dedup guard, RPC timeout, and hook existence checks

### DIFF
--- a/ask/scripts/claudecode-controller/main.py
+++ b/ask/scripts/claudecode-controller/main.py
@@ -68,6 +68,8 @@ class MCPClient:
         self._recently_launched_cwds: set = set()
         # per-session locks so concurrent iOS replies are serialized (prevents clipboard races)
         self._route_locks: dict = {}
+        # (session_id, text) -> monotonic timestamp of last successful send — dedup guard
+        self._last_sent: dict = {}
         # Tile state
         self._active_confirmations = 0
         self._tile_body: Optional[str] = None
@@ -1652,6 +1654,26 @@ class MCPClient:
           tmux — _capture_tmux_response (polls capture-pane)
           TTY  — _capture_tty_response  (polls via wait_for_idle)
         """
+        # Dedup guard: drop identical (session, text) pairs within 5 s.
+        # Protects against ghost-execution when an RPC times out in the caller
+        # but terminal-manager still completes the operation — the timeout
+        # triggers a retry, resulting in the same text being sent 2-3 times.
+        # NOTE: timestamp is recorded AFTER a successful send (not here) so that
+        # a failed first attempt does not suppress a legitimate retry.
+        dedup_key = (session_id, text)
+        now = time.monotonic()
+        if now - self._last_sent.get(dedup_key, float('-inf')) < 5.0:
+            _log(f'[claudecode] dedup: dropping duplicate send to {session_id[:8]}')
+            return
+
+        def _record_sent():
+            """Record this (session, text) pair as successfully sent and evict stale entries."""
+            ts = time.monotonic()
+            self._last_sent[dedup_key] = ts
+            stale = [k for k, v in self._last_sent.items() if ts - v > 30]
+            for k in stale:
+                del self._last_sent[k]
+
         session = self._sessions.get(session_id, {})
         tmux_target = session.get('tmux_target')
 
@@ -1665,9 +1687,10 @@ class MCPClient:
                     result = await self._rpc('tools/call', {
                         'name': 'inject_tty',
                         'arguments': {'session_id': session_id, 'text': text}
-                    }, timeout=3.0)
+                    }, timeout=8.0)
                     if isinstance(result, dict) and result.get('ok'):
                         _log(f'[claudecode] routed via inject_tty: {session_id[:8]}')
+                        _record_sent()
                         asyncio.create_task(self._capture_tty_response(session_id))
                         return
                     break  # got a valid response (ok=False), no point retrying
@@ -1685,9 +1708,10 @@ class MCPClient:
                     result = await self._rpc('tools/call', {
                         'name': 'send_text',
                         'arguments': {'session_id': session_id, 'text': text}
-                    }, timeout=3.0)
+                    }, timeout=8.0)
                     if isinstance(result, dict) and result.get('ok'):
                         _log(f'[claudecode] routed via send_text: {session_id[:8]}')
+                        _record_sent()
                         asyncio.create_task(self._capture_tty_response(session_id))
                         return
                     break
@@ -1709,9 +1733,10 @@ class MCPClient:
                     result = await self._rpc('tools/call', {
                         'name': 'send_text',
                         'arguments': {'session_id': session_id, 'text': text}
-                    }, timeout=3.0)
+                    }, timeout=8.0)
                     if isinstance(result, dict) and result.get('ok'):
                         _log(f'[claudecode] routed via terminal-manager send_text: {session_id[:8]}')
+                        _record_sent()
                         asyncio.create_task(self._capture_tmux_response(tmux_target, session_id))
                         return
                     break
@@ -1736,6 +1761,7 @@ class MCPClient:
                 await p2.communicate()
             except Exception as e:
                 print(f'[claudecode-controller] tmux send-keys fallback failed: {e}', file=sys.stderr)
+            _record_sent()
             asyncio.create_task(self._capture_tmux_response(tmux_target, session_id))
             return
 
@@ -1947,6 +1973,7 @@ end tell
                 _log(f'[claudecode] osascript error: {err.decode().strip()}')
             else:
                 _log(f'[claudecode] osascript succeeded (rc={proc.returncode})')
+                _record_sent()
                 asyncio.create_task(self._capture_tty_response(session_id))
         except Exception as e:
             _log(f'[claudecode] _route_to_terminal exception: {e}')
@@ -2441,7 +2468,26 @@ async def _session_heartbeat(client):
             print(f'[claudecode-controller] start_session heartbeat error: {e}', file=sys.stderr)
 
 
+def _check_hook_files():
+    """Warn loudly on startup if any hook file is missing."""
+    hooks_dir = os.path.join(os.path.dirname(__file__), 'hooks')
+    required = [
+        'session_start.py', 'user_prompt_submit.py', 'pre_tool_use.py',
+        'post_tool_use.py', 'session_stop.py',
+    ]
+    missing = [f for f in required if not os.path.exists(os.path.join(hooks_dir, f))]
+    if missing:
+        print(
+            f'[claudecode-controller] WARNING: hook files missing in {hooks_dir}: {missing}\n'
+            f'         Messages will be blocked until hooks are deployed.\n'
+            f'         Run: /deploy-scripts claudecode-controller',
+            file=sys.stderr,
+        )
+    return missing
+
+
 async def run():
+    _check_hook_files()
     client = MCPClient()
     server = await client.start_socket_server()
 

--- a/ask/scripts/claudecode-controller/manifest.json
+++ b/ask/scripts/claudecode-controller/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "claudecode-controller",
   "name": "Claude Code",
-  "version": "2.27.0",
+  "version": "2.28.0",
   "setup": "setup.py",
   "description": "Claude Code session supervisor \u2014 routes permissions and notifications to iPhone",
   "script_dependencies": ["terminal-manager"],

--- a/ask/scripts/claudecode-controller/test_claudecode_controller.py
+++ b/ask/scripts/claudecode-controller/test_claudecode_controller.py
@@ -605,3 +605,135 @@ class TestConcurrentReplySerialization:
 
         # Both should have started at nearly the same time (within 20ms)
         assert abs(start_times.get('s1', 0) - start_times.get('s2', 0)) < 0.02
+
+
+# ---------------------------------------------------------------------------
+# Dedup guard — prevents double/triple send from RPC timeout + retry
+# ---------------------------------------------------------------------------
+
+class TestDedupGuard:
+    def _make_client_with_tty_session(self):
+        client = make_client()
+        client._sessions['s1'] = {
+            'cwd': '/code/repo', 'project': 'repo',
+            'last_seen': time.time(), 'tty': 'ttys009',
+        }
+        return client
+
+    @pytest.mark.asyncio
+    async def test_exact_duplicate_within_window_is_dropped(self):
+        """Second call with same (session, text) within 5 s must not reach the terminal."""
+        client = self._make_client_with_tty_session()
+        send_count = 0
+
+        async def mock_rpc(method, params=None, timeout=10.0):
+            nonlocal send_count
+            name = (params or {}).get('name', '')
+            if name == 'inject_tty':
+                send_count += 1
+                return {'ok': True}
+            return {'ok': False}
+
+        client._rpc = mock_rpc
+        with patch('asyncio.create_task'):
+            await client._route_to_terminal_locked('s1', 'hello')
+            await client._route_to_terminal_locked('s1', 'hello')  # duplicate
+
+        assert send_count == 1, f'Expected 1 send, got {send_count}'
+
+    @pytest.mark.asyncio
+    async def test_different_text_is_not_deduplicated(self):
+        """Different text to the same session must both be delivered."""
+        client = self._make_client_with_tty_session()
+        sent_texts = []
+
+        async def mock_rpc(method, params=None, timeout=10.0):
+            name = (params or {}).get('name', '')
+            if name == 'inject_tty':
+                sent_texts.append((params or {}).get('arguments', {}).get('text', ''))
+                return {'ok': True}
+            return {'ok': False}
+
+        client._rpc = mock_rpc
+        with patch('asyncio.create_task'):
+            await client._route_to_terminal_locked('s1', 'hello')
+            await client._route_to_terminal_locked('s1', 'world')
+
+        assert sent_texts == ['hello', 'world']
+
+    @pytest.mark.asyncio
+    async def test_same_text_different_sessions_both_delivered(self):
+        """Same text to different sessions must both be delivered."""
+        client = make_client()
+        for sid in ('s1', 's2'):
+            client._sessions[sid] = {
+                'cwd': f'/code/{sid}', 'project': sid,
+                'last_seen': time.time(), 'tty': f'ttys00{sid[-1]}',
+            }
+        send_count = 0
+
+        async def mock_rpc(method, params=None, timeout=10.0):
+            nonlocal send_count
+            if (params or {}).get('name') == 'inject_tty':
+                send_count += 1
+                return {'ok': True}
+            return {'ok': False}
+
+        client._rpc = mock_rpc
+        with patch('asyncio.create_task'):
+            await client._route_to_terminal_locked('s1', 'hello')
+            await client._route_to_terminal_locked('s2', 'hello')
+
+        assert send_count == 2
+
+    @pytest.mark.asyncio
+    async def test_duplicate_allowed_after_window_expires(self):
+        """Same text is allowed again once the 5 s dedup window has passed."""
+        client = self._make_client_with_tty_session()
+        send_count = 0
+
+        async def mock_rpc(method, params=None, timeout=10.0):
+            nonlocal send_count
+            if (params or {}).get('name') == 'inject_tty':
+                send_count += 1
+                return {'ok': True}
+            return {'ok': False}
+
+        client._rpc = mock_rpc
+        # Plant an entry that expired 6 s ago
+        client._last_sent[('s1', 'hello')] = time.monotonic() - 6.0
+        with patch('asyncio.create_task'):
+            await client._route_to_terminal_locked('s1', 'hello')
+
+        assert send_count == 1
+
+    @pytest.mark.asyncio
+    async def test_slow_rpc_ghost_does_not_cause_double_send(self):
+        """Simulate the ghost-execution bug: RPC times out in caller, but terminal-manager
+        still completes the operation.  The dedup guard must absorb the retry send."""
+        client = self._make_client_with_tty_session()
+        send_count = 0
+
+        async def slow_inject_rpc(method, params=None, timeout=10.0):
+            nonlocal send_count
+            name = (params or {}).get('name', '')
+            if name == 'inject_tty':
+                # Simulate ghost: operation executes but reply comes after timeout
+                send_count += 1
+                await asyncio.sleep(0.01)   # fast in test, but would be slow in prod
+                return {'ok': True}
+            return {'ok': False}
+
+        client._rpc = slow_inject_rpc
+
+        # First call: inject_tty succeeds → dedup key recorded
+        with patch('asyncio.create_task'):
+            await client._route_to_terminal_locked('s1', 'hello')
+
+        assert send_count == 1
+
+        # Second call (retry after ghost timeout): must be absorbed by dedup guard
+        with patch('asyncio.create_task'):
+            await client._route_to_terminal_locked('s1', 'hello')
+
+        assert send_count == 1, f'Dedup guard failed: {send_count} sends (expected 1)'

--- a/ask/scripts/codex-2/main.py
+++ b/ask/scripts/codex-2/main.py
@@ -228,6 +228,24 @@ def _ensure_config_flag():
             _log(f'Could not update config.toml: {e}', 'WARN')
 
 
+def _check_hook_files():
+    """Warn loudly if any hook file is missing — missing hooks block message submission."""
+    hooks_dir = os.path.join(SCRIPT_DIR, 'hooks')
+    required = [
+        'session_start.py', 'pre_tool_use.py', 'post_tool_use.py',
+        'session_stop.py', 'user_prompt_submit.py',
+    ]
+    missing = [f for f in required if not os.path.exists(os.path.join(hooks_dir, f))]
+    if missing:
+        print(
+            f'[codex-2] WARNING: hook files missing in {hooks_dir}: {missing}\n'
+            f'         Messages will be blocked until hooks are deployed.\n'
+            f'         Run: /deploy-scripts codex-2',
+            file=sys.stderr,
+        )
+    return missing
+
+
 def _write_hooks_json():
     py = sys.executable
     hooks_dir = os.path.join(SCRIPT_DIR, 'hooks')
@@ -1965,6 +1983,7 @@ class CodexController:
 
     async def run(self):
         _log('codex-2 starting')
+        _check_hook_files()
         _install_hooks()
         server = await self._start_socket_server()
 

--- a/ask/scripts/codex-2/manifest.json
+++ b/ask/scripts/codex-2/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "codex-2",
   "name": "Codex",
-  "version": "1.7.10",
+  "version": "1.7.11",
   "description": "Codex CLI session supervisor — uses terminal-manager for TUI detection",
   "entry": "main.py",
   "icon": "sparkles",


### PR DESCRIPTION
## Summary

- **Dedup guard fix**: Timestamp is now recorded AFTER a successful send, not before routing. Previous implementation set the timestamp at the top of the function, so if a send failed and was retried, the dedup guard incorrectly blocked the retry. Also fixed a startup bug where `time.monotonic()` starting near zero caused `now - 0 < 5.0` to be `True`, dropping the first legitimate send.
- **RPC timeout increase**: `inject_tty` and `send_text` calls bumped from 3s → 8s to reduce the ghost-execution scenario (timeout fires in caller, terminal-manager continues executing, retry causes duplicate send).
- **Hook file checks**: Both `claudecode-controller` and `codex-2` now warn at startup if hook files are missing from their script directory, helping diagnose the "hooks blocked submit" bug.
- **5 new tests**: Cover exact-duplicate drop, different text/session pass-through, expired window re-allow, and the ghost-execution scenario.

## Test plan
- [x] All 57 tests pass: `python3 -m pytest ask/scripts/claudecode-controller/test_claudecode_controller.py`
- [x] New `TestDedupGuard` class: 5/5 tests green
- [ ] Deploy and verify no duplicate sends from iPhone
- [ ] Verify hook error warnings appear in logs when hooks are missing

🤖 Generated with [Claude Code](https://claude.com/claude-code)