### PR TITLE
feat(claude-3): tmux-first redesign — fire-and-forget permissions, migrate_to_tmux (v0.3.0)

### DIFF
--- a/ask/scripts/claude-3/hooks/permission_request.py
+++ b/ask/scripts/claude-3/hooks/permission_request.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 """
 Claude Code PermissionRequest hook for claude-3.
-Sends the permission request to the daemon via Unix socket and blocks until
-the user responds on iPhone (or the timeout elapses).
+Sends the permission request to the daemon via Unix socket and exits immediately.
+Claude Code shows its native terminal prompt; the daemon surfaces the card on
+iPhone in parallel. Whichever path the user responds through first wins.
 """
 import sys
 import json
@@ -79,18 +80,9 @@ else:
     options = ['Yes', 'No']
 
 
-def output_decision(decision):
-    print(json.dumps({
-        'hookSpecificOutput': {
-            'hookEventName': 'PermissionRequest',
-            'decision': decision,
-        }
-    }))
-
-
 try:
     sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-    sock.settimeout(None)   # wait indefinitely — user responds on iPhone
+    sock.settimeout(0.5)
     sock.connect(SOCKET_PATH)
     sock.sendall(json.dumps({
         'type': 'permission_request',
@@ -102,30 +94,10 @@ try:
         'tty': _get_tty(),
     }).encode())
     sock.shutdown(socket.SHUT_WR)
-    chunks = []
-    while True:
-        chunk = sock.recv(4096)
-        if not chunk:
-            break
-        chunks.append(chunk)
     sock.close()
-    response = json.loads(b''.join(chunks).decode())
-    value = response.get('value', '')
 except Exception as e:
-    print(f'[claude-3/permission_request] daemon not running, falling back: {e}', file=sys.stderr)
-    sys.exit(0)
+    print(f'[claude-3/permission_request] daemon not running: {e}', file=sys.stderr)
 
-# Map value to Claude Code decision
-if value in ('Allow', 'Yes'):
-    output_decision({'behavior': 'allow'})
-    sys.exit(0)
-elif value in ('Deny', 'No'):
-    output_decision({'behavior': 'deny', 'message': 'Permission denied by user on iPhone.'})
-    sys.exit(2)
-elif value in suggestions_map:
-    output_decision({'behavior': 'allow', 'updatedPermissions': [suggestions_map[value]]})
-    sys.exit(0)
-else:
-    # Empty string or unknown — allow by default (fall-through)
-    output_decision({'behavior': 'allow'})
-    sys.exit(0)
+# Exit with no decision output — Claude Code shows its native terminal prompt.
+# If the user responds on iPhone, the daemon injects the response via tmux.
+sys.exit(0)

--- a/ask/scripts/claude-3/main.py
+++ b/ask/scripts/claude-3/main.py
@@ -1046,7 +1046,6 @@ class Claude3:
             ok = await self._route_text(session, value)
             _log(f'reply session={session.session_id!r} ok={ok} text={value[:80]!r}')
             if ok:
-                self._fire_a2a(self.append_message(session.task_id, 'user', value))
                 session.state = 'running_tool'
                 session.preview = value[:200]
                 self._fire_a2a(self._set_task_status(session, 'working'))
@@ -1074,7 +1073,6 @@ class Claude3:
         ok = await self._route_text(session, text)
         if not ok:
             return {'error': 'session is not routable'}
-        await self.append_message(session.task_id, 'user', text)
         session.state = 'running_tool'
         session.preview = text[:200]
         await self._set_task_status(session, 'working')

--- a/ask/scripts/claude-3/main.py
+++ b/ask/scripts/claude-3/main.py
@@ -19,6 +19,7 @@ import os
 import sys
 import tempfile
 import uuid
+from typing import Optional
 
 from registry import PendingPermission, SessionRecord, SessionRegistry
 from transport import discover_claude_processes, find_repos, parse_tmux_prompt, tty_is_live
@@ -189,6 +190,7 @@ class Claude3:
         self._pending_permissions: dict[str, asyncio.Future] = {}
         self._start_choices: dict[str, dict] = {}
         self._tty_monitors: set[str] = set()  # session_ids with running monitors
+        self._pending_tmux_by_cwd: dict[str, str] = {}  # cwd → tmux_target for in-flight launches
         self._initialized = False
         self._emitted_payloads: dict[str, str] = {}  # block_id → last serialized payload
 
@@ -328,6 +330,7 @@ class Claude3:
         await self.emit_block(START_BLOCK_ID, 'start_session', payload, ttl=600)
 
     async def _emit_session_block(self, session: SessionRecord):
+        is_tmux = bool(session.tmux_target)
         payload = {
             'session_id': session.session_id,
             'task_id': session.task_id,
@@ -338,8 +341,10 @@ class Claude3:
             'cwd': session.cwd,
             'is_working': session.state in ('starting', 'awaiting_user', 'running_tool', 'waiting_permission'),
             'is_headless': False,
+            'is_tmux': is_tmux,
             'permission_mode': _load_permission_mode(),
             'tty': session.tty,
+            'tmux_target': session.tmux_target or None,
             'current_tool': session.current_tool or None,
             'current_preview': session.preview or None,
             'last_message': session.last_message or None,
@@ -353,7 +358,10 @@ class Claude3:
                 'body': session.pending_permission.preview,
                 'options': session.pending_permission.options,
             }
-        _log(f'_emit_session_block: {session.session_id} state={session.state} tty={session.tty!r}')
+        # Offer migrate action for terminal-observed sessions that have a raw_id
+        if not is_tmux and session.raw_id:
+            payload['actions'] = [{'id': '__migrate_to_tmux__', 'label': 'Move to tmux'}]
+        _log(f'_emit_session_block: {session.session_id} state={session.state} tty={session.tty!r} tmux={session.tmux_target!r}')
         await self.emit_block(
             self._session_block_id(session.session_id),
             'agent_session',
@@ -423,6 +431,13 @@ class Claude3:
             return False
 
     async def _tm_send_interrupt(self, session: SessionRecord) -> bool:
+        if session.tmux_target:
+            try:
+                await self._call_tool('send_interrupt', {'target': session.tmux_target}, timeout=5.0)
+                return True
+            except Exception as e:
+                _log(f'send_interrupt(tmux) failed for {session.session_id}: {e}', 'WARN')
+                return False
         if not session.raw_id:
             return False
         try:
@@ -451,7 +466,9 @@ class Claude3:
 
     async def _tm_register(self, session: SessionRecord):
         """Register this session with terminal-manager so inject_tty/send_text work."""
-        if not session.raw_id or not session.tty:
+        if not session.raw_id:
+            return
+        if not session.tty and not session.tmux_target:
             return
         try:
             await self._rpc('tools/call', {
@@ -460,22 +477,33 @@ class Claude3:
                     'session_id': session.raw_id,
                     'app_id': 'claude-3',
                     'tty': session.tty,
-                    'tmux_target': '',
+                    'tmux_target': session.tmux_target,
                 },
             }, timeout=4.0)
-            _log(f'tm_register {session.session_id[:12]} tty={session.tty!r}')
+            _log(f'tm_register {session.session_id[:12]} tty={session.tty!r} tmux={session.tmux_target!r}')
         except Exception as e:
             _log(f'tm_register failed: {e}', 'WARN')
 
     async def _route_text(self, session: SessionRecord, text: str) -> bool:
-        """Send user text to a session via inject_tty, with send_text fallback for sessions with no TTY."""
+        """Send user text to a session. Uses tmux send-keys for managed sessions,
+        inject_tty/send_text fallback for terminal-observed sessions."""
+        if session.tmux_target:
+            # Wait for idle prompt, then send
+            try:
+                await self._call_tool('wait_for_pattern', {
+                    'target': session.tmux_target,
+                    'pattern': r'[>?]\s*$',
+                    'timeout': 30.0,
+                    'stable_count': 2,
+                }, timeout=35.0)
+            except Exception as e:
+                _log(f'wait_for_pattern timed out for {session.session_id}: {e}', 'WARN')
+            return await self._tm_send_text(session, text)
+
         text_with_newline = text if text.endswith('\n') else text + '\n'
         had_tty = bool(session.tty)
         ok = await self._tm_inject_tty(session, text_with_newline)
         if had_tty:
-            # TTY was known before the call. A timeout most likely means AskMac was slow
-            # to ack — the text was probably delivered. Do NOT fall through to send_text,
-            # which would inject a second copy.
             return ok
         # TTY was unknown — try to discover it, re-register, and retry once.
         if session.cwd:
@@ -531,6 +559,40 @@ class Claude3:
         await self.clear_block(START_BLOCK_ID)
         _log(f'Launched Claude Code in {project}')
 
+    async def _launch_in_tmux(self, repo_path: str) -> Optional[str]:
+        """Launch Claude Code inside a tmux window owned by the daemon.
+
+        Returns the tmux target string ('ask:<project>') or None on failure.
+        """
+        repo_path = os.path.expanduser(repo_path)
+        project = os.path.basename(repo_path.rstrip('/'))
+        socket_quoted = SOCKET_PATH.replace("'", "'\\''")
+        env_cmd = f"ASK_SOCKET_PATH='{socket_quoted}' claude"
+        try:
+            result = await self._call_tool('create_window', {
+                'session': 'ask',
+                'window_name': project,
+                'command': env_cmd,
+                'cwd': repo_path,
+            }, timeout=15.0)
+            tmux_target = result.get('target', f'ask:{project}') if isinstance(result, dict) else f'ask:{project}'
+        except Exception as e:
+            _log(f'launch_in_tmux failed for {project}: {e}', 'WARN')
+            return None
+
+        # Track the cwd→target so _handle_session_start can backfill tmux_target
+        self._pending_tmux_by_cwd[repo_path] = tmux_target
+
+        settings_path = os.path.expanduser('~/.ask/claude3-settings.json')
+        settings = _load_json(settings_path, {'recent_repos': []})
+        recent = [repo_path] + [p for p in settings.get('recent_repos', []) if p != repo_path]
+        settings['recent_repos'] = recent[:5]
+        _save_json(settings_path, settings)
+
+        await self.clear_block(START_BLOCK_ID)
+        _log(f'Launched Claude Code in tmux for {project}: {tmux_target}')
+        return tmux_target
+
     # ------------------------------------------------------------------
     # Hook event handlers
     # ------------------------------------------------------------------
