### PR TITLE
feat(terminal-manager): v2.0 — tmux lifecycle, health, pattern wait, screenshot

### DIFF
--- a/ask/scripts/terminal-manager/main.py
+++ b/ask/scripts/terminal-manager/main.py
@@ -17,6 +17,9 @@ import os
 import re
 import subprocess
 import datetime
+import tempfile
+import base64
+import time as _time
 
 sys.stdout = open(sys.stdout.fileno(), mode='w', encoding='utf-8', buffering=1, closefd=False)
 
@@ -1519,6 +1522,393 @@ class TerminalManager:
             if l.strip() and not _re.match(r'^[-─━═╌╍\s]+$', l)
         ]
         return '\n'.join(response_lines[-40:]).strip()[:4000]
+
+    # -----------------------------------------------------------------------
+    # tmux lifecycle & advanced tools
+    # -----------------------------------------------------------------------
+
+    async def _tmux_ensure_session(self, session: str, cwd: str = '') -> bool:
+        """Create tmux session if it doesn't exist. Returns True if created, False if already existed."""
+        proc = await asyncio.create_subprocess_exec(
+            TMUX, 'has-session', '-t', session,
+            stdout=asyncio.subprocess.DEVNULL, stderr=asyncio.subprocess.DEVNULL,
+        )
+        await asyncio.wait_for(proc.wait(), timeout=3)
+        if proc.returncode == 0:
+            return False
+        cmd = [TMUX, 'new-session', '-d', '-s', session]
+        if cwd:
+            cmd += ['-c', cwd]
+        proc = await asyncio.create_subprocess_exec(
+            *cmd, stdout=asyncio.subprocess.DEVNULL, stderr=asyncio.subprocess.DEVNULL,
+        )
+        await asyncio.wait_for(proc.wait(), timeout=10)
+        _log(f'_tmux_ensure_session: created {session!r}')
+        return True
+
+    async def _tool_create_window(self, params: dict) -> dict:
+        """Create a named tmux window, optionally running a command inside it."""
+        session = params.get('session', 'ask')
+        window_name = params['window_name']
+        command = params.get('command', '')
+        cwd = params.get('cwd', '')
+        await self._tmux_ensure_session(session, cwd)
+        cmd = [TMUX, 'new-window', '-t', session, '-n', window_name]
+        if cwd:
+            cmd += ['-c', cwd]
+        if command:
+            cmd.append(command)
+        proc = await asyncio.create_subprocess_exec(
+            *cmd, stdout=asyncio.subprocess.DEVNULL, stderr=asyncio.subprocess.DEVNULL,
+        )
+        await asyncio.wait_for(proc.communicate(), timeout=10)
+        target = f'{session}:{window_name}'
+        _log(f'_tool_create_window: created {target!r}')
+        return {'target': target, 'session': session, 'window': window_name}
+
+    async def _tool_destroy_window(self, params: dict) -> dict:
+        """Kill a tmux window, optionally sending Ctrl+C first. Unregisters any matching session."""
+        target = params['target']
+        force = params.get('force', False)
+        try:
+            if not force:
+                proc = await asyncio.create_subprocess_exec(
+                    TMUX, 'send-keys', '-t', target, 'C-c', '',
+                    stdout=asyncio.subprocess.DEVNULL, stderr=asyncio.subprocess.DEVNULL,
+                )
+                await asyncio.wait_for(proc.communicate(), timeout=5)
+                await asyncio.sleep(0.3)
+            proc = await asyncio.create_subprocess_exec(
+                TMUX, 'kill-window', '-t', target,
+                stdout=asyncio.subprocess.DEVNULL, stderr=asyncio.subprocess.DEVNULL,
+            )
+            await asyncio.wait_for(proc.communicate(), timeout=10)
+            ok = True
+        except Exception as exc:
+            _log(f'_tool_destroy_window: error killing {target!r}: {exc}')
+            ok = False
+        # Unregister any registered session whose tmux_target matches
+        to_remove = [sid for sid, s in self._sessions.items() if s.tmux_target == target]
+        for sid in to_remove:
+            del self._sessions[sid]
+            _log(f'_tool_destroy_window: unregistered session {sid!r} (target={target!r})')
+        _log(f'_tool_destroy_window: ok={ok} target={target!r}')
+        return {'ok': ok, 'target': target}
+
+    async def _tool_list_windows(self, params: dict) -> dict:
+        """List all windows in a tmux session with index, name, active state, and command."""
+        session = params.get('session', 'ask')
+        fmt = '#{window_index}\t#{window_name}\t#{window_active}\t#{pane_current_command}\t#{pane_dead}'
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                TMUX, 'list-windows', '-t', session, '-F', fmt,
+                stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.DEVNULL,
+            )
+            stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=5)
+        except Exception:
+            return {'session': session, 'windows': []}
+        if proc.returncode != 0:
+            return {'session': session, 'windows': []}
+        windows = []
+        for line in stdout.decode().splitlines():
+            parts = line.split('\t')
+            if len(parts) < 5:
+                continue
+            index, name, active, command, dead = parts
+            windows.append({
+                'index': index,
+                'name': name,
+                'target': f'{session}:{name}',
+                'active': active == '1',
+                'command': command,
+                'alive': dead != '1',
+            })
+        _log(f'_tool_list_windows: session={session!r} count={len(windows)}')
+        return {'session': session, 'windows': windows}
+
+    async def _tool_rename_window(self, params: dict) -> dict:
+        """Rename a tmux window by target string."""
+        target = params['target']
+        new_name = params['new_name']
+        proc = await asyncio.create_subprocess_exec(
+            TMUX, 'rename-window', '-t', target, new_name,
+            stdout=asyncio.subprocess.DEVNULL, stderr=asyncio.subprocess.PIPE,
+        )
+        _, stderr = await asyncio.wait_for(proc.communicate(), timeout=5)
+        if proc.returncode != 0:
+            raise RuntimeError(f'rename-window failed: {stderr.decode().strip()}')
+        _log(f'_tool_rename_window: {target!r} -> {new_name!r}')
+        return {'ok': True, 'target': target, 'new_name': new_name}
+
+    async def _tool_split_pane(self, params: dict) -> dict:
+        """Split a tmux pane horizontally or vertically, optionally running a command."""
+        target = params['target']
+        direction = params.get('direction', 'horizontal')
+        command = params.get('command', '')
+        cwd = params.get('cwd', '')
+        percent = params.get('percent', 50)
+        flag = '-h' if direction == 'horizontal' else '-v'
+        cmd = [TMUX, 'split-window', flag, '-t', target, '-p', str(percent)]
+        if cwd:
+            cmd += ['-c', cwd]
+        if command:
+            cmd.append(command)
+        proc = await asyncio.create_subprocess_exec(
+            *cmd, stdout=asyncio.subprocess.DEVNULL, stderr=asyncio.subprocess.DEVNULL,
+        )
+        await asyncio.wait_for(proc.communicate(), timeout=10)
+        # Get new pane target
+        proc2 = await asyncio.create_subprocess_exec(
+            TMUX, 'display-message', '-t', target, '-p',
+            '#{session_name}:#{window_name}.#{pane_index}',
+            stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.DEVNULL,
+        )
+        stdout, _ = await asyncio.wait_for(proc2.communicate(), timeout=5)
+        new_target = stdout.decode().strip()
+        _log(f'_tool_split_pane: target={target!r} new_pane={new_target!r} direction={direction!r}')
+        return {'ok': True, 'target': target, 'new_pane': new_target, 'direction': direction}
+
+    async def _tool_pane_alive(self, params: dict) -> dict:
+        """Check whether a tmux pane is still running (not dead)."""
+        target = params['target']
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                TMUX, 'display-message', '-t', target, '-p', '#{pane_dead}',
+                stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.DEVNULL,
+            )
+            stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=5)
+        except asyncio.TimeoutError:
+            return {'alive': False, 'target': target, 'reason': 'timeout'}
+        except Exception:
+            return {'alive': False, 'target': target, 'reason': 'not_found'}
+        if proc.returncode != 0:
+            return {'alive': False, 'target': target, 'reason': 'not_found'}
+        dead = stdout.decode().strip()
+        return {'alive': dead != '1', 'target': target}
+
+    async def _tool_get_pane_info(self, params: dict) -> dict:
+        """Return full metadata for a tmux pane: pid, command, dimensions, tty, session, window."""
+        target = params['target']
+        fmt = '#{pane_pid}\t#{pane_current_command}\t#{pane_dead}\t#{pane_width}\t#{pane_height}\t#{window_name}\t#{session_name}\t#{pane_tty}'
+        proc = await asyncio.create_subprocess_exec(
+            TMUX, 'display-message', '-t', target, '-p', fmt,
+            stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.DEVNULL,
+        )
+        stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=5)
+        parts = stdout.decode().strip().split('\t')
+        pid_raw, command, dead, width_raw, height_raw, window, session, tty = (parts + [''] * 8)[:8]
+        try:
+            pid = int(pid_raw)
+        except (ValueError, TypeError):
+            pid = None
+        try:
+            width = int(width_raw)
+        except (ValueError, TypeError):
+            width = 0
+        try:
+            height = int(height_raw)
+        except (ValueError, TypeError):
+            height = 0
+        return {
+            'target': target,
+            'session': session,
+            'window': window,
+            'tty': tty,
+            'pid': pid,
+            'command': command,
+            'alive': dead != '1',
+            'width': width,
+            'height': height,
+        }
+
+    async def _tool_send_interrupt(self, params: dict) -> dict:
+        """Send Ctrl+C to a tmux pane by direct target or registered session_id."""
+        target = params.get('target', '')
+        session_id = params.get('session_id', '')
+        if not target and session_id:
+            session = self._sessions.get(session_id)
+            if session and session.tmux_target:
+                target = session.tmux_target
+        if not target:
+            raise ValueError('send_interrupt requires target or a valid session_id with a tmux_target')
+        proc = await asyncio.create_subprocess_exec(
+            TMUX, 'send-keys', '-t', target, 'C-c', '',
+            stdout=asyncio.subprocess.DEVNULL, stderr=asyncio.subprocess.DEVNULL,
+        )
+        await asyncio.wait_for(proc.communicate(), timeout=5)
+        _log(f'_tool_send_interrupt: sent C-c to {target!r}')
+        return {'ok': True, 'target': target}
+
+    async def _tool_wait_for_pattern(self, params: dict) -> dict:
+        """Poll a tmux pane until a regex pattern matches, with stable-count and timeout support."""
+        target = params.get('target', '')
+        session_id = params.get('session_id', '')
+        pattern = params['pattern']
+        timeout = float(params.get('timeout', 30))
+        poll_interval = float(params.get('poll_interval', 0.5))
+        stable_count = int(params.get('stable_count', 1))
+        lines = int(params.get('lines', 50))
+        if not target and session_id:
+            session = self._sessions.get(session_id)
+            if session and session.tmux_target:
+                target = session.tmux_target
+        if not target:
+            raise ValueError('wait_for_pattern requires target or a valid session_id with a tmux_target')
+        _log(f'_tool_wait_for_pattern: waiting for {pattern!r} on {target!r} timeout={timeout}')
+        deadline = _time.monotonic() + timeout
+        last_content = ''
+        consecutive = 0
+        timed_out = False
+        matched = False
+        while _time.monotonic() < deadline:
+            content = await _tmux_read(target, lines)
+            if re.search(pattern, content, re.MULTILINE):
+                if content == last_content:
+                    consecutive += 1
+                else:
+                    consecutive = 1
+                last_content = content
+                if consecutive >= stable_count:
+                    matched = True
+                    break
+            else:
+                consecutive = 0
+                last_content = content
+            remaining = deadline - _time.monotonic()
+            await asyncio.sleep(min(poll_interval, max(0, remaining)))
+        else:
+            timed_out = True
+        _log(f'_tool_wait_for_pattern: matched={matched} timed_out={timed_out} target={target!r}')
+        return {'matched': matched, 'output': last_content, 'timed_out': timed_out}
+
+    async def _tool_run_command(self, params: dict) -> dict:
+        """Create an ephemeral tmux window, run a command, wait for completion, return output."""
+        command = params['command']
+        session = params.get('session', 'ask')
+        timestamp = int(_time.time())
+        window_name = params.get('window_name', f'run_{timestamp}')
+        cwd = params.get('cwd', '')
+        timeout = float(params.get('timeout', 60))
+        keep_window = params.get('keep_window', False)
+        create_result = await self._tool_create_window({
+            'session': session,
+            'window_name': window_name,
+            'command': command,
+            'cwd': cwd,
+        })
+        target = create_result['target']
+        _prompt_re = re.compile(r'[$#%>]\s*$', re.MULTILINE)
+        start = _time.monotonic()
+        timed_out = False
+        while True:
+            elapsed = _time.monotonic() - start
+            if elapsed >= timeout:
+                timed_out = True
+                break
+            alive_result = await self._tool_pane_alive({'target': target})
+            if not alive_result.get('alive', True):
+                break
+            snippet = await _tmux_read(target, 5)
+            if _prompt_re.search(snippet):
+                break
+            await asyncio.sleep(1)
+        elapsed = _time.monotonic() - start
+        output = await _tmux_read(target, 500)
+        if not keep_window:
+            await self._tool_destroy_window({'target': target, 'force': True})
+            final_target = None
+        else:
+            final_target = target
+        _log(f'_tool_run_command: elapsed={elapsed:.1f}s timed_out={timed_out} target={target!r}')
+        return {'output': output, 'elapsed': elapsed, 'timed_out': timed_out, 'target': final_target}
+
+    async def _tool_screenshot(self, params: dict) -> dict:
+        """Capture the current state of a tmux pane as text and optionally as a PNG image."""
+        target = params.get('target', '')
+        session_id = params.get('session_id', '')
+        fmt = params.get('format', 'auto')
+        if not target and session_id:
+            session = self._sessions.get(session_id)
+            if session and session.tmux_target:
+                target = session.tmux_target
+        if not target:
+            raise ValueError('screenshot requires target or a valid session_id with a tmux_target')
+        # Always capture text
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                TMUX, 'capture-pane', '-p', '-t', target,
+                stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.DEVNULL,
+            )
+            stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=10)
+            raw_text = stdout.decode()
+        except Exception:
+            raw_text = ''
+        # Strip ANSI escape codes
+        ansi_re = re.compile(r'\x1b\[[0-9;]*[A-Za-z]|\x1b\][^\x07]*\x07|\x1b[^[\\]', re.DOTALL)
+        text = ansi_re.sub('', raw_text)
+        result: dict = {'target': target, 'text': text}
+        if fmt in ('image', 'auto'):
+            image_data = await self._capture_terminal_image(target)
+            if image_data is not None:
+                result['image'] = image_data
+        return result
+
+    async def _capture_terminal_image(self, target: str):
+        """Capture a PNG screenshot of the terminal window hosting the given tmux pane."""
+        try:
+            # Step 1: get pane TTY
+            proc = await asyncio.create_subprocess_exec(
+                TMUX, 'display-message', '-t', target, '-p', '#{pane_tty}',
+                stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.DEVNULL,
+            )
+            stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=5)
+            tty = stdout.decode().strip()
+            if not tty:
+                return None
+            # Step 2: detect terminal app
+            app = await _detect_terminal_for_tty(tty)
+            if app == 'unknown':
+                return None
+            # Step 3: get window ID via osascript
+            script = (
+                f'tell application "System Events"\n'
+                f'    if not (exists process "{app}") then return ""\n'
+                f'    tell process "{app}"\n'
+                f'        if (count of windows) = 0 then return ""\n'
+                f'        return id of front window\n'
+                f'    end tell\n'
+                f'end tell'
+            )
+            proc = await asyncio.create_subprocess_exec(
+                'osascript', '-e', script,
+                stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.DEVNULL,
+            )
+            stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=10)
+            window_id = stdout.decode().strip()
+            if not window_id:
+                return None
+            # Step 4: screencapture to temp file
+            tmp = tempfile.NamedTemporaryFile(suffix='.png', delete=False)
+            tmp_path = tmp.name
+            tmp.close()
+            try:
+                proc = await asyncio.create_subprocess_exec(
+                    'screencapture', '-l', window_id, '-x', '-o', tmp_path,
+                    stdout=asyncio.subprocess.DEVNULL, stderr=asyncio.subprocess.DEVNULL,
+                )
+                await asyncio.wait_for(proc.communicate(), timeout=15)
+                with open(tmp_path, 'rb') as f:
+                    data = f.read()
+                b64_string = base64.b64encode(data).decode('ascii')
+            finally:
+                try:
+                    os.unlink(tmp_path)
+                except Exception:
+                    pass
+            return {'format': 'png', 'encoding': 'base64', 'data': b64_string}
+        except Exception as exc:
+            _log(f'WARN _capture_terminal_image: {exc}')
+            return None
 
     # -----------------------------------------------------------------------
     # I/O dispatch

