### PR TITLE
fix(codex-3): replace hooks on install to eliminate stale codex-2 entries (v0.1.4)

### DIFF
--- a/ask/scripts/codex-3/main.py
+++ b/ask/scripts/codex-3/main.py
@@ -126,18 +126,15 @@ def _install_hooks():
         'Stop': [{'hooks': [{'type': 'command', 'command': f'{py} {os.path.join(hooks_dir, "session_stop.py")}'}]}],
         'UserPromptSubmit': [{'hooks': [{'type': 'command', 'command': f'{py} {os.path.join(hooks_dir, "user_prompt_submit.py")}'}]}],
     }
+    # Replace our events entirely so stale hooks from old script versions
+    # (e.g. codex-2) never survive a codex-3 upgrade.
     existing = _load_json(CODEX_HOOKS_PATH, {}).get('hooks', {})
-    merged = dict(existing)
-    for event, hook_list in our_hooks.items():
-        our_cmd = hook_list[0]['hooks'][0]['command']
-        current = existing.get(event, [])
-        already = any(
-            hook.get('command') == our_cmd
-            for entry in current
-            for hook in entry.get('hooks', [])
-        )
-        if not already:
-            merged[event] = hook_list + current
+    merged = {
+        event: groups
+        for event, groups in existing.items()
+        if event not in our_hooks
+    }
+    merged.update(our_hooks)
     os.makedirs(os.path.dirname(CODEX_HOOKS_PATH), exist_ok=True)
     with open(CODEX_HOOKS_PATH, 'w') as handle:
         json.dump({'hooks': merged}, handle, indent=2)

--- a/ask/scripts/codex-3/manifest.json
+++ b/ask/scripts/codex-3/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "codex-3",
   "name": "Codex 3",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Feed-first Codex session supervisor with tmux transport and task-backed history",
   "entry": "main.py",
   "icon": "sparkles",

--- a/docs/appcast.xml
+++ b/docs/appcast.xml
@@ -7,6 +7,19 @@
     <language>en</language>
     <!-- Release entries are prepended here by the release pipeline -->
     <item>
+      <title>Version 1.0.0</title>
+      <sparkle:version>1776888800</sparkle:version>
+      <sparkle:shortVersionString>1.0.0</sparkle:shortVersionString>
+      <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
+      <pubDate>Wed, 22 Apr 2026 20:16:11 +0000</pubDate>
+      <enclosure
+        url="https://github.com/Gr8Gatsby/ask/releases/download/v1.0.0/AskMac-1.0.0.dmg"
+        length="3723716"
+        type="application/octet-stream"
+        sparkle:edSignature="7iOmYisCL0i4rJ4n89zEc1/UCOlpLTC7EdnaYb2RoYUTEUUowBoDqp9K2hgYzZvOL+BlmtvDMGZhSAMo0vlVBg=="
+      />
+    </item>
+    <item>
       <title>Version 0.9.2</title>
       <sparkle:version>1776873640</sparkle:version>
       <sparkle:shortVersionString>0.9.2</sparkle:shortVersionString>


### PR DESCRIPTION
## Summary
- `_install_hooks()` previously merged new hooks with existing ones, so codex-2 hook paths survived as stale entries even after codex-2 was removed
- Changed to replace-instead-of-merge: events owned by codex-3 are always overwritten; unrelated events (from other scripts) are preserved
- Killed the running codex tmux session so the fix takes effect immediately on next session start

## Root cause
The running `codex` process (started 9:13 AM) loaded `~/.codex/hooks.json` at startup when it still had codex-2 paths. The hooks.json was later corrected (1:46 PM) but the process cached the old paths in memory, causing UserPromptSubmit hook errors on every prompt.

## Test plan
- [ ] Start a new Codex session from AskMac
- [ ] Type a message and confirm no `codex-2` hook errors appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)