@@ -556,6 +618,14 @@ class Claude3:
         session = self._registry.ensure(raw_id=raw_id, tty=tty, cwd=cwd, project=project)
         session.state = 'idle'
         session.permission_mode = _load_permission_mode()
+
+        # Backfill tmux_target if this session was launched via _launch_in_tmux
+        if not session.tmux_target and cwd:
+            tmux_target = self._pending_tmux_by_cwd.pop(cwd, '')
+            if tmux_target:
+                session.tmux_target = tmux_target
+                _log(f'backfilled tmux_target={tmux_target!r} for raw_id={raw_id[:8]}')
+
         await self._set_task_status(session, 'working')
         await self._append_structured_message(session, 'Session started', f'Launched in `{session.project}`.')
         await self._tm_register(session)
@@ -563,7 +633,7 @@ class Claude3:
         await self._emit_tile()
         await self._emit_start_session_block()
         _save_registry(self._registry)
-        _log(f'session_start raw_id={raw_id[:8]} tty={tty} project={project}')
+        _log(f'session_start raw_id={raw_id[:8]} tty={tty} tmux={session.tmux_target!r} project={project}')
 
         # Start TTY monitor for interactive prompt detection
         if session.session_id not in self._tty_monitors:
@@ -665,14 +735,16 @@ class Claude3:
         self._fire_a2a(self._append_structured_message(session, 'Context compacted', summary))
         _log(f'post_compact raw_id={raw_id[:8]} summary={summary[:60]}')
 
-    async def _handle_permission_request(self, msg: dict) -> str:
+    async def _handle_permission_request(self, msg: dict):
+        """Surface a permission request on iPhone and return immediately.
+
+        The hook has already exited — Claude Code shows its native terminal
+        prompt. If the user responds on iPhone, _inject_permission_response
+        injects the answer via tmux send-keys. If they respond in the terminal,
+        Claude Code resolves natively and the TTY monitor clears the card.
+        """
         mode = _load_permission_mode()
         preview = msg.get('preview', '')
-
-        if mode == 'full-auto':
-            return 'Allow'
-        if _is_allowlisted(preview):
-            return 'Allow'
 
         raw_id = msg.get('session_id', '')
         session = self._registry.ensure(
@@ -681,6 +753,13 @@ class Claude3:
             cwd=msg.get('cwd', ''),
             project=os.path.basename((msg.get('cwd', '') or '').rstrip('/')) if msg.get('cwd') else '',
         )
+
+        if mode == 'full-auto' or _is_allowlisted(preview):
+            # Auto-approve: inject 'y\n' directly for tmux sessions
+            if session.tmux_target:
+                asyncio.create_task(self._inject_permission_response(session, 'Allow', ['Allow', 'Deny']))
+            return
+
         options = list(msg.get('options', ['Allow', 'Deny']))
         suggestions = msg.get('suggestions', {})
         request = PendingPermission(
@@ -710,15 +789,28 @@ class Claude3:
         await self._emit_tile()
         _save_registry(self._registry)
 
+        # Background: wait for iPhone response and inject it into the tmux pane
+        asyncio.create_task(self._await_and_inject_permission(session, request, fut))
+
+    async def _await_and_inject_permission(self, session: SessionRecord,
+                                           request: PendingPermission, fut: asyncio.Future):
+        """Wait for iPhone permission response and inject it into the terminal."""
         try:
             value = await asyncio.wait_for(fut, timeout=PERMISSION_TIMEOUT)
         except asyncio.TimeoutError:
-            value = 'Deny'
+            value = None
         finally:
             self._pending_permissions.pop(request.request_id, None)
 
-        self._fire_a2a(self._append_structured_message(session, 'Permission resolved', value))
         session.pending_permission = None
+
+        if value is None:
+            # Timeout — leave Claude Code to resolve natively (user at terminal)
+            session.state = 'idle'
+            await self._emit_session_block(session)
+            return
+
+        self._fire_a2a(self._append_structured_message(session, 'Permission resolved', value))
         session.state = 'running_tool' if value in ('Allow', 'Always Allow', 'executed') else 'idle'
         self._fire_a2a(self._set_task_status(session, 'working'))
         await self._emit_session_block(session)
@@ -726,9 +818,34 @@ class Claude3:
         _save_registry(self._registry)
 
         if value == 'Always Allow':
-            _append_allowlist(preview)
+            _append_allowlist(request.preview)
 
-        return value
+        # Inject response into tmux pane so the native terminal prompt resolves
+        if session.tmux_target and value not in ('executed',):
+            await self._inject_permission_response(session, value, request.options)
+
+    async def _inject_permission_response(self, session: SessionRecord,
+                                          value: str, options: list):
+        """Inject a permission response into the tmux pane to answer the native prompt."""
+        if not session.tmux_target:
+            return
+        # Map to the keystrokes that satisfy Claude Code's numbered permission prompt
+        if value in ('Allow', 'Yes'):
+            text = 'y'
+        elif value in ('Deny', 'No'):
+            text = 'n'
+        elif value in options:
+            idx = options.index(value)
+            text = str(idx + 1)
+        else:
+            text = 'y'
+        try:
+            await self._call_tool('send_text', {
+                'session_id': session.raw_id,
+                'text': text,
+            }, timeout=5.0)
+        except Exception as e:
+            _log(f'inject_permission_response failed for {session.session_id}: {e}', 'WARN')
 
     # ------------------------------------------------------------------
     # TTY monitoring — interactive prompt detection
@@ -869,7 +986,7 @@ class Claude3:
             choice = self._start_choices.get(value, {})
             repo_path = choice.get('repo_path', value)
             if repo_path:
-                asyncio.create_task(self._launch(repo_path))
+                asyncio.create_task(self._launch_in_tmux(repo_path))
             return
 
         session = next(
@@ -899,6 +1016,11 @@ class Claude3:
             _save_registry(self._registry)
             return
 
+        # Migrate terminal session to tmux
+        if value == '__migrate_to_tmux__':
+            asyncio.create_task(self._do_migrate_to_tmux(session))
+            return
+
         # Close session
         if value == '__close_session__':
             await self._tm_inject_tty(session, '/quit\n')
@@ -913,6 +1035,10 @@ class Claude3:
             fut = self._pending_permissions.get(session.pending_permission.request_id)
             if fut and not fut.done():
                 fut.set_result(value)
+            # For non-tmux sessions (TTY prompt), inject directly here
+            elif session.tmux_target and session.pending_permission:
+                asyncio.create_task(self._inject_permission_response(
+                    session, value, session.pending_permission.options))
             return
 
         # Free-text reply
@@ -934,7 +1060,7 @@ class Claude3:
     async def _tool_start_session(self, args: dict) -> dict:
         repo_path = args.get('repo_path', '').strip()
         if repo_path:
-            asyncio.create_task(self._launch(repo_path))
+            asyncio.create_task(self._launch_in_tmux(repo_path))
         else:
             await self._emit_start_session_block()
         return {'ok': True}
@@ -969,6 +1095,37 @@ class Claude3:
         _save_registry(self._registry)
         return {'ok': True}
 
+    async def _do_migrate_to_tmux(self, session: SessionRecord):
+        """Migrate a terminal-observed session into a tmux window."""
+        if not session.raw_id:
+            return
+        try:
+            result = await self._call_tool('migrate_to_tmux', {
+                'session_id': session.raw_id,
+                'session': 'ask',
+                'window_name': session.project,
+            }, timeout=20.0)
+            if isinstance(result, dict) and result.get('tmux_target'):
+                session.tmux_target = result['tmux_target']
+                await self._tm_register(session)
+                self._fire_a2a(self._append_structured_message(
+                    session, 'Moved to tmux', f'Session now running in `{session.tmux_target}`.'))
+                await self._emit_session_block(session)
+                _save_registry(self._registry)
+                _log(f'migrated {session.session_id} to tmux: {session.tmux_target}')
+            else:
+                _log(f'migrate_to_tmux returned unexpected result: {result}', 'WARN')
+        except Exception as e:
+            _log(f'migrate_to_tmux failed for {session.session_id}: {e}', 'WARN')
+
+    async def _tool_migrate_to_tmux(self, args: dict) -> dict:
+        session_id = args.get('session_id', '')
+        session = self._registry.sessions.get(session_id)
+        if not session:
+            return {'error': 'unknown session'}
+        await self._do_migrate_to_tmux(session)
+        return {'ok': True, 'tmux_target': session.tmux_target}
+
     # ------------------------------------------------------------------
     # Heartbeat — session liveness and block refresh
     # ------------------------------------------------------------------
@@ -978,11 +1135,29 @@ class Claude3:
             if session.state == 'stopped':
                 continue
             # Re-register with terminal-manager on each cycle (it loses state on restart)
-            if session.raw_id and session.tty:
+            if session.raw_id and (session.tty or session.tmux_target):
                 asyncio.create_task(self._tm_register(session))
-            # Only evict if we have a known TTY and it is confirmed dead.
+            # For tmux sessions, check pane liveness
+            if session.tmux_target:
+                try:
+                    result = await self._call_tool('pane_alive', {'target': session.tmux_target}, timeout=5.0)
+                    if isinstance(result, dict) and not result.get('alive', True):
+                        _log(f'tmux pane gone for {session.session_id} — marking stopped')
+                        session.state = 'stopped'
+                        session.stopped_at = datetime.datetime.now().timestamp()
+                        self._registry.remove(session.session_id)
+                        try:
+                            await self._append_structured_message(session, 'Session ended', 'tmux pane exited.')
+                            await self._set_task_status(session, 'completed')
+                            await self.clear_block(self._session_block_id(session.session_id))
+                        except Exception as exc:
+                            _log(f'tmux-gone cleanup error for {session.session_id}: {exc}', 'WARN')
+                        continue
+                except Exception:
+                    pass
+            # Only evict TTY sessions if the TTY is confirmed dead.
             # An empty TTY means we haven't resolved routing yet — keep the session alive.
-            if session.tty and not tty_is_live(session.tty):
+            if not session.tmux_target and session.tty and not tty_is_live(session.tty):
                 _log(f'session {session.session_id} TTY gone — marking stopped')
                 session.state = 'stopped'
                 session.stopped_at = datetime.datetime.now().timestamp()
@@ -1037,13 +1212,12 @@ class Claude3:
             elif msg_type == 'post_compact':
                 await self._handle_post_compact(msg)
             elif msg_type == 'permission_request':
-                if not self._initialized:
-                    writer.write(json.dumps({'value': ''}).encode())
-                    await writer.drain()
-                    return
-                value = await self._handle_permission_request(msg)
-                writer.write(json.dumps({'value': value}).encode())
+                # Acknowledge immediately — hook exits, Claude Code shows native prompt.
+                # iPhone card is surfaced in the background; response injected via tmux.
+                writer.write(json.dumps({'value': ''}).encode())
                 await writer.drain()
+                if self._initialized:
+                    asyncio.create_task(self._handle_permission_request(msg))
             elif msg_type == 'ui_respond':
                 # Response from MockAskMac web UI (dev tool) — treat like iPhone response
                 sid = msg.get('session_id', '')
@@ -1138,6 +1312,15 @@ class Claude3:
                         'required': ['session_id'],
                     },
                 },
