### PR TITLE
fix(ScriptManager): dispatch onTerminate to MainActor to prevent crash

### DIFF
--- a/AskMac/AskMac.xcodeproj/project.pbxproj
+++ b/AskMac/AskMac.xcodeproj/project.pbxproj
@@ -696,7 +696,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 1.0.0;
+				MARKETING_VERSION = 1.1.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -743,7 +743,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 1.0.0;
+				MARKETING_VERSION = 1.1.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",

--- a/AskMac/Sources/AskMac/Services/ScriptManager.swift
+++ b/AskMac/Sources/AskMac/Services/ScriptManager.swift
@@ -1401,17 +1401,19 @@ final class ScriptManager: @unchecked Sendable {
         let conn = SystemScriptConnection(scriptID: manifest.id, entryURL: entryURL)
 
         conn.onTerminate = { [weak self, weak conn] in
-            guard let self else { return }
-            guard self.systemConnections[manifest.id] === conn else { return }
-            self.systemConnections.removeValue(forKey: manifest.id)
-            self.upsertStatus(manifest.id, name: manifest.name, icon: manifest.icon,
-                              iconImage: self.manifests[manifest.id]?.icon, status: .crashed, isEnabled: true)
-            let delay = self.restartDelays[manifest.id] ?? 1.0
-            self.restartDelays[manifest.id] = min(delay * 2, 30.0)
-            logger.debug("System script \(manifest.id) terminated — restarting in \(Int(delay))s")
-            Task { @MainActor [weak self] in
+            // terminationHandler fires on a background queue — hop to MainActor before
+            // touching any @Observable state to avoid a data race crash.
+            Task { @MainActor [weak self, weak conn] in
+                guard let self else { return }
+                guard self.systemConnections[manifest.id] === conn else { return }
+                self.systemConnections.removeValue(forKey: manifest.id)
+                self.upsertStatus(manifest.id, name: manifest.name, icon: manifest.icon,
+                                  iconImage: self.manifests[manifest.id]?.icon, status: .crashed, isEnabled: true)
+                let delay = self.restartDelays[manifest.id] ?? 1.0
+                self.restartDelays[manifest.id] = min(delay * 2, 30.0)
+                logger.debug("System script \(manifest.id) terminated — restarting in \(Int(delay))s")
                 try? await Task.sleep(for: .seconds(delay))
-                self?.launchSystem(manifest: manifest, scriptDir: scriptDir)
+                self.launchSystem(manifest: manifest, scriptDir: scriptDir)
             }
         }
 


### PR DESCRIPTION
## Problem
`Process.terminationHandler` fires on a background queue. The `onTerminate` closure called `upsertStatus()` which mutates the `@Observable` `scripts` array off the main thread — a data race that crashes the app. This manifested as AskMac disappearing from the menu bar immediately after "Update Scripts" is used (multiple daemon processes start/crash simultaneously, each triggering the handler).

## Fix
Wrap the entire `onTerminate` body in `Task { @MainActor [weak self, weak conn] in ... }`. The separate restart `Task` is merged into the same block so the exponential-backoff delay sleep also runs on the actor.

## Testing
Run Update Scripts with brew-monitor and claude-3 installed — app should stay in menu bar with no crash.