### PR TITLE
fix(mac): copy ask_sdk.py to vault root during catalog install

### DIFF
--- a/AskMac/Sources/AskMac/Services/ScriptInstaller.swift
+++ b/AskMac/Sources/AskMac/Services/ScriptInstaller.swift
@@ -369,6 +369,19 @@ final class ScriptInstaller {
 
         skipped.append(contentsOf: installationErrors)
 
+        // Copy ask_sdk.py to the vault root if the archive included it.
+        // Scripts that use setup.py depend on `import ask_sdk`, and the vault root
+        // is always on their PYTHONPATH — without this file, setup.py fails silently
+        // on machines that have never had scripts deployed via the dev tool.
+        if let tmp = tempDir {
+            let sdkSrc = tmp.appendingPathComponent("ask_sdk.py")
+            let sdkDest = vaultURL.appendingPathComponent("ask_sdk.py")
+            if fm.fileExists(atPath: sdkSrc.path) {
+                try? fm.removeItem(at: sdkDest)
+                try? fm.copyItem(at: sdkSrc, to: sdkDest)
+            }
+        }
+
         // Mark all pending scripts as known+enabled so the reload triggered by endInstall()
         // starts them immediately. Scripts that failed to copy won't have a valid manifest
         // in the vault, so the reload simply won't find them.


### PR DESCRIPTION
Scripts with setup.py depend on `import ask_sdk`. On machines that install via catalog only, `ask_sdk.py` was never present at the vault root, causing setup.py to fail silently. Fix: ScriptInstaller now copies `ask_sdk.py` from the archive root to the vault root when found. Each script zip now includes it.