+                {
+                    'name': 'migrate_to_tmux',
+                    'description': 'Move a terminal-observed session into a tmux window for full control',
+                    'inputSchema': {
+                        'type': 'object',
+                        'properties': {'session_id': {'type': 'string'}},
+                        'required': ['session_id'],
+                    },
+                },
             ]
             self._write({'jsonrpc': '2.0', 'id': rpc_id, 'result': {'tools': tools}})
             return
@@ -1152,6 +1335,8 @@ class Claude3:
                 result = await self._tool_reply(args)
             elif name == 'stop_session':
                 result = await self._tool_stop_session(args)
+            elif name == 'migrate_to_tmux':
+                result = await self._tool_migrate_to_tmux(args)
             else:
                 result = {'error': f'Unknown tool: {name}'}
             self._write({

--- a/ask/scripts/claude-3/main.py
+++ b/ask/scripts/claude-3/main.py
@@ -492,7 +492,7 @@ class Claude3:
             try:
                 await self._call_tool('wait_for_pattern', {
                     'target': session.tmux_target,
-                    'pattern': r'[>?]\s*$',
+                    'pattern': r'[>?❯]\s*$',
                     'timeout': 30.0,
                     'stable_count': 2,
                 }, timeout=35.0)
@@ -1326,36 +1326,44 @@ class Claude3:
             return
 
         if method == 'tools/call':
-            params = msg.get('params', {})
-            name = params.get('name', '')
-            args = params.get('arguments', {})
-            if name == 'start_session':
-                result = await self._tool_start_session(args)
-            elif name == 'reply':
-                result = await self._tool_reply(args)
-            elif name == 'stop_session':
-                result = await self._tool_stop_session(args)
-            elif name == 'migrate_to_tmux':
-                result = await self._tool_migrate_to_tmux(args)
-            else:
-                result = {'error': f'Unknown tool: {name}'}
-            self._write({
-                'jsonrpc': '2.0',
-                'id': rpc_id,
-                'result': {'content': [{'type': 'text', 'text': json.dumps(result)}]},
-            })
+            # Spawn as background task so _read_stdin immediately reads the next
+            # line — critical because tool handlers call _rpc, whose responses
+            # arrive via stdin and must not be blocked waiting for this handler.
+            asyncio.create_task(self._dispatch_tool_call(rpc_id, msg.get('params', {})))
             return
 
         if method == 'notifications/message':
-            data = msg.get('params', {}).get('data', {})
-            msg_type = data.get('type', '')
-            if msg_type == 'user_response':
-                await self._handle_block_response(data.get('blockId', ''), data.get('value', ''))
-            elif msg_type == 'chat_message':
-                await self._tool_reply({
-                    'session_id': data.get('sessionId', ''),
-                    'message': data.get('text', ''),
-                })
+            # Same: block responses and chat messages call _rpc internally.
+            asyncio.create_task(self._dispatch_notification(msg.get('params', {}).get('data', {})))
+
+    async def _dispatch_tool_call(self, rpc_id, params: dict):
+        name = params.get('name', '')
+        args = params.get('arguments', {})
+        if name == 'start_session':
+            result = await self._tool_start_session(args)
+        elif name == 'reply':
+            result = await self._tool_reply(args)
+        elif name == 'stop_session':
+            result = await self._tool_stop_session(args)
+        elif name == 'migrate_to_tmux':
+            result = await self._tool_migrate_to_tmux(args)
+        else:
+            result = {'error': f'Unknown tool: {name}'}
+        self._write({
+            'jsonrpc': '2.0',
+            'id': rpc_id,
+            'result': {'content': [{'type': 'text', 'text': json.dumps(result)}]},
+        })
+
+    async def _dispatch_notification(self, data: dict):
+        msg_type = data.get('type', '')
+        if msg_type == 'user_response':
+            await self._handle_block_response(data.get('blockId', ''), data.get('value', ''))
+        elif msg_type == 'chat_message':
+            await self._tool_reply({
+                'session_id': data.get('sessionId', ''),
+                'message': data.get('text', ''),
+            })
 
     async def _read_stdin(self):
         loop = asyncio.get_running_loop()
@@ -1363,7 +1371,10 @@ class Claude3:
             line = await loop.run_in_executor(None, sys.stdin.readline)
             if not line:
                 break
-            await self._handle_rpc_line(line)
+            # Don't await — _handle_rpc_line must return quickly for slow handlers
+            # so this loop can immediately start reading the next line (e.g. _rpc
+            # responses that arrive while a handler is running).
+            asyncio.create_task(self._handle_rpc_line(line))
 
     # ------------------------------------------------------------------
     # Entry point

--- a/ask/scripts/claude-3/manifest.json
+++ b/ask/scripts/claude-3/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "claude-3",
   "name": "Claude 3",
-  "version": "0.2.12",
+  "version": "0.3.0",
   "setup": "setup.py",
   "description": "Feed-first Claude Code session supervisor — routes permissions and session history to iPhone",
   "entry": "main.py",
@@ -27,6 +27,13 @@
     {
       "name": "stop_session",
       "description": "Interrupt a live Claude Code session.",
+      "params": [
+        { "name": "session_id", "type": "string", "required": true }
+      ]
+    },
+    {
+      "name": "migrate_to_tmux",
+      "description": "Move a terminal-observed session into a tmux window for full bidirectional control.",
       "params": [
         { "name": "session_id", "type": "string", "required": true }
       ]

--- a/ask/scripts/claude-3/manifest.json
+++ b/ask/scripts/claude-3/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "claude-3",
   "name": "Claude 3",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "setup": "setup.py",
   "description": "Feed-first Claude Code session supervisor — routes permissions and session history to iPhone",
   "entry": "main.py",

--- a/ask/scripts/claude-3/manifest.json
+++ b/ask/scripts/claude-3/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "claude-3",
   "name": "Claude 3",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "setup": "setup.py",
   "description": "Feed-first Claude Code session supervisor — routes permissions and session history to iPhone",
   "entry": "main.py",

--- a/ask/scripts/claude-3/registry.py
+++ b/ask/scripts/claude-3/registry.py
@@ -39,6 +39,7 @@ class SessionRecord:
     project: str
     cwd: str = ''
     tty: str = ''
+    tmux_target: str = ''   # 'ask:<project>' when daemon owns the terminal
     state: str = 'starting'
     current_tool: str = ''
     preview: str = ''
@@ -68,6 +69,7 @@ class SessionRecord:
             project=raw.get('project', raw['session_id'][:8]),
             cwd=raw.get('cwd', ''),
             tty=raw.get('tty', ''),
+            tmux_target=raw.get('tmux_target', ''),
             state=raw.get('state', 'starting'),
             current_tool=raw.get('current_tool', ''),
             preview=raw.get('preview', ''),

--- a/ask/scripts/terminal-manager/main.py
+++ b/ask/scripts/terminal-manager/main.py
@@ -17,6 +17,9 @@ import os
 import re
 import subprocess
 import datetime
+import tempfile
+import base64
+import time as _time
 
 sys.stdout = open(sys.stdout.fileno(), mode='w', encoding='utf-8', buffering=1, closefd=False)
 
@@ -1519,6 +1522,393 @@ class TerminalManager:
             if l.strip() and not _re.match(r'^[-─━═╌╍\s]+$', l)
         ]
         return '\n'.join(response_lines[-40:]).strip()[:4000]
+
+    # -----------------------------------------------------------------------
+    # tmux lifecycle & advanced tools
+    # -----------------------------------------------------------------------
+
+    async def _tmux_ensure_session(self, session: str, cwd: str = '') -> bool:
+        """Create tmux session if it doesn't exist. Returns True if created, False if already existed."""
+        proc = await asyncio.create_subprocess_exec(
+            TMUX, 'has-session', '-t', session,
+            stdout=asyncio.subprocess.DEVNULL, stderr=asyncio.subprocess.DEVNULL,
+        )
+        await asyncio.wait_for(proc.wait(), timeout=3)
+        if proc.returncode == 0:
+            return False
+        cmd = [TMUX, 'new-session', '-d', '-s', session]
+        if cwd:
+            cmd += ['-c', cwd]
+        proc = await asyncio.create_subprocess_exec(
+            *cmd, stdout=asyncio.subprocess.DEVNULL, stderr=asyncio.subprocess.DEVNULL,
+        )
+        await asyncio.wait_for(proc.wait(), timeout=10)
+        _log(f'_tmux_ensure_session: created {session!r}')
+        return True
+
+    async def _tool_create_window(self, params: dict) -> dict:
+        """Create a named tmux window, optionally running a command inside it."""
+        session = params.get('session', 'ask')
+        window_name = params['window_name']
+        command = params.get('command', '')
+        cwd = params.get('cwd', '')
+        await self._tmux_ensure_session(session, cwd)
+        cmd = [TMUX, 'new-window', '-t', session, '-n', window_name]
+        if cwd:
+            cmd += ['-c', cwd]
+        if command:
+            cmd.append(command)
+        proc = await asyncio.create_subprocess_exec(
+            *cmd, stdout=asyncio.subprocess.DEVNULL, stderr=asyncio.subprocess.DEVNULL,
+        )
+        await asyncio.wait_for(proc.communicate(), timeout=10)
+        target = f'{session}:{window_name}'
+        _log(f'_tool_create_window: created {target!r}')
+        return {'target': target, 'session': session, 'window': window_name}
+
+    async def _tool_destroy_window(self, params: dict) -> dict:
+        """Kill a tmux window, optionally sending Ctrl+C first. Unregisters any matching session."""
+        target = params['target']
+        force = params.get('force', False)
+        try:
+            if not force:
+                proc = await asyncio.create_subprocess_exec(
+                    TMUX, 'send-keys', '-t', target, 'C-c', '',
+                    stdout=asyncio.subprocess.DEVNULL, stderr=asyncio.subprocess.DEVNULL,
+                )
+                await asyncio.wait_for(proc.communicate(), timeout=5)
+                await asyncio.sleep(0.3)
+            proc = await asyncio.create_subprocess_exec(
+                TMUX, 'kill-window', '-t', target,
+                stdout=asyncio.subprocess.DEVNULL, stderr=asyncio.subprocess.DEVNULL,
+            )
+            await asyncio.wait_for(proc.communicate(), timeout=10)
+            ok = True
+        except Exception as exc:
+            _log(f'_tool_destroy_window: error killing {target!r}: {exc}')
+            ok = False
+        # Unregister any registered session whose tmux_target matches
+        to_remove = [sid for sid, s in self._sessions.items() if s.tmux_target == target]
+        for sid in to_remove:
+            del self._sessions[sid]
+            _log(f'_tool_destroy_window: unregistered session {sid!r} (target={target!r})')
+        _log(f'_tool_destroy_window: ok={ok} target={target!r}')
+        return {'ok': ok, 'target': target}
+
+    async def _tool_list_windows(self, params: dict) -> dict:
+        """List all windows in a tmux session with index, name, active state, and command."""
+        session = params.get('session', 'ask')
+        fmt = '#{window_index}\t#{window_name}\t#{window_active}\t#{pane_current_command}\t#{pane_dead}'
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                TMUX, 'list-windows', '-t', session, '-F', fmt,
+                stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.DEVNULL,
+            )
+            stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=5)
+        except Exception:
+            return {'session': session, 'windows': []}
+        if proc.returncode != 0:
+            return {'session': session, 'windows': []}
+        windows = []
+        for line in stdout.decode().splitlines():
+            parts = line.split('\t')
+            if len(parts) < 5:
+                continue
+            index, name, active, command, dead = parts
+            windows.append({
+                'index': index,
+                'name': name,
+                'target': f'{session}:{name}',
+                'active': active == '1',
+                'command': command,
+                'alive': dead != '1',
+            })
+        _log(f'_tool_list_windows: session={session!r} count={len(windows)}')
+        return {'session': session, 'windows': windows}
+
+    async def _tool_rename_window(self, params: dict) -> dict:
+        """Rename a tmux window by target string."""
+        target = params['target']
+        new_name = params['new_name']
+        proc = await asyncio.create_subprocess_exec(
+            TMUX, 'rename-window', '-t', target, new_name,
+            stdout=asyncio.subprocess.DEVNULL, stderr=asyncio.subprocess.PIPE,
+        )
+        _, stderr = await asyncio.wait_for(proc.communicate(), timeout=5)
+        if proc.returncode != 0:
+            raise RuntimeError(f'rename-window failed: {stderr.decode().strip()}')
+        _log(f'_tool_rename_window: {target!r} -> {new_name!r}')
+        return {'ok': True, 'target': target, 'new_name': new_name}
+
+    async def _tool_split_pane(self, params: dict) -> dict:
+        """Split a tmux pane horizontally or vertically, optionally running a command."""
+        target = params['target']
+        direction = params.get('direction', 'horizontal')
+        command = params.get('command', '')
+        cwd = params.get('cwd', '')
+        percent = params.get('percent', 50)
+        flag = '-h' if direction == 'horizontal' else '-v'
+        cmd = [TMUX, 'split-window', flag, '-t', target, '-p', str(percent)]
+        if cwd:
+            cmd += ['-c', cwd]
+        if command:
+            cmd.append(command)
+        proc = await asyncio.create_subprocess_exec(
+            *cmd, stdout=asyncio.subprocess.DEVNULL, stderr=asyncio.subprocess.DEVNULL,
+        )
+        await asyncio.wait_for(proc.communicate(), timeout=10)
+        # Get new pane target
+        proc2 = await asyncio.create_subprocess_exec(
+            TMUX, 'display-message', '-t', target, '-p',
+            '#{session_name}:#{window_name}.#{pane_index}',
+            stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.DEVNULL,
+        )
+        stdout, _ = await asyncio.wait_for(proc2.communicate(), timeout=5)
+        new_target = stdout.decode().strip()
+        _log(f'_tool_split_pane: target={target!r} new_pane={new_target!r} direction={direction!r}')
+        return {'ok': True, 'target': target, 'new_pane': new_target, 'direction': direction}
+
+    async def _tool_pane_alive(self, params: dict) -> dict:
+        """Check whether a tmux pane is still running (not dead)."""
+        target = params['target']
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                TMUX, 'display-message', '-t', target, '-p', '#{pane_dead}',
+                stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.DEVNULL,
+            )
+            stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=5)
+        except asyncio.TimeoutError:
+            return {'alive': False, 'target': target, 'reason': 'timeout'}
+        except Exception:
+            return {'alive': False, 'target': target, 'reason': 'not_found'}
+        if proc.returncode != 0:
+            return {'alive': False, 'target': target, 'reason': 'not_found'}
+        dead = stdout.decode().strip()
+        return {'alive': dead != '1', 'target': target}
+
+    async def _tool_get_pane_info(self, params: dict) -> dict:
+        """Return full metadata for a tmux pane: pid, command, dimensions, tty, session, window."""
+        target = params['target']
+        fmt = '#{pane_pid}\t#{pane_current_command}\t#{pane_dead}\t#{pane_width}\t#{pane_height}\t#{window_name}\t#{session_name}\t#{pane_tty}'
+        proc = await asyncio.create_subprocess_exec(
+            TMUX, 'display-message', '-t', target, '-p', fmt,
+            stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.DEVNULL,
+        )
+        stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=5)
+        parts = stdout.decode().strip().split('\t')
+        pid_raw, command, dead, width_raw, height_raw, window, session, tty = (parts + [''] * 8)[:8]
+        try:
+            pid = int(pid_raw)
+        except (ValueError, TypeError):
+            pid = None
+        try:
+            width = int(width_raw)
+        except (ValueError, TypeError):
+            width = 0
+        try:
+            height = int(height_raw)
+        except (ValueError, TypeError):
+            height = 0
+        return {
+            'target': target,
+            'session': session,
+            'window': window,
+            'tty': tty,
+            'pid': pid,
+            'command': command,
+            'alive': dead != '1',
+            'width': width,
+            'height': height,
+        }
+
+    async def _tool_send_interrupt(self, params: dict) -> dict:
+        """Send Ctrl+C to a tmux pane by direct target or registered session_id."""
+        target = params.get('target', '')
+        session_id = params.get('session_id', '')
+        if not target and session_id:
+            session = self._sessions.get(session_id)
+            if session and session.tmux_target:
+                target = session.tmux_target
+        if not target:
+            raise ValueError('send_interrupt requires target or a valid session_id with a tmux_target')
+        proc = await asyncio.create_subprocess_exec(
+            TMUX, 'send-keys', '-t', target, 'C-c', '',
+            stdout=asyncio.subprocess.DEVNULL, stderr=asyncio.subprocess.DEVNULL,
+        )
+        await asyncio.wait_for(proc.communicate(), timeout=5)
+        _log(f'_tool_send_interrupt: sent C-c to {target!r}')
+        return {'ok': True, 'target': target}
+
+    async def _tool_wait_for_pattern(self, params: dict) -> dict:
+        """Poll a tmux pane until a regex pattern matches, with stable-count and timeout support."""
+        target = params.get('target', '')
+        session_id = params.get('session_id', '')
+        pattern = params['pattern']
+        timeout = float(params.get('timeout', 30))
+        poll_interval = float(params.get('poll_interval', 0.5))
+        stable_count = int(params.get('stable_count', 1))
+        lines = int(params.get('lines', 50))
+        if not target and session_id:
+            session = self._sessions.get(session_id)
+            if session and session.tmux_target:
+                target = session.tmux_target
+        if not target:
+            raise ValueError('wait_for_pattern requires target or a valid session_id with a tmux_target')
+        _log(f'_tool_wait_for_pattern: waiting for {pattern!r} on {target!r} timeout={timeout}')
+        deadline = _time.monotonic() + timeout
+        last_content = ''
+        consecutive = 0
+        timed_out = False
+        matched = False
+        while _time.monotonic() < deadline:
+            content = await _tmux_read(target, lines)
+            if re.search(pattern, content, re.MULTILINE):
+                if content == last_content:
+                    consecutive += 1
+                else:
+                    consecutive = 1
+                last_content = content
+                if consecutive >= stable_count:
+                    matched = True
+                    break
+            else:
+                consecutive = 0
+                last_content = content
+            remaining = deadline - _time.monotonic()
+            await asyncio.sleep(min(poll_interval, max(0, remaining)))
+        else:
+            timed_out = True
+        _log(f'_tool_wait_for_pattern: matched={matched} timed_out={timed_out} target={target!r}')
+        return {'matched': matched, 'output': last_content, 'timed_out': timed_out}
+
+    async def _tool_run_command(self, params: dict) -> dict:
+        """Create an ephemeral tmux window, run a command, wait for completion, return output."""
+        command = params['command']
+        session = params.get('session', 'ask')
+        timestamp = int(_time.time())
+        window_name = params.get('window_name', f'run_{timestamp}')
+        cwd = params.get('cwd', '')
+        timeout = float(params.get('timeout', 60))
+        keep_window = params.get('keep_window', False)
+        create_result = await self._tool_create_window({
+            'session': session,
+            'window_name': window_name,
+            'command': command,
+            'cwd': cwd,
+        })
+        target = create_result['target']
+        _prompt_re = re.compile(r'[$#%>]\s*$', re.MULTILINE)
+        start = _time.monotonic()
+        timed_out = False
+        while True:
+            elapsed = _time.monotonic() - start
+            if elapsed >= timeout:
+                timed_out = True
+                break
+            alive_result = await self._tool_pane_alive({'target': target})
+            if not alive_result.get('alive', True):
+                break
+            snippet = await _tmux_read(target, 5)
+            if _prompt_re.search(snippet):
+                break
+            await asyncio.sleep(1)
+        elapsed = _time.monotonic() - start
+        output = await _tmux_read(target, 500)
+        if not keep_window:
+            await self._tool_destroy_window({'target': target, 'force': True})
+            final_target = None
+        else:
+            final_target = target
+        _log(f'_tool_run_command: elapsed={elapsed:.1f}s timed_out={timed_out} target={target!r}')
+        return {'output': output, 'elapsed': elapsed, 'timed_out': timed_out, 'target': final_target}
+
+    async def _tool_screenshot(self, params: dict) -> dict:
+        """Capture the current state of a tmux pane as text and optionally as a PNG image."""
+        target = params.get('target', '')
+        session_id = params.get('session_id', '')
+        fmt = params.get('format', 'auto')
+        if not target and session_id:
+            session = self._sessions.get(session_id)
+            if session and session.tmux_target:
+                target = session.tmux_target
+        if not target:
+            raise ValueError('screenshot requires target or a valid session_id with a tmux_target')
+        # Always capture text
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                TMUX, 'capture-pane', '-p', '-t', target,
+                stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.DEVNULL,
+            )
+            stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=10)
+            raw_text = stdout.decode()
+        except Exception:
+            raw_text = ''
+        # Strip ANSI escape codes
+        ansi_re = re.compile(r'\x1b\[[0-9;]*[A-Za-z]|\x1b\][^\x07]*\x07|\x1b[^[\\]', re.DOTALL)
+        text = ansi_re.sub('', raw_text)
+        result: dict = {'target': target, 'text': text}
+        if fmt in ('image', 'auto'):
+            image_data = await self._capture_terminal_image(target)
+            if image_data is not None:
+                result['image'] = image_data
+        return result
+
+    async def _capture_terminal_image(self, target: str):
+        """Capture a PNG screenshot of the terminal window hosting the given tmux pane."""
+        try:
+            # Step 1: get pane TTY
+            proc = await asyncio.create_subprocess_exec(
+                TMUX, 'display-message', '-t', target, '-p', '#{pane_tty}',
+                stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.DEVNULL,
+            )
+            stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=5)
+            tty = stdout.decode().strip()
+            if not tty:
+                return None
+            # Step 2: detect terminal app
+            app = await _detect_terminal_for_tty(tty)
+            if app == 'unknown':
+                return None
+            # Step 3: get window ID via osascript
+            script = (
+                f'tell application "System Events"\n'
+                f'    if not (exists process "{app}") then return ""\n'
+                f'    tell process "{app}"\n'
+                f'        if (count of windows) = 0 then return ""\n'
+                f'        return id of front window\n'
+                f'    end tell\n'
+                f'end tell'
+            )
+            proc = await asyncio.create_subprocess_exec(
+                'osascript', '-e', script,
+                stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.DEVNULL,
+            )
+            stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=10)
+            window_id = stdout.decode().strip()
+            if not window_id:
+                return None
+            # Step 4: screencapture to temp file
+            tmp = tempfile.NamedTemporaryFile(suffix='.png', delete=False)
+            tmp_path = tmp.name
+            tmp.close()
+            try:
+                proc = await asyncio.create_subprocess_exec(
+                    'screencapture', '-l', window_id, '-x', '-o', tmp_path,
+                    stdout=asyncio.subprocess.DEVNULL, stderr=asyncio.subprocess.DEVNULL,
+                )
+                await asyncio.wait_for(proc.communicate(), timeout=15)
+                with open(tmp_path, 'rb') as f:
+                    data = f.read()
+                b64_string = base64.b64encode(data).decode('ascii')
+            finally:
+                try:
+                    os.unlink(tmp_path)
+                except Exception:
+                    pass
+            return {'format': 'png', 'encoding': 'base64', 'data': b64_string}
+        except Exception as exc:
+            _log(f'WARN _capture_terminal_image: {exc}')
+            return None
 
     # -----------------------------------------------------------------------
     # I/O dispatch

