### PR TITLE
chore: promote v1.1.0 to stable channel

### DIFF
--- a/docs/appcast.xml
+++ b/docs/appcast.xml
@@ -11,7 +11,6 @@
       <sparkle:version>1777482991</sparkle:version>
       <sparkle:shortVersionString>1.1.0</sparkle:shortVersionString>
       <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
-      <sparkle:channel>beta</sparkle:channel>
       <pubDate>Wed, 29 Apr 2026 17:19:22 +0000</pubDate>
       <enclosure
         url="https://github.com/Gr8Gatsby/ask/releases/download/v1.1.0/AskMac-1.1.0.dmg"


### PR DESCRIPTION
Removes the beta channel tag from the v1.1.0 appcast entry so all users on v1.0.0 receive the update via Sparkle.