### PR TITLE
chore: add AskMac run scheme to ask.xcodeproj

### DIFF
--- a/ask/ask.xcodeproj/xcshareddata/xcschemes/AskMac.xcscheme
+++ b/ask/ask.xcodeproj/xcshareddata/xcschemes/AskMac.xcscheme
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1600"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "NO"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "AA000007000000000000AA01"
+               BuildableName = "AskMac.app"
+               BlueprintName = "AskMac"
+               ReferencedContainer = "container:ask.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "AA000007000000000000AA01"
+            BuildableName = "AskMac.app"
+            BlueprintName = "AskMac"
+            ReferencedContainer = "container:ask.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "AA000007000000000000AA01"
+            BuildableName = "AskMac.app"
+            BlueprintName = "AskMac"
+            ReferencedContainer = "container:ask.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/docs/appcast.xml
+++ b/docs/appcast.xml
@@ -7,6 +7,19 @@
     <language>en</language>
     <!-- Release entries are prepended here by the release pipeline -->
     <item>
+      <title>Version 1.0.0</title>
+      <sparkle:version>1776888800</sparkle:version>
+      <sparkle:shortVersionString>1.0.0</sparkle:shortVersionString>
+      <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
+      <pubDate>Wed, 22 Apr 2026 20:16:11 +0000</pubDate>
+      <enclosure
+        url="https://github.com/Gr8Gatsby/ask/releases/download/v1.0.0/AskMac-1.0.0.dmg"
+        length="3723716"
+        type="application/octet-stream"
+        sparkle:edSignature="7iOmYisCL0i4rJ4n89zEc1/UCOlpLTC7EdnaYb2RoYUTEUUowBoDqp9K2hgYzZvOL+BlmtvDMGZhSAMo0vlVBg=="
+      />
+    </item>
+    <item>
       <title>Version 0.9.2</title>
       <sparkle:version>1776873640</sparkle:version>
       <sparkle:shortVersionString>0.9.2</sparkle:shortVersionString>


### PR DESCRIPTION
## Summary
- Adds `AskMac.xcscheme` to `ask/ask.xcodeproj` so both schemes (normal run + first-run reset) are visible when the project is opened from the repo root

🤖 Generated with [Claude Code](https://claude.com/claude-code)