--- a/ask/scripts/terminal-manager/main.py
+++ b/ask/scripts/terminal-manager/main.py
@@ -1910,6 +1910,121 @@ class TerminalManager:
             _log(f'WARN _capture_terminal_image: {exc}')
             return None
 
+    async def _get_tty_cwd(self, tty: str) -> str:
+        """Return the cwd of the foreground shell process on a TTY, via lsof."""
+        short = tty.replace('/dev/', '')
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                'ps', '-t', short, '-o', 'pid=,comm=',
+                stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.DEVNULL,
+            )
+            stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=5)
+        except Exception:
+            return ''
+
+        shell_names = {'bash', 'zsh', 'fish', 'sh', 'tcsh', 'csh'}
+        shell_pid = None
+        first_pid = None
+        for line in stdout.decode().splitlines():
+            parts = line.strip().split(None, 1)
+            if len(parts) < 2:
+                continue
+            pid_str, comm = parts
+            comm_base = comm.split('/')[-1].lstrip('-')
+            if first_pid is None:
+                first_pid = pid_str
+            if comm_base in shell_names and shell_pid is None:
+                shell_pid = pid_str
+
+        target_pid = shell_pid or first_pid
+        if not target_pid:
+            return ''
+
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                'lsof', '-p', target_pid, '-d', 'cwd', '-Fn',
+                stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.DEVNULL,
+            )
+            stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=5)
+            for line in stdout.decode().splitlines():
+                if line.startswith('n') and line[1:].startswith('/'):
+                    return line[1:]
+        except Exception:
+            pass
+        return ''
+
+    async def _tool_migrate_to_tmux(self, params: dict) -> dict:
+        """Migrate a terminal session (TTY) to a tmux-owned window.
+
+        Detects the cwd of the shell on the TTY, creates a new tmux window
+        there, and updates (or creates) the session record to point at tmux.
+        The original TTY entry is cleared so all subsequent tool calls use
+        the tmux path automatically.
+
+        params:
+          session_id   — registered session to migrate (provides tty automatically)
+          tty          — TTY device path, e.g. /dev/ttys003 (used when no session_id)
+          cwd          — override cwd detection
+          session      — tmux session name (default 'ask')
+          window_name  — tmux window name (default: basename of cwd)
+          command      — command to run in the new window (e.g. 'claude')
+        """
+        session_id = params.get('session_id', '')
+        tty = params.get('tty', '')
+        cwd = params.get('cwd', '')
+        tmux_session = params.get('session', 'ask')
+        command = params.get('command', '')
+        window_name = params.get('window_name', '')
+
+        source = None
+        if session_id:
+            source = self._sessions.get(session_id)
+            if not source:
+                raise ValueError(f'Unknown session: {session_id!r}')
+            tty = tty or source.tty
+
+        if not tty:
+            raise ValueError('session_id (with a registered tty) or tty required')
+
+        if not cwd:
+            cwd = await self._get_tty_cwd(tty)
+            _log(f'migrate_to_tmux: detected cwd={cwd!r} from tty={tty!r}')
+
+        if not window_name:
+            window_name = os.path.basename(cwd.rstrip('/')) if cwd else 'terminal'
+
+        result = await self._tool_create_window({
+            'session': tmux_session,
+            'window_name': window_name,
+            'command': command,
+            'cwd': cwd,
+        })
+        target = result['target']
+
+        if source:
+            source.tty = ''
+            source.tmux_target = target
+            source.session_type = 'tmux'
+            source.terminal_app = ''
+        else:
+            new_sid = f'migrated:{os.path.basename(tty)}'
+            self._sessions[new_sid] = Session(
+                session_id=new_sid,
+                app_id='migrated',
+                tty='',
+                tmux_target=target,
+            )
+            session_id = new_sid
+
+        _log(f'migrate_to_tmux: {tty!r} → {target!r} cwd={cwd!r}')
+        return {
+            'target': target,
+            'session_id': session_id,
+            'cwd': cwd,
+            'window': window_name,
+            'tmux_session': tmux_session,
+        }
+
     # -----------------------------------------------------------------------
     # I/O dispatch
     # -----------------------------------------------------------------------