--- a/ask/scripts/terminal-manager/main.py
+++ b/ask/scripts/terminal-manager/main.py
@@ -1910,6 +1910,121 @@ class TerminalManager:
             _log(f'WARN _capture_terminal_image: {exc}')
             return None
 
+    async def _get_tty_cwd(self, tty: str) -> str:
+        """Return the cwd of the foreground shell process on a TTY, via lsof."""
+        short = tty.replace('/dev/', '')
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                'ps', '-t', short, '-o', 'pid=,comm=',
+                stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.DEVNULL,
+            )
+            stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=5)
+        except Exception:
+            return ''
+
+        shell_names = {'bash', 'zsh', 'fish', 'sh', 'tcsh', 'csh'}
+        shell_pid = None
+        first_pid = None
+        for line in stdout.decode().splitlines():
+            parts = line.strip().split(None, 1)
+            if len(parts) < 2:
+                continue
+            pid_str, comm = parts
+            comm_base = comm.split('/')[-1].lstrip('-')
+            if first_pid is None:
+                first_pid = pid_str
+            if comm_base in shell_names and shell_pid is None:
+                shell_pid = pid_str
+
+        target_pid = shell_pid or first_pid
+        if not target_pid:
+            return ''
+
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                'lsof', '-p', target_pid, '-d', 'cwd', '-Fn',
+                stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.DEVNULL,
+            )
+            stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=5)
+            for line in stdout.decode().splitlines():
+                if line.startswith('n') and line[1:].startswith('/'):
+                    return line[1:]
+        except Exception:
+            pass
+        return ''
+
+    async def _tool_migrate_to_tmux(self, params: dict) -> dict:
+        """Migrate a terminal session (TTY) to a tmux-owned window.
+
+        Detects the cwd of the shell on the TTY, creates a new tmux window
+        there, and updates (or creates) the session record to point at tmux.
+        The original TTY entry is cleared so all subsequent tool calls use
+        the tmux path automatically.
+
+        params:
+          session_id   — registered session to migrate (provides tty automatically)
+          tty          — TTY device path, e.g. /dev/ttys003 (used when no session_id)
+          cwd          — override cwd detection
+          session      — tmux session name (default 'ask')
+          window_name  — tmux window name (default: basename of cwd)
+          command      — command to run in the new window (e.g. 'claude')
+        """
+        session_id = params.get('session_id', '')
+        tty = params.get('tty', '')
+        cwd = params.get('cwd', '')
+        tmux_session = params.get('session', 'ask')
+        command = params.get('command', '')
+        window_name = params.get('window_name', '')
+
+        source = None
+        if session_id:
+            source = self._sessions.get(session_id)
+            if not source:
+                raise ValueError(f'Unknown session: {session_id!r}')
+            tty = tty or source.tty
+
+        if not tty:
+            raise ValueError('session_id (with a registered tty) or tty required')
+
+        if not cwd:
+            cwd = await self._get_tty_cwd(tty)
+            _log(f'migrate_to_tmux: detected cwd={cwd!r} from tty={tty!r}')
+
+        if not window_name:
+            window_name = os.path.basename(cwd.rstrip('/')) if cwd else 'terminal'
+
+        result = await self._tool_create_window({
+            'session': tmux_session,
+            'window_name': window_name,
+            'command': command,
+            'cwd': cwd,
+        })
+        target = result['target']
+
+        if source:
+            source.tty = ''
+            source.tmux_target = target
+            source.session_type = 'tmux'
+            source.terminal_app = ''
+        else:
+            new_sid = f'migrated:{os.path.basename(tty)}'
+            self._sessions[new_sid] = Session(
+                session_id=new_sid,
+                app_id='migrated',
+                tty='',
+                tmux_target=target,
+            )
+            session_id = new_sid
+
+        _log(f'migrate_to_tmux: {tty!r} → {target!r} cwd={cwd!r}')
+        return {
+            'target': target,
+            'session_id': session_id,
+            'cwd': cwd,
+            'window': window_name,
+            'tmux_session': tmux_session,
+        }
+
     # -----------------------------------------------------------------------
     # I/O dispatch
     # -----------------------------------------------------------------------

