### PR TITLE
fix(ios): add image case to requiresResponse switch

### DIFF
--- a/ask/ask/RemoteKitModels.swift
+++ b/ask/ask/RemoteKitModels.swift
@@ -378,7 +378,7 @@ struct RKBlock: Identifiable {
         switch blockType {
         case .confirmation, .prompt, .chatPrompt, .picker, .list, .detail, .agentSession, .startSession, .quickReply: return true
         case .alert, .status, .infoCard, .iconCard, .claudeMessage, .tile, .countdown, .feedItem,
-             .activityFeed, .compactSummary, .sessionEvent, .diagnostics: return false
+             .activityFeed, .compactSummary, .sessionEvent, .diagnostics, .image: return false
         }
     }
 


### PR DESCRIPTION
Fixes Swift compilation error: `switch must be exhaustive` in `RemoteKitModels.swift:378`. The `image` block type was added to `RKBlockType` but not handled in the `requiresResponse` computed property. Added it to the `false` branch (images don't require a user response).