--- a/ask/scripts/terminal-manager/manifest.json
+++ b/ask/scripts/terminal-manager/manifest.json
@@ -2,7 +2,7 @@
   "id": "terminal-manager",
   "name": "Terminal Manager",
   "type": "system",
-  "version": "1.6.0",
+  "version": "2.0.0",
   "description": "Local terminal session registry and TUI detector. Tools are available to all scripts via AskMac MCP — not exposed to iPhone.",
   "entry": "main.py",
   "tools": [
@@ -92,6 +92,106 @@
         { "name": "prompt_pattern", "type": "string",  "required": false },
         { "name": "poll_interval",  "type": "number",  "required": false },
         { "name": "stable_count",   "type": "integer", "required": false }
+      ]
+    },
+    {
+      "name": "create_window",
+      "description": "Create a named tmux window in a session. Ensures the session exists first. Optionally runs a command inside the new window and sets its working directory. Returns the target string (session:window_name) you can pass to other tools.",
+      "params": [
+        { "name": "session",     "type": "string", "required": false },
+        { "name": "window_name", "type": "string", "required": true },
+        { "name": "command",     "type": "string", "required": false },
+        { "name": "cwd",         "type": "string", "required": false }
+      ]
+    },
+    {
+      "name": "destroy_window",
+      "description": "Kill a tmux window by target string. Sends Ctrl+C first unless force=true, then runs kill-window. Also unregisters any registered session whose tmux_target matches.",
+      "params": [
+        { "name": "target", "type": "string",  "required": true },
+        { "name": "force",  "type": "boolean", "required": false }
+      ]
+    },
+    {
+      "name": "list_windows",
+      "description": "List all windows in a tmux session. Returns index, name, target, active flag, current command, and whether the pane is alive. Returns an empty list if the session doesn't exist.",
+      "params": [
+        { "name": "session", "type": "string", "required": false }
+      ]
+    },
+    {
+      "name": "rename_window",
+      "description": "Rename a tmux window. Pass the current target (session:name or session:index) and the new name. Raises an error if the window doesn't exist.",
+      "params": [
+        { "name": "target",   "type": "string", "required": true },
+        { "name": "new_name", "type": "string", "required": true }
+      ]
+    },
+    {
+      "name": "split_pane",
+      "description": "Split a tmux pane into two. direction='horizontal' places the new pane side-by-side; direction='vertical' stacks it above/below. Optionally runs a command in the new pane. Returns both the original target and the new pane's target string.",
+      "params": [
+        { "name": "target",    "type": "string",  "required": true },
+        { "name": "direction", "type": "string",  "required": false },
+        { "name": "command",   "type": "string",  "required": false },
+        { "name": "cwd",       "type": "string",  "required": false },
+        { "name": "percent",   "type": "integer", "required": false }
+      ]
+    },
+    {
+      "name": "pane_alive",
+      "description": "Check whether a tmux pane is still running. Returns alive=true/false. Use this to poll after launching a command to know when it exits.",
+      "params": [
+        { "name": "target", "type": "string", "required": true }
+      ]
+    },
+    {
+      "name": "get_pane_info",
+      "description": "Return full metadata for a tmux pane: pid, current command, alive state, width, height, tty, window name, and session name.",
+      "params": [
+        { "name": "target", "type": "string", "required": true }
+      ]
+    },
+    {
+      "name": "send_interrupt",
+      "description": "Send Ctrl+C to a tmux pane to interrupt the running process. Accepts either a direct tmux target string or a registered session_id (at least one is required).",
+      "params": [
+        { "name": "target",     "type": "string", "required": false },
+        { "name": "session_id", "type": "string", "required": false }
+      ]
+    },
+    {
+      "name": "wait_for_pattern",
+      "description": "Poll a tmux pane until a regex pattern matches in the recent output, then return the output. Use stable_count to require multiple consecutive matching reads before returning. Accepts target or session_id.",
+      "params": [
+        { "name": "target",         "type": "string",  "required": false },
+        { "name": "session_id",     "type": "string",  "required": false },
+        { "name": "pattern",        "type": "string",  "required": true },
+        { "name": "timeout",        "type": "number",  "required": false },
+        { "name": "poll_interval",  "type": "number",  "required": false },
+        { "name": "stable_count",   "type": "integer", "required": false },
+        { "name": "lines",          "type": "integer", "required": false }
+      ]
+    },
+    {
+      "name": "run_command",
+      "description": "Run a shell command in an ephemeral tmux window, wait for it to finish (shell prompt or pane exit), then return the full output. Set keep_window=true to leave the window open after the command completes.",
+      "params": [
+        { "name": "command",     "type": "string",  "required": true },
+        { "name": "session",     "type": "string",  "required": false },
+        { "name": "window_name", "type": "string",  "required": false },
+        { "name": "cwd",         "type": "string",  "required": false },
+        { "name": "timeout",     "type": "number",  "required": false },
+        { "name": "keep_window", "type": "boolean", "required": false }
+      ]
+    },
+    {
+      "name": "screenshot",
+      "description": "Capture the current state of a tmux pane as text (always) and optionally as a base64-encoded PNG image of the terminal window (format='image' or 'auto'). Accepts target or session_id.",
+      "params": [
+        { "name": "target",     "type": "string", "required": false },
+        { "name": "session_id", "type": "string", "required": false },
+        { "name": "format",     "type": "string", "required": false }
       ]
     }
   ]