--- a/ask/scripts/terminal-manager/manifest.json
+++ b/ask/scripts/terminal-manager/manifest.json
@@ -2,7 +2,7 @@
   "id": "terminal-manager",
   "name": "Terminal Manager",
   "type": "system",
-  "version": "1.6.0",
+  "version": "2.0.0",
   "description": "Local terminal session registry and TUI detector. Tools are available to all scripts via AskMac MCP — not exposed to iPhone.",
   "entry": "main.py",
   "tools": [
@@ -92,6 +92,106 @@
         { "name": "prompt_pattern", "type": "string",  "required": false },
         { "name": "poll_interval",  "type": "number",  "required": false },
         { "name": "stable_count",   "type": "integer", "required": false }
+      ]
+    },
+    {
+      "name": "create_window",
+      "description": "Create a named tmux window in a session. Ensures the session exists first. Optionally runs a command inside the new window and sets its working directory. Returns the target string (session:window_name) you can pass to other tools.",
+      "params": [
+        { "name": "session",     "type": "string", "required": false },
+        { "name": "window_name", "type": "string", "required": true },
+        { "name": "command",     "type": "string", "required": false },
+        { "name": "cwd",         "type": "string", "required": false }
+      ]
+    },
+    {
+      "name": "destroy_window",
+      "description": "Kill a tmux window by target string. Sends Ctrl+C first unless force=true, then runs kill-window. Also unregisters any registered session whose tmux_target matches.",
+      "params": [
+        { "name": "target", "type": "string",  "required": true },
+        { "name": "force",  "type": "boolean", "required": false }
+      ]
+    },
+    {
+      "name": "list_windows",
+      "description": "List all windows in a tmux session. Returns index, name, target, active flag, current command, and whether the pane is alive. Returns an empty list if the session doesn't exist.",
+      "params": [
+        { "name": "session", "type": "string", "required": false }
+      ]
+    },
+    {
+      "name": "rename_window",
+      "description": "Rename a tmux window. Pass the current target (session:name or session:index) and the new name. Raises an error if the window doesn't exist.",
+      "params": [
+        { "name": "target",   "type": "string", "required": true },
+        { "name": "new_name", "type": "string", "required": true }
+      ]
+    },
+    {
+      "name": "split_pane",
+      "description": "Split a tmux pane into two. direction='horizontal' places the new pane side-by-side; direction='vertical' stacks it above/below. Optionally runs a command in the new pane. Returns both the original target and the new pane's target string.",
+      "params": [
+        { "name": "target",    "type": "string",  "required": true },
+        { "name": "direction", "type": "string",  "required": false },
+        { "name": "command",   "type": "string",  "required": false },
+        { "name": "cwd",       "type": "string",  "required": false },
+        { "name": "percent",   "type": "integer", "required": false }
+      ]
+    },
+    {
+      "name": "pane_alive",
+      "description": "Check whether a tmux pane is still running. Returns alive=true/false. Use this to poll after launching a command to know when it exits.",
+      "params": [
+        { "name": "target", "type": "string", "required": true }
+      ]
+    },
+    {
+      "name": "get_pane_info",
+      "description": "Return full metadata for a tmux pane: pid, current command, alive state, width, height, tty, window name, and session name.",
+      "params": [
+        { "name": "target", "type": "string", "required": true }
+      ]
+    },
+    {
+      "name": "send_interrupt",
+      "description": "Send Ctrl+C to a tmux pane to interrupt the running process. Accepts either a direct tmux target string or a registered session_id (at least one is required).",
+      "params": [
+        { "name": "target",     "type": "string", "required": false },
+        { "name": "session_id", "type": "string", "required": false }
+      ]
+    },
+    {
+      "name": "wait_for_pattern",
+      "description": "Poll a tmux pane until a regex pattern matches in the recent output, then return the output. Use stable_count to require multiple consecutive matching reads before returning. Accepts target or session_id.",
+      "params": [
+        { "name": "target",         "type": "string",  "required": false },
+        { "name": "session_id",     "type": "string",  "required": false },
+        { "name": "pattern",        "type": "string",  "required": true },
+        { "name": "timeout",        "type": "number",  "required": false },
+        { "name": "poll_interval",  "type": "number",  "required": false },
+        { "name": "stable_count",   "type": "integer", "required": false },
+        { "name": "lines",          "type": "integer", "required": false }
+      ]
+    },
+    {
+      "name": "run_command",
+      "description": "Run a shell command in an ephemeral tmux window, wait for it to finish (shell prompt or pane exit), then return the full output. Set keep_window=true to leave the window open after the command completes.",
+      "params": [
+        { "name": "command",     "type": "string",  "required": true },
+        { "name": "session",     "type": "string",  "required": false },
+        { "name": "window_name", "type": "string",  "required": false },
+        { "name": "cwd",         "type": "string",  "required": false },
+        { "name": "timeout",     "type": "number",  "required": false },
+        { "name": "keep_window", "type": "boolean", "required": false }
+      ]
+    },
+    {
+      "name": "screenshot",
+      "description": "Capture the current state of a tmux pane as text (always) and optionally as a base64-encoded PNG image of the terminal window (format='image' or 'auto'). Accepts target or session_id.",
+      "params": [
+        { "name": "target",     "type": "string", "required": false },
+        { "name": "session_id", "type": "string", "required": false },
+        { "name": "format",     "type": "string", "required": false }
       ]
     }
   ]

