### PR TITLE
chore: bump AskMac to v1.0.0

### DIFF
--- a/AskMac/project.yml
+++ b/AskMac/project.yml
@@ -68,7 +68,7 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.kevinhill.askmac
-        MARKETING_VERSION: "0.9.2"
+        MARKETING_VERSION: "1.0.0"
         CURRENT_PROJECT_VERSION: "1"
         CODE_SIGN_STYLE: Manual
         CODE_SIGN_IDENTITY: "Developer ID Application: Kevin Hill (B5J28L8ARB)"


### PR DESCRIPTION
## Summary
- Bumps `MARKETING_VERSION` from 0.9.2 → 1.0.0 for the first major release of AskMac

## Test plan
- [ ] Build passes with `./scripts/build-release.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)