--- a/ask/scripts/terminal-manager/manifest.json
+++ b/ask/scripts/terminal-manager/manifest.json
@@ -2,7 +2,7 @@
   "id": "terminal-manager",
   "name": "Terminal Manager",
   "type": "system",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Local terminal session registry and TUI detector. Tools are available to all scripts via AskMac MCP — not exposed to iPhone.",
   "entry": "main.py",
   "tools": [
@@ -192,6 +192,18 @@
         { "name": "target",     "type": "string", "required": false },
         { "name": "session_id", "type": "string", "required": false },
         { "name": "format",     "type": "string", "required": false }
+      ]
+    },
+    {
+      "name": "migrate_to_tmux",
+      "description": "Migrate a running terminal session (TTY) into a tmux-owned window. Detects the shell's cwd automatically, creates a named tmux window there, and updates the session record so all subsequent tool calls use tmux. Optionally runs a command in the new window (e.g. 'claude' to resume a Claude Code session). Pass session_id for a registered session, or tty directly for an unregistered one.",
+      "params": [
+        { "name": "session_id",  "type": "string", "required": false },
+        { "name": "tty",         "type": "string", "required": false },
+        { "name": "cwd",         "type": "string", "required": false },
+        { "name": "session",     "type": "string", "required": false },
+        { "name": "window_name", "type": "string", "required": false },
+        { "name": "command",     "type": "string", "required": false }
       ]
     }
   ]

--- a/docs/claude-3-redesign-spec.md
+++ b/docs/claude-3-redesign-spec.md
@@ -177,3 +177,4 @@ Daemon ──── tmux send-keys ──► tmux pane (Claude Code)
 | Date | Change |
 |------|--------|
 | 2026-04-26 | Initial draft |
+| 2026-04-26 | Implemented: tmux launch path, fire-and-forget permissions, migrate_to_tmux, is_tmux session flag, tmux liveness check in heartbeat (claude-3 v0.3.0) |

--- a/docs/claude-3-redesign-spec.md
+++ b/docs/claude-3-redesign-spec.md
@@ -178,3 +178,4 @@ Daemon ──── tmux send-keys ──► tmux pane (Claude Code)
 |------|--------|
 | 2026-04-26 | Initial draft |
 | 2026-04-26 | Implemented: tmux launch path, fire-and-forget permissions, migrate_to_tmux, is_tmux session flag, tmux liveness check in heartbeat (claude-3 v0.3.0) |
+| 2026-04-26 | Fixed stdin deadlock: _read_stdin now fires _handle_rpc_line as background task; extracted _dispatch_tool_call and _dispatch_notification. Fixed wait_for_pattern pattern to include ❯ (U+276F). (claude-3 v0.3.1) |