--- a/ask/scripts/terminal-manager/manifest.json
+++ b/ask/scripts/terminal-manager/manifest.json
@@ -2,7 +2,7 @@
   "id": "terminal-manager",
   "name": "Terminal Manager",
   "type": "system",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Local terminal session registry and TUI detector. Tools are available to all scripts via AskMac MCP — not exposed to iPhone.",
   "entry": "main.py",
   "tools": [
@@ -192,6 +192,18 @@
         { "name": "target",     "type": "string", "required": false },
         { "name": "session_id", "type": "string", "required": false },
         { "name": "format",     "type": "string", "required": false }
+      ]
+    },
+    {
+      "name": "migrate_to_tmux",
+      "description": "Migrate a running terminal session (TTY) into a tmux-owned window. Detects the shell's cwd automatically, creates a named tmux window there, and updates the session record so all subsequent tool calls use tmux. Optionally runs a command in the new window (e.g. 'claude' to resume a Claude Code session). Pass session_id for a registered session, or tty directly for an unregistered one.",
+      "params": [
+        { "name": "session_id",  "type": "string", "required": false },
+        { "name": "tty",         "type": "string", "required": false },
+        { "name": "cwd",         "type": "string", "required": false },
+        { "name": "session",     "type": "string", "required": false },
+        { "name": "window_name", "type": "string", "required": false },
+        { "name": "command",     "type": "string", "required": false }
       ]
     }
   ]