--- a/docs/claude-3-redesign-spec.md
+++ b/docs/claude-3-redesign-spec.md
@@ -1,0 +1,179 @@
+# claude-3 Redesign — Functional Spec
+
+**Status:** Draft for review  
+**Date:** 2026-04-26  
+**Version target:** 1.0.0
+
+---
+
+## Problem
+
+The current claude-3 script is unreliable as a remote control layer:
+
+1. **TTY injection fails on macOS 13+** — TIOCSTI is restricted; injected text is dropped silently
+2. **TTY discovery is fragile** — heuristics (ps scan, lsof, cwd matching) miss sessions and create ghost sessions
+3. **Session identity is ambiguous** — Claude Code's `raw_id`, the daemon's `session_id`, and the terminal `tty` are three different things that get mismatched
+4. **Messages are not durable** — if the daemon crashes while a message is queued, it is lost
+
+---
+
+## Goals
+
+- **100% delivery** of iPhone messages to Claude Code
+- **100% delivery** of permission requests to iPhone
+- **Zero session identity confusion** — one canonical ID per session
+- **No lost events** — hook events and iPhone messages survive daemon restart
+- **No TTY heuristics** — the daemon owns the terminal it controls
+
+---
+
+## Non-goals
+
+- Controlling sessions the daemon did not start (view-only observation is fine)
+- Supporting Claude Code launched in any terminal other than tmux (for full control)
+- Backward compatibility with the existing session file format
+
+---
+
+## Core Principle: Hooks Are Observation-Only
+
+**Hooks must never block, never control, and never interfere with Claude Code's execution.**
+
+- Every hook fires, writes its event, and exits immediately
+- No hook waits for a response from the daemon, iPhone, or any other process
+- No hook returns a decision that alters Claude Code's behavior (e.g. approving/denying a tool)
+- Other users or scripts may register additional hooks; our hooks must coexist safely
+
+**Control is exclusively via `tmux send-keys`.** The daemon injects text into the terminal it owns. Hooks have no role in the control path.
+
+---
+
+## Functional Requirements
+
+### 1. Session Lifecycle
+
+**1.1** Sessions are started via the Ask app (`start_session` tool) or by the user running `ask start` from the CLI.
+
+**1.2** The daemon launches Claude Code inside a tmux window it owns. The tmux session is named `ask`, windows are named by project (e.g. `ask:myrepo`).
+
+**1.3** Claude Code's `raw_id` (from the `SessionStart` hook) becomes the canonical session ID. All subsequent hook events, CloudKit records, and iPhone messages use this ID.
+
+**1.4** If Claude Code is started outside the daemon (externally launched), the session appears as **view-only**: hook events are visible on iPhone but iPhone cannot send messages or answer permission requests.
+
+**1.5** Session state persists to disk. If the daemon restarts, it reads existing state and reattaches to live tmux windows.
+
+**1.6** Sessions are marked stopped when: (a) the `SessionStop` hook fires, (b) the tmux pane exits, or (c) the daemon detects the pane has been dead for > 30 seconds.
+
+---
+
+### 2. Observation (Claude Code → iPhone)
+
+**2.1** All hook events (SessionStart, PreToolUse, PostToolUse, PermissionRequest, SessionStop, PreCompact, PostCompact, UserPromptSubmit) are written to CloudKit before the hook returns.
+
+**2.2** Hooks connect to the daemon via Unix socket with a short non-blocking timeout (100ms). If the daemon is unreachable, the hook writes the event to a local spool file and exits. The daemon drains the spool on startup.
+
+**2.3** iPhone sees: session state, current tool, last assistant message, permission requests, and task feed entries — all in real-time.
+
+**2.4** No observation event is ever discarded. If CloudKit write fails, it is retried with exponential backoff until it succeeds.
+
+---
+
+### 3. Control (iPhone → Claude Code)
+
+**3.1** Messages from iPhone are written to CloudKit by the iOS app before the send is acknowledged to the user.
+
+**3.2** The daemon polls CloudKit for pending messages addressed to each live session.
+
+**3.3** Before injecting any message, the daemon confirms Claude Code is at an idle interactive prompt (not mid-output, not processing a tool). If not idle, the daemon waits (up to 30 seconds) and retries.
+
+**3.4** Messages are injected via `tmux send-keys` into the window the daemon owns for that session. No TTY device is used.
+
+**3.5** Messages are delivered in the order they were sent. If two messages are queued, the second is not injected until Claude Code returns to idle after the first.
+
+**3.6** After injection, the daemon writes a delivery acknowledgment to CloudKit. If the injection fails (tmux window gone), the message is surfaced as undeliverable on iPhone.
+
+**3.7** If the daemon crashes with messages in the delivery queue, the messages remain in CloudKit and are re-delivered when the daemon restarts and reattaches to the tmux session.
+
+---
+
+### 4. Permission Requests
+
+**4.1** When Claude Code requests tool permission, the `PermissionRequest` hook fires and immediately writes the request to CloudKit, then exits. The hook does **not** block. Claude Code shows its native terminal permission prompt.
+
+**4.2** The daemon reads the permission request from CloudKit and surfaces it on iPhone as a permission card.
+
+**4.3** Two resolution paths exist — whichever fires first wins:
+- **Terminal**: the user types a response at the tmux pane directly; Claude Code resolves natively
+- **iPhone**: the user responds on iPhone; the iOS app writes the response to CloudKit; the daemon injects the response via `tmux send-keys` into the pane
+
+**4.4** Before injecting an iPhone response, the daemon checks that the pane is still showing a permission prompt (idle, waiting for input). If the terminal has already moved on (user already responded), the injection is skipped.
+
+**4.5** For sessions in **auto-approve** mode, the daemon injects the approval via `tmux send-keys` immediately without surfacing it to iPhone, consistent with the existing allowlist behavior.
+
+---
+
+### 5. Idle Detection
+
+**5.1** The daemon reads tmux pane output to determine when Claude Code is at an interactive prompt. An interactive prompt is defined as: the pane ends with a `>` or `?` prompt pattern and no new output has appeared for 500ms.
+
+**5.2** `wait_for_idle` is called before every injection (messages and permission responses).
+
+**5.3** If idle is not detected within 30 seconds, the daemon logs a warning and does not inject. The message remains queued for the next idle window.
+
+---
+
+### 6. Session Identity
+
+**6.1** The canonical session ID is Claude Code's `raw_id` (the UUID Claude Code generates per session, delivered via the `SessionStart` hook).
+
+**6.2** The tmux window target (`ask:<project>`) is stored as a routing handle. Multiple fields are never used as competing identifiers.
+
+**6.3** If two Claude Code instances share the same cwd, they are treated as distinct sessions (no merging by cwd).
+
+---
+
+### 7. Start Session UX
+
+**7.1** `start_session` with a repo path opens a tmux window for that repo and launches Claude Code in it. If a live session already exists for that repo, it surfaces the existing session instead of creating a duplicate.
+
+**7.2** `start_session` with no arguments shows a repo picker (existing behavior).
+
+**7.3** If tmux is not installed, the tool returns an actionable error with an install command.
+
+---
+
+### 8. Backward Compatibility
+
+**8.1** Existing `reply`, `stop_session` tool signatures are unchanged.
+
+**8.2** The session state file format changes. Old state files are ignored (sessions will be rediscovered from live tmux windows on first start after upgrade).
+
+---
+
+## Architecture Summary
+
+```
+iPhone
+  │ write message or permission response
+  ▼
+CloudKit  ◄──────────────────── Daemon (writes hook events + permission requests)
+  │                                  ▲
+  │ poll for messages/responses      │ Unix socket (hook events)
+  ▼                                  │
+Daemon ──── tmux send-keys ──► tmux pane (Claude Code)
+             (wait_for_idle)         │
+                                     │ hooks fire (non-blocking, fire-and-forget)
+                                     ▼
+                            Hook scripts ──► Unix socket ──► Daemon
+                            (PermissionRequest hook exits immediately;
+                             terminal prompt shown natively while
+                             iPhone card shown in parallel)
+```
+
+---
+
+## Change Log
+
+| Date | Change |
+|------|--------|
+| 2026-04-26 | Initial draft |