--- a/docs/claude-3-redesign-spec.md
+++ b/docs/claude-3-redesign-spec.md
@@ -1,0 +1,179 @@
+# claude-3 Redesign — Functional Spec
+
+**Status:** Draft for review  
+**Date:** 2026-04-26  
+**Version target:** 1.0.0
+
+---
+
+## Problem
+
+The current claude-3 script is unreliable as a remote control layer:
+
+1. **TTY injection fails on macOS 13+** — TIOCSTI is restricted; injected text is dropped silently
+2. **TTY discovery is fragile** — heuristics (ps scan, lsof, cwd matching) miss sessions and create ghost sessions
+3. **Session identity is ambiguous** — Claude Code's `raw_id`, the daemon's `session_id`, and the terminal `tty` are three different things that get mismatched
+4. **Messages are not durable** — if the daemon crashes while a message is queued, it is lost
+
+---
+
+## Goals
+
+- **100% delivery** of iPhone messages to Claude Code
+- **100% delivery** of permission requests to iPhone
+- **Zero session identity confusion** — one canonical ID per session
+- **No lost events** — hook events and iPhone messages survive daemon restart
+- **No TTY heuristics** — the daemon owns the terminal it controls
+
+---
+
+## Non-goals
+
+- Controlling sessions the daemon did not start (view-only observation is fine)
+- Supporting Claude Code launched in any terminal other than tmux (for full control)
+- Backward compatibility with the existing session file format
+
+---
+
+## Core Principle: Hooks Are Observation-Only
+
+**Hooks must never block, never control, and never interfere with Claude Code's execution.**
+
+- Every hook fires, writes its event, and exits immediately
+- No hook waits for a response from the daemon, iPhone, or any other process
+- No hook returns a decision that alters Claude Code's behavior (e.g. approving/denying a tool)
+- Other users or scripts may register additional hooks; our hooks must coexist safely
+
+**Control is exclusively via `tmux send-keys`.** The daemon injects text into the terminal it owns. Hooks have no role in the control path.
+
+---
+
+## Functional Requirements
+
+### 1. Session Lifecycle
+
+**1.1** Sessions are started via the Ask app (`start_session` tool) or by the user running `ask start` from the CLI.
+
+**1.2** The daemon launches Claude Code inside a tmux window it owns. The tmux session is named `ask`, windows are named by project (e.g. `ask:myrepo`).
+
+**1.3** Claude Code's `raw_id` (from the `SessionStart` hook) becomes the canonical session ID. All subsequent hook events, CloudKit records, and iPhone messages use this ID.
+
+**1.4** If Claude Code is started outside the daemon (externally launched), the session appears as **view-only**: hook events are visible on iPhone but iPhone cannot send messages or answer permission requests.
+
+**1.5** Session state persists to disk. If the daemon restarts, it reads existing state and reattaches to live tmux windows.
+
+**1.6** Sessions are marked stopped when: (a) the `SessionStop` hook fires, (b) the tmux pane exits, or (c) the daemon detects the pane has been dead for > 30 seconds.
+
+---
+
+### 2. Observation (Claude Code → iPhone)
+
+**2.1** All hook events (SessionStart, PreToolUse, PostToolUse, PermissionRequest, SessionStop, PreCompact, PostCompact, UserPromptSubmit) are written to CloudKit before the hook returns.
+
+**2.2** Hooks connect to the daemon via Unix socket with a short non-blocking timeout (100ms). If the daemon is unreachable, the hook writes the event to a local spool file and exits. The daemon drains the spool on startup.
+
+**2.3** iPhone sees: session state, current tool, last assistant message, permission requests, and task feed entries — all in real-time.
+
+**2.4** No observation event is ever discarded. If CloudKit write fails, it is retried with exponential backoff until it succeeds.
+
+---
+
+### 3. Control (iPhone → Claude Code)
+
+**3.1** Messages from iPhone are written to CloudKit by the iOS app before the send is acknowledged to the user.
+
+**3.2** The daemon polls CloudKit for pending messages addressed to each live session.
+
+**3.3** Before injecting any message, the daemon confirms Claude Code is at an idle interactive prompt (not mid-output, not processing a tool). If not idle, the daemon waits (up to 30 seconds) and retries.
+
+**3.4** Messages are injected via `tmux send-keys` into the window the daemon owns for that session. No TTY device is used.
+
+**3.5** Messages are delivered in the order they were sent. If two messages are queued, the second is not injected until Claude Code returns to idle after the first.
+
+**3.6** After injection, the daemon writes a delivery acknowledgment to CloudKit. If the injection fails (tmux window gone), the message is surfaced as undeliverable on iPhone.
+
+**3.7** If the daemon crashes with messages in the delivery queue, the messages remain in CloudKit and are re-delivered when the daemon restarts and reattaches to the tmux session.
+
+---
+
+### 4. Permission Requests
+
+**4.1** When Claude Code requests tool permission, the `PermissionRequest` hook fires and immediately writes the request to CloudKit, then exits. The hook does **not** block. Claude Code shows its native terminal permission prompt.
+
+**4.2** The daemon reads the permission request from CloudKit and surfaces it on iPhone as a permission card.
+
+**4.3** Two resolution paths exist — whichever fires first wins:
+- **Terminal**: the user types a response at the tmux pane directly; Claude Code resolves natively
+- **iPhone**: the user responds on iPhone; the iOS app writes the response to CloudKit; the daemon injects the response via `tmux send-keys` into the pane
+
+**4.4** Before injecting an iPhone response, the daemon checks that the pane is still showing a permission prompt (idle, waiting for input). If the terminal has already moved on (user already responded), the injection is skipped.
+
+**4.5** For sessions in **auto-approve** mode, the daemon injects the approval via `tmux send-keys` immediately without surfacing it to iPhone, consistent with the existing allowlist behavior.
+
+---
+
+### 5. Idle Detection
+
+**5.1** The daemon reads tmux pane output to determine when Claude Code is at an interactive prompt. An interactive prompt is defined as: the pane ends with a `>` or `?` prompt pattern and no new output has appeared for 500ms.
+
+**5.2** `wait_for_idle` is called before every injection (messages and permission responses).
+
+**5.3** If idle is not detected within 30 seconds, the daemon logs a warning and does not inject. The message remains queued for the next idle window.
+
+---
+
+### 6. Session Identity
+
+**6.1** The canonical session ID is Claude Code's `raw_id` (the UUID Claude Code generates per session, delivered via the `SessionStart` hook).
+
+**6.2** The tmux window target (`ask:<project>`) is stored as a routing handle. Multiple fields are never used as competing identifiers.
+
+**6.3** If two Claude Code instances share the same cwd, they are treated as distinct sessions (no merging by cwd).
+
+---
+
+### 7. Start Session UX
+
+**7.1** `start_session` with a repo path opens a tmux window for that repo and launches Claude Code in it. If a live session already exists for that repo, it surfaces the existing session instead of creating a duplicate.
+
+**7.2** `start_session` with no arguments shows a repo picker (existing behavior).
+
+**7.3** If tmux is not installed, the tool returns an actionable error with an install command.
+
+---
+
+### 8. Backward Compatibility
+
+**8.1** Existing `reply`, `stop_session` tool signatures are unchanged.
+
+**8.2** The session state file format changes. Old state files are ignored (sessions will be rediscovered from live tmux windows on first start after upgrade).
+
+---
+
+## Architecture Summary
+
+```
+iPhone
+  │ write message or permission response
+  ▼
+CloudKit  ◄──────────────────── Daemon (writes hook events + permission requests)
+  │                                  ▲
+  │ poll for messages/responses      │ Unix socket (hook events)
+  ▼                                  │
+Daemon ──── tmux send-keys ──► tmux pane (Claude Code)
+             (wait_for_idle)         │
+                                     │ hooks fire (non-blocking, fire-and-forget)
+                                     ▼
+                            Hook scripts ──► Unix socket ──► Daemon
+                            (PermissionRequest hook exits immediately;
+                             terminal prompt shown natively while
+                             iPhone card shown in parallel)
+```
+
+---
+
+## Change Log
+
+| Date | Change |
+|------|--------|
+| 2026-04-26 | Initial draft |


### PR DESCRIPTION
## Summary
- Adds 11 new tools to terminal-manager, making it the shared tmux infrastructure layer for all scripts (claude-3, codex-3, future scripts)
- New tools work directly on tmux targets without requiring a prior `register_session` call
- Also adds `docs/claude-3-redesign-spec.md` — functional spec for the upcoming claude-3 reliability rewrite

## New tools

| Category | Tools |
|---|---|
| Lifecycle | `create_window`, `destroy_window`, `list_windows`, `rename_window`, `split_pane` |
| Health | `pane_alive`, `get_pane_info` |
| Control | `send_interrupt`, `wait_for_pattern` (generic; `wait_for_idle` wraps this) |
| Ephemeral | `run_command` (create temp window, run command, capture output, destroy) |
| Visual | `screenshot` (text always; PNG via screencapture when terminal app is findable) |

## Design notes
- All new tools accept `target` (tmux target string) directly — no session registration required
- `wait_for_pattern` is the generic version of `wait_for_idle`: poll until any regex matches, with configurable stable_count and timeout
- `screenshot` returns text snapshot always; attempts PNG capture by detecting the terminal app window via osascript + screencapture
- Existing 11 tools are unchanged — full backward compatibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)