--- a/web/src/screens/SessionChatScreen.tsx
+++ b/web/src/screens/SessionChatScreen.tsx
@@ -16,41 +16,6 @@ function parsePayload<T>(json: string): T | null {
 
 interface Part { type: string; text?: string; name?: string; input?: unknown; content?: unknown; source?: unknown; thinking?: string }
 
-function renderPart(p: Part, i: number) {
-  if (p.type === 'text' && p.text) {
-    return <Markdown key={i}>{p.text}</Markdown>
-  }
-  if (p.type === 'tool_use') {
-    return (
-      <span key={i} className="text-[10px] font-mono text-ask-secondary/70 bg-ask-card2 px-1.5 py-0.5 rounded">
-        ⚙ {p.name}
-      </span>
-    )
-  }
-  if (p.type === 'tool_result') {
-    const text = typeof p.content === 'string' ? p.content : ''
-    return (
-      <span key={i} className="text-[10px] font-mono text-ask-secondary/60 line-clamp-2">
-        {text.slice(0, 120)}
-      </span>
-    )
-  }
-  if (p.type === 'thinking' && p.thinking) {
-    return (
-      <span key={i} className="text-[10px] italic text-ask-secondary/50">
-        {p.thinking.slice(0, 80)}…
-      </span>
-    )
-  }
-  if (p.type === 'image') {
-    return <span key={i} className="text-[10px] text-ask-secondary">[image]</span>
-  }
-  if (p.type === 'document') {
-    return <span key={i} className="text-[10px] text-ask-secondary">[document]</span>
-  }
-  return null
-}
-
 // ---- Tool status line ----
 
 const TOOL_ICONS: Record<string, string> = {
@@ -164,6 +129,21 @@ function PendingConfirmationBar({
   )
 }
 
+// ---- Local message model ----
+
+interface LocalMessage {
+  key: string
+  role: 'user' | 'assistant'
+  text: string
+}
+
+function extractText(partsJSON: string): string {
+  try {
+    const parts = JSON.parse(partsJSON) as Part[]
+    return parts.filter(p => p.type === 'text' && p.text).map(p => p.text!).join('\n')
+  } catch { return '' }
+}
+
 // ---- Screen ----
 
 export default function SessionChatScreen() {
@@ -176,7 +156,8 @@ export default function SessionChatScreen() {
   const { blocks: allBlocks, respond } = useBlocks()
   const [reply, setReply] = useState('')
   const [sending, setSending] = useState(false)
-  const [messages, setMessages] = useState<TaskMessage[]>([])
+  const [localMessages, setLocalMessages] = useState<LocalMessage[]>([])
+  const lastAssistantText = useRef('')
   const bottomRef = useRef<HTMLDivElement>(null)
 
   const sessionBlock = allBlocks.find(b => {
@@ -194,20 +175,42 @@ export default function SessionChatScreen() {
     return () => setAppBrandColor(null)
   }, [accentColor, theme.isAndroid]) // eslint-disable-line react-hooks/exhaustive-deps
 
-  // Load chat history from task messages
+  // Seed history from CloudKit task messages on mount / task_id change
   useEffect(() => {
     if (!payload?.task_id) return
-    getTaskMessages(payload.task_id).then(setMessages)
-  }, [payload?.task_id])
+    getTaskMessages(payload.task_id).then((msgs: TaskMessage[]) => {
+      const loaded: LocalMessage[] = msgs
+        .map(m => ({ key: m.messageID, role: m.role, text: extractText(m.partsJSON) }))
+        .filter(m => m.text)
+      setLocalMessages(loaded)
+      // Track last assistant text so we don't re-append it from last_message
+      const lastAsst = [...loaded].reverse().find(m => m.role === 'assistant')
+      if (lastAsst) lastAssistantText.current = lastAsst.text
+    })
+  }, [payload?.task_id]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Append new assistant message when last_message changes
+  useEffect(() => {
+    const msg = payload?.last_message
+    if (!msg || msg === lastAssistantText.current) return
+    lastAssistantText.current = msg
+    setLocalMessages(prev => {
+      const last = prev[prev.length - 1]
+      if (last?.role === 'assistant' && last.text === msg) return prev
+      return [...prev, { key: `live-${Date.now()}`, role: 'assistant', text: msg }]
+    })
+  }, [payload?.last_message])
 
   // Scroll to bottom on new messages
   useEffect(() => {
     bottomRef.current?.scrollIntoView({ behavior: 'smooth' })
-  }, [messages, payload?.last_message])
+  }, [localMessages.length, payload?.is_working])
 
   const handleSend = async (text: string) => {
     if (!text.trim() || !sessionBlock || sending) return
     setSending(true)
+    // Optimistically add user message so it appears immediately
+    setLocalMessages(prev => [...prev, { key: `user-${Date.now()}`, role: 'user', text: text.trim() }])
     await respond(sessionBlock.blockID, text.trim())
     setReply('')
     setSending(false)
@@ -304,65 +307,58 @@ export default function SessionChatScreen() {
         <div className="flex items-center justify-center h-24 text-ask-secondary text-sm">Session ended</div>
       ) : (
         <>
-          {messages.map(msg => {
-            let parts: Part[] = []
-            try { parts = JSON.parse(msg.partsJSON) } catch { /* */ }
-            const textParts = parts.filter(p => p.type === 'text' && p.text)
-            if (textParts.length === 0 && parts.some(p => p.type === 'tool_use' || p.type === 'tool_result')) {
-              return null
-            }
+          {localMessages.map(msg => {
             if (msg.role === 'user') {
               return (
-                <div key={msg.messageID} className="flex justify-end">
+                <div key={msg.key} className="flex justify-end">
                   <div className="max-w-[80%] rounded-[20px] rounded-br-[5px] px-3.5 py-2.5 bg-ask-blue text-white text-[15px] leading-snug">
-                    {parts.map((p, i) => renderPart(p, i))}
+                    {msg.text}
                   </div>
                 </div>
               )
             }
             return (
-              <div key={msg.messageID} className="text-ask-text text-[15px]">
-                {parts.map((p, i) => renderPart(p, i))}
+              <div key={msg.key} className="text-ask-text text-[15px]">
+                <Markdown>{msg.text}</Markdown>
               </div>
             )
           })}
 
-          <div className="flex flex-col gap-1.5">
-            <div className="flex items-center gap-1.5">
-              <div
-                className="w-4 h-4 rounded-full flex items-center justify-center text-[8px] font-bold text-white flex-shrink-0"
-                style={{ backgroundColor: accentColor }}
-              >
-                {(payload?.agent_name ?? 'C')[0]}
-              </div>
-              <span className="text-[11px] font-semibold text-ask-secondary">
-                {payload?.agent_name ?? 'Claude Code'}
-              </span>
-            </div>
-            {payload?.is_working ? (
-              <div className="flex flex-col gap-1.5 pl-0.5">
-                {payload.tool_history && payload.tool_history.length > 0 && (
-                  <ToolHistoryTimeline entries={payload.tool_history.slice(-5)} color={accentColor} />
-                )}
-                {payload.current_tool && (
-                  <ToolStatusLine tool={payload.current_tool} preview={payload.current_preview} color={accentColor} />
-                )}
-                <div className="flex items-center gap-2">
-                  {[0, 1, 2].map(i => (
-                    <div key={i} className="w-1.5 h-1.5 rounded-full animate-bounce"
-                      style={{ backgroundColor: accentColor, animationDelay: `${i * 0.15}s` }} />
-                  ))}
-                  <span className="text-xs text-ask-secondary ml-1">Working…</span>
+          {/* Agent name + working indicator (only shown while working or on empty state) */}
+          {(payload?.is_working || localMessages.length === 0) && (
+            <div className="flex flex-col gap-1.5">
+              <div className="flex items-center gap-1.5">
+                <div
+                  className="w-4 h-4 rounded-full flex items-center justify-center text-[8px] font-bold text-white flex-shrink-0"
+                  style={{ backgroundColor: accentColor }}
+                >
+                  {(payload?.agent_name ?? 'C')[0]}
                 </div>
+                <span className="text-[11px] font-semibold text-ask-secondary">
+                  {payload?.agent_name ?? 'Claude Code'}
+                </span>
               </div>
-            ) : payload?.last_message ? (
-              <div className="text-[15px] text-ask-text">
-                <Markdown>{payload.last_message}</Markdown>
-              </div>
-            ) : (
-              <span className="text-xs text-ask-secondary">Session started</span>
-            )}
-          </div>
+              {payload?.is_working ? (
+                <div className="flex flex-col gap-1.5 pl-0.5">
+                  {payload.tool_history && payload.tool_history.length > 0 && (
+                    <ToolHistoryTimeline entries={payload.tool_history.slice(-5)} color={accentColor} />
+                  )}
+                  {payload.current_tool && (
+                    <ToolStatusLine tool={payload.current_tool} preview={payload.current_preview} color={accentColor} />
+                  )}
+                  <div className="flex items-center gap-2">
+                    {[0, 1, 2].map(i => (
+                      <div key={i} className="w-1.5 h-1.5 rounded-full animate-bounce"
+                        style={{ backgroundColor: accentColor, animationDelay: `${i * 0.15}s` }} />
+                    ))}
+                    <span className="text-xs text-ask-secondary ml-1">Working…</span>
+                  </div>
+                </div>
+              ) : (
+                <span className="text-xs text-ask-secondary">Session started</span>
+              )}
+            </div>
+          )}
           <div ref={bottomRef} />
         </>
       )}


### PR DESCRIPTION
## Summary

- **Hooks are observation-only**: `permission_request.py` now exits immediately with no decision output. Claude Code shows its native terminal prompt; the iPhone card appears in parallel, and the daemon injects the user's iPhone response via `tmux send-keys` if they respond there first.
- **tmux launch path**: `start_session` now calls `create_window` on the terminal-manager to launch Claude Code in `ask:<project>` tmux windows owned by the daemon — no more TIOCSTI, no more AppleScript Terminal.app.
- **Reliable routing**: `_route_text` uses `wait_for_pattern` + `send_text` for tmux sessions. `_tm_send_interrupt` uses `send_interrupt` tool for tmux targets.
- **migrate_to_tmux**: Terminal-observed sessions show a "Move to tmux" action. Calling it upgrades the session to full tmux control in-place.
- **Session block** gains `is_tmux` flag and `tmux_target` field.
- **Heartbeat** checks `pane_alive` for tmux sessions instead of `tty_is_live`.
- `registry.py`: added `tmux_target: str = ''` field to `SessionRecord`.

## Test plan
- [ ] Start a session from iPhone → verify it opens in tmux `ask:<project>` window
- [ ] Send a reply from iPhone → verify wait_for_pattern + send_text delivers it
- [ ] Trigger a permission request → verify hook exits immediately, native prompt shows, iPhone card appears
- [ ] Respond to permission on iPhone → verify daemon injects response into tmux pane
- [ ] Start session in regular Terminal → verify observation still works, "Move to tmux" action appears
- [ ] Click "Move to tmux" → verify session migrates and full control works

🤖 Generated with [Claude Code](https://claude.com/claude-code)