### PR TITLE
fix(sessions): persist claude-3/codex-3 sessions through restarts and idle

### DIFF
--- a/.claude/skills/validate-messaging/SKILL.md
+++ b/.claude/skills/validate-messaging/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: validate-messaging
 description: End-to-end test that messages from the iPhone/web app reach a live Claude Code or Codex tmux/terminal session and that responses flow back. Lets Claude self-verify the supervisor pipeline without asking the user to reinstall AskMac.
-argument-hint: [claude|codex|both]  (default: both)
+argument-hint: [claude|codex|both] [--stress=N]  (default: both, no stress)
 ---
 
 Validates the **iPhone → CloudKit → AskMac → daemon → terminal-manager → tmux/tty → agent → hook → AskMac → iPhone** messaging round-trip on the dev box, end to end. Use this whenever you've changed claude-3, codex-3, terminal-manager, or any of the hooks and want to confirm the round trip still works.
@@ -240,6 +240,44 @@ codex-3    codex3:104cb45519 (codex:skills.0)   PASS         PASS     PASS      
 **Pass criteria for the overall run:** Routing + Hook-back both PASS for every tested agent. Block-flash is advisory — `WARN` is acceptable. Block-in-UI is required for messaging through the UI to work, but the run can still pass with `FAIL` if you fell back to the socket and the rest of the chain works (this signals "daemon side is fine, but a separate UI-emit bug exists").
 
 Then a one-line verdict: `✅ All agents healthy.` or `❌ codex-3 hook timed out — see ~/.ask/logs/codex-3.log @ offset NNN`.
+
+## Stress mode (`--stress=N`)
+
+When the user includes `--stress=N` in `$ARGUMENTS` (default N is omitted = single run), repeat steps 5–9 N times against the same session, with a short sleep between iterations, and report flake rate. Skip step 10 (it's already advisory).
+
+```python
+N = int(<arg>)            # e.g. 20
+results = []              # list of {routing, tmux_recv, hook_back_secs}
+for i in range(N):
+    PROBE = f"stress-{i}-{int(time.time())}-{random.randint(1000,9999)}"
+    offset = os.path.getsize(LOG)
+    requests.post(f"{BACKEND}/respond/{BLOCK_ID}", json={"value": PROBE})
+    time.sleep(1)
+    new = open(LOG, 'rb').read()[offset:].decode(errors='replace')
+    routing = ('reply session=' in new and 'ok=True' in new)
+    tmux_ok = (PROBE in subprocess.run(['tmux','capture-pane','-t',TMUX_TARGET,'-p'],
+                                       capture_output=True, text=True).stdout)
+    hook_t = None
+    for s in range(8):
+        time.sleep(1)
+        new = open(LOG, 'rb').read()[offset:].decode(errors='replace')
+        if 'user_prompt_submit' in new:
+            hook_t = s + 1
+            break
+    results.append({'routing': routing, 'tmux_recv': tmux_ok, 'hook_back_secs': hook_t})
+    time.sleep(3)   # let agent settle / go idle before the next probe
+
+# Summary
+total = len(results)
+routing_ok  = sum(1 for r in results if r['routing'])
+tmux_ok     = sum(1 for r in results if r['tmux_recv'])
+hook_ok     = sum(1 for r in results if r['hook_back_secs'] is not None)
+hook_secs   = [r['hook_back_secs'] for r in results if r['hook_back_secs'] is not None]
+print(f"stress {total}× — routing {routing_ok}/{total}, tmux {tmux_ok}/{total}, "
+      f"hook {hook_ok}/{total} (median {sorted(hook_secs)[len(hook_secs)//2] if hook_secs else 'n/a'}s)")
+```
+
+**Pass bar for production-grade:** `routing == N`, `tmux == N`, `hook >= 0.95 * N`, median hook latency ≤ 2s. Anything below that is a flake to investigate before claiming the path is solid.
 
 ## Common failure modes
 

--- a/.claude/skills/validate-messaging/SKILL.md
+++ b/.claude/skills/validate-messaging/SKILL.md
@@ -1,0 +1,236 @@
+---
+name: validate-messaging
+description: End-to-end test that messages from the iPhone/web app reach a live Claude Code or Codex tmux/terminal session and that responses flow back. Lets Claude self-verify the supervisor pipeline without asking the user to reinstall AskMac.
+argument-hint: [claude|codex|both]  (default: both)
+---
+
+Validates the **iPhone → CloudKit → AskMac → daemon → terminal-manager → tmux/tty → agent → hook → CloudKit → iPhone** messaging round-trip on the dev box, end to end. Use this whenever you've changed claude-3, codex-3, terminal-manager, or any of the hooks and want to confirm the round trip still works.
+
+## What this tests
+
+```
+[test driver]                                                          [agent]
+     │                                                                    ▲
+     ▼                                                                    │
+ mock /respond ──→ daemon socket ──→ inject_tty/send_text ──→ tty/tmux ──┘
+     ▲                                                                    │
+     │                                                                    ▼
+ blocks.json ◀─── emit_block ◀─── _handle_user_prompt ◀─── hook fires ◀───┘
+```
+
+If a message goes in via the test driver and a fresh hook event lands in the daemon log within a few seconds, the round trip is healthy.
+
+## When to use vs. NOT use
+
+**Use when:**
+- You changed code in `ask/scripts/claude-3/`, `ask/scripts/codex-3/`, the hooks, or `terminal-manager`
+- A user reports a session disappearing, messages not arriving, or hook events not firing
+- You want to confirm a fix before pushing
+
+**Do NOT use when:**
+- You only changed the web/iOS UI (no daemon changes) — run `npm run dev` and inspect manually
+- The user is mid-session in the target tmux pane — the test injects a visible message into their terminal
+
+## Prerequisites (assumed live on the dev box)
+
+These must be running before the skill executes. The skill **detects and reports**, but does NOT auto-start AskMac (a debugger is usually attached):
+
+| Component | Check | If missing |
+|---|---|---|
+| AskMac (Xcode build) | `pgrep -fl AskMac` | Tell the user to launch from Xcode |
+| claude-3 daemon | `test -S ~/.ask/sockets/claude-3.sock` | Reload scripts in AskMac (↺ in Settings → Actions) |
+| codex-3 daemon | `test -S ~/.ask/sockets/codex-3.sock` | Same |
+
+These can be started by the skill if missing:
+
+| Component | Check | Auto-start command |
+|---|---|---|
+| Mock server | `curl -sS http://localhost:4243/blocks` | `cd web && PORT=4243 npx tsx mock/server.ts > /tmp/mock-server.log 2>&1 &` |
+| Vite dev | `curl -sS http://localhost:5173/` | `cd web && npx vite > /tmp/vite.log 2>&1 &` |
+
+## Steps
+
+### 1 — Resolve which agent(s) to test
+
+`$ARGUMENTS` is `claude`, `codex`, or `both` (default both). Map to script IDs `claude-3` and/or `codex-3`.
+
+### 2 — Preflight
+
+Run all checks in parallel via Bash. Stop and report if any **required** prereq fails. Auto-start the optional components.
+
+```bash
+pgrep -fl AskMac >/dev/null || echo "MISSING: AskMac"
+test -S "$HOME/.ask/sockets/claude-3.sock" || echo "MISSING: claude-3 socket"
+test -S "$HOME/.ask/sockets/codex-3.sock"  || echo "MISSING: codex-3 socket"
+curl -fsS http://localhost:4243/blocks > /dev/null || echo "START: mock server"
+curl -fsS http://localhost:5173/        > /dev/null || echo "START: vite"
+```
+
+If `START: mock server` appears, run `cd /Users/kevin/Documents/code/ask/web && PORT=4243 npx tsx mock/server.ts > /tmp/mock-server.log 2>&1 &` and wait until `curl http://localhost:4243/blocks` returns 200.
+
+If `START: vite` appears, run `cd /Users/kevin/Documents/code/ask/web && npx vite > /tmp/vite.log 2>&1 &` and poll until `curl http://localhost:5173/` returns 200.
+
+### 3 — Pick a target session per agent
+
+Read the daemon's session registry and pick a session in `state` `idle`, `awaiting_user`, or `running_tool` (skip `stopped`, `starting`). Prefer sessions with a populated `tty` or `tmux_target` so the test can verify the actual terminal received the message.
+
+```bash
+python3 - <<'PY'
+import json, os
+for agent, path in [
+    ('claude-3', os.path.expanduser('~/.ask/claude3-sessions.json')),
+    ('codex-3',  os.path.expanduser('~/.ask/codex3-sessions.json')),
+]:
+    try:
+        sessions = json.load(open(path))
+    except Exception:
+        print(f'{agent}: NO SESSIONS')
+        continue
+    for sid, s in sessions.items():
+        state = s.get('state', '?')
+        if state in ('stopped', 'starting'):
+            continue
+        print(f'{agent}\t{sid}\t{state}\ttty={s.get("tty","")}\ttmux={s.get("tmux_target","")}\tcwd={s.get("cwd","")}')
+PY
+```
+
+**If no usable sessions exist for an agent**, mark that agent as `SKIPPED — no live sessions` and continue. Do NOT auto-launch a session — that opens a Terminal window the user didn't ask for.
+
+⚠️ **Never target the Claude Code session that this skill is running in** — it's the parent process. Filter out any claude-3 session whose `raw_id` matches `$CLAUDE_SESSION_ID` (the env var the agent is running under), or — if that's not available — whose `tty` is empty AND `tmux_target` is empty (the in-process supervisor session has no routing). Prefer claude-3 sessions with a real `tty` or `tmux_target`.
+
+### 4 — Snapshot the daemon log offset
+
+For each agent under test, record the current size of its log so we can read just the new lines later:
+
+```bash
+CLAUDE_OFFSET=$(wc -c < ~/.ask/logs/claude-3.log 2>/dev/null || echo 0)
+CODEX_OFFSET=$(wc -c <  ~/.ask/logs/codex-3.log  2>/dev/null || echo 0)
+```
+
+### 5 — Inject the test message
+
+Generate a unique probe string per session so we can grep for it cleanly:
+
+```
+PROBE="ask-validate-$(date +%s)-${RANDOM}"
+```
+
+Send via the **mock server's HTTP endpoint** (this is the same path the iPhone/web UI uses). The skill should NOT call the daemon socket directly — the point is to test the full chain that the user sees.
+
+The mock server resolves the block by `blockID` and looks up its `scriptID` and `session_id` from the payload. The block ID is `<agent>-session-<suffix>`, where `<suffix>` is the **full** segment after the colon in `session_id`:
+
+```bash
+SUFFIX="${SESSION_ID##*:}"            # e.g. "104cb45519" (claude/codex both use full suffix)
+# claude-3:  block id = claude3-session-${SUFFIX}
+# codex-3:   block id = codex3-session-${SUFFIX}
+BLOCK_ID="${AGENT_PREFIX}-session-${SUFFIX}"
+
+curl -sS -X POST "http://localhost:4243/respond/${BLOCK_ID}" \
+  -H 'Content-Type: application/json' \
+  -d "{\"value\":\"${PROBE}\"}"
+```
+
+If the block is **not currently in `~/.ask/blocks.json`** (which happens when the daemon hasn't re-emitted the session block yet, or AskMac dropped it on TTL), the mock server's `/respond/<blockID>` endpoint will fall through to its `clearBlock` default. In that case **fall back to direct socket** as a covered failure mode, and report it as a UI-path gap:
+
+```bash
+python3 - <<PY
+import socket, json
+sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+sock.settimeout(5)
+sock.connect(os.path.expanduser('~/.ask/sockets/${AGENT}.sock'))
+sock.sendall(json.dumps({'type':'ui_respond','session_id':'${SESSION_ID}','value':'${PROBE}'}).encode())
+sock.shutdown(socket.SHUT_WR)
+print(sock.recv(4096).decode())
+PY
+```
+
+### 6 — Verify the daemon routed the message
+
+Read the daemon log starting from the offset captured in step 4 and grep for the probe and routing markers:
+
+```bash
+tail -c +$((CLAUDE_OFFSET+1)) ~/.ask/logs/claude-3.log | grep -E "${PROBE}|ui_respond|inject_tty|send_text"
+```
+
+**PASS criteria for routing:**
+- A line matching `socket event type='ui_respond'` for the target session
+- A line containing `reply session=...` with `ok=True`
+
+If both are present, the message reached the daemon and was routed. If routing failed (`ok=False`), report the routing error and stop.
+
+### 7 — Verify the agent received the message (tmux only)
+
+For sessions with `tmux_target`, capture the pane and look for the probe text:
+
+```bash
+tmux capture-pane -t "${TMUX_TARGET}" -p | grep -F "${PROBE}"
+```
+
+For tty-only sessions (claude-3 plain-terminal): there's no portable way to read the terminal's scrollback. Skip this check and note "agent-receive verification skipped (no tmux)".
+
+### 8 — Wait for the hook round-trip
+
+Poll the daemon log (every 1s, up to 8s) for a fresh `user_prompt_submit` event with a session_id that matches the target session's `raw_id`. This is the agent calling its own hook to acknowledge the typed message:
+
+```bash
+for i in $(seq 1 8); do
+  if tail -c +$((OFFSET+1)) ~/.ask/logs/${AGENT}.log | grep -q "user_prompt_submit.*${RAW_ID:0:11}"; then
+    echo "HOOK FIRED"
+    break
+  fi
+  sleep 1
+done
+```
+
+**PASS criteria for round-trip:** the hook fires within 8s. **WARN if delayed** (>4s) — agent is alive but slow. **FAIL** if no hook fires within 8s — the message was injected but the agent didn't see it (terminal disconnected, agent crashed, or tmux pane is in a non-input state like a scroll buffer).
+
+### 9 — Verify the block updates in blocks.json
+
+After the hook fires, the daemon should call `_emit_session_block` again with the new `last_prompt`/`first_prompt`. Read `~/.ask/blocks.json` and confirm the agent_session block's payload now contains the probe:
+
+```bash
+python3 - <<PY
+import json, os
+data = json.load(open(os.path.expanduser('~/.ask/blocks.json')))
+for b in data.get('blocks', []):
+    if b['blockID'] == '${BLOCK_ID}':
+        payload = json.loads(b['payload'])
+        print('last_prompt:', payload.get('last_prompt',''))
+        print('preview:    ', payload.get('preview',''))
+        break
+else:
+    print('BLOCK NOT FOUND')
+PY
+```
+
+**PASS criteria for UI update:** `last_prompt` or `preview` contains `${PROBE}`. If `BLOCK NOT FOUND`, the daemon emitted but AskMac didn't persist the block to disk — flag this as a separate problem.
+
+### 10 — Report
+
+Print a single table summarising each tested agent:
+
+```
+Agent      Session                         Routing  Tmux-recv  Hook-back  Block-updated
+claude-3   claude3:582bdb8a25 (no tty)     PASS     SKIP       PASS       PASS
+codex-3    codex3:104cb45519 (codex:skills)PASS     PASS       PASS (1s)  PASS
+```
+
+Then a one-line verdict: `✅ All agents healthy.` or `❌ codex-3 hook timed out — see ~/.ask/logs/codex-3.log:NNN`.
+
+If anything failed, link to the relevant log file with the byte offset that was captured at step 4 so the user can `tail -c +OFFSET file | less` themselves.
+
+## Common failure modes and what they mean
+
+| Symptom | Likely cause | Where to look |
+|---|---|---|
+| `MISSING: claude-3 socket` after AskMac is up | Daemon crashed on startup | `~/.ask/logs/claude-3.log` head |
+| Routing PASS, hook-back FAIL | tmux pane is in scroll/copy mode, or agent crashed | `tmux capture-pane -t ... -p` for the agent's prompt |
+| Routing PASS, tmux-recv FAIL | `inject_tty`/`send_text` returned ok but text never arrived — terminal-manager-agent mismatch | `~/.ask/logs/terminal-manager.log` |
+| Hook-back PASS, block-updated FAIL | Daemon emitted but AskMac dropped the block | AskMac console (Xcode) for `emit_block` errors |
+| `BLOCK NOT FOUND` from the start | Daemon hasn't re-emitted since restart — `_emit_session_block` dedup gating may be skipping a re-emit | Restart the script via the AskMac reload button |
+
+## Notes on self-sufficiency
+
+- This skill **does not require an AskMac restart** — daemons reload via the Settings → Actions ↺ button, which Claude can suggest but the user must click. After deployment via `/deploy-scripts`, run this skill instead of asking the user to reinstall.
+- The skill **does not require the iPhone** — it exercises the same `/respond/<blockID>` HTTP endpoint that the iPhone hits via CloudKit + the web bridge. If this skill passes, the iPhone path passes too (assuming iPhone↔CloudKit auth is healthy, which is a separate concern).
+- The skill **must NOT target its own session** — see the warning in step 3.

--- a/.claude/skills/validate-messaging/SKILL.md
+++ b/.claude/skills/validate-messaging/SKILL.md
@@ -4,7 +4,7 @@ description: End-to-end test that messages from the iPhone/web app reach a live 
 argument-hint: [claude|codex|both]  (default: both)
 ---
 
-Validates the **iPhone → CloudKit → AskMac → daemon → terminal-manager → tmux/tty → agent → hook → CloudKit → iPhone** messaging round-trip on the dev box, end to end. Use this whenever you've changed claude-3, codex-3, terminal-manager, or any of the hooks and want to confirm the round trip still works.
+Validates the **iPhone → CloudKit → AskMac → daemon → terminal-manager → tmux/tty → agent → hook → AskMac → iPhone** messaging round-trip on the dev box, end to end. Use this whenever you've changed claude-3, codex-3, terminal-manager, or any of the hooks and want to confirm the round trip still works.
 
 ## What this tests
 
@@ -12,13 +12,13 @@ Validates the **iPhone → CloudKit → AskMac → daemon → terminal-manager �
 [test driver]                                                          [agent]
      │                                                                    ▲
      ▼                                                                    │
- mock /respond ──→ daemon socket ──→ inject_tty/send_text ──→ tty/tmux ──┘
+ AskMac /respond ──→ daemon socket ──→ inject_tty/send_text ──→ tty/tmux ─┘
      ▲                                                                    │
      │                                                                    ▼
- blocks.json ◀─── emit_block ◀─── _handle_user_prompt ◀─── hook fires ◀───┘
+ AskMac /blocks ◀── emit_block ◀── _handle_user_prompt ◀── hook fires ◀───┘
 ```
 
-If a message goes in via the test driver and a fresh hook event lands in the daemon log within a few seconds, the round trip is healthy.
+The test exercises the same HTTP endpoints that the iPhone hits via CloudKit and that the web app hits via the vite proxy. If a message goes in via the test driver and a fresh hook event lands in the daemon log within a few seconds, the round trip is healthy.
 
 ## When to use vs. NOT use
 
@@ -31,22 +31,25 @@ If a message goes in via the test driver and a fresh hook event lands in the dae
 - You only changed the web/iOS UI (no daemon changes) — run `npm run dev` and inspect manually
 - The user is mid-session in the target tmux pane — the test injects a visible message into their terminal
 
-## Prerequisites (assumed live on the dev box)
+## Backend selection
 
-These must be running before the skill executes. The skill **detects and reports**, but does NOT auto-start AskMac (a debugger is usually attached):
+The skill calls a single backend that exposes `/blocks` and `/respond/<blockID>`. There are two:
+
+| Port | Backend | When |
+|---|---|---|
+| **4242** | AskMac LocalHTTPServer (real, in DEBUG builds) | AskMac is running from Xcode — preferred |
+| **4243** | Mock server (`web/mock/server.ts`) | AskMac is not running — fallback |
+
+⚠️ The mock server reads `~/.ask/blocks.json`, which **AskMac does not currently write to** — so the mock server's view of `agent_session` blocks is stale. Always prefer port 4242 when AskMac is up. The skill picks 4242 if it answers, else 4243, else fails the preflight.
+
+## Prerequisites
 
 | Component | Check | If missing |
 |---|---|---|
 | AskMac (Xcode build) | `pgrep -fl AskMac` | Tell the user to launch from Xcode |
 | claude-3 daemon | `test -S ~/.ask/sockets/claude-3.sock` | Reload scripts in AskMac (↺ in Settings → Actions) |
 | codex-3 daemon | `test -S ~/.ask/sockets/codex-3.sock` | Same |
-
-These can be started by the skill if missing:
-
-| Component | Check | Auto-start command |
-|---|---|---|
-| Mock server | `curl -sS http://localhost:4243/blocks` | `cd web && PORT=4243 npx tsx mock/server.ts > /tmp/mock-server.log 2>&1 &` |
-| Vite dev | `curl -sS http://localhost:5173/` | `cd web && npx vite > /tmp/vite.log 2>&1 &` |
+| Backend on 4242 OR 4243 | `curl -fsS http://localhost:4242/blocks` then 4243 | If AskMac is running on 4242, you're done. Otherwise start the mock server (see below). |
 
 ## Steps
 
@@ -56,19 +59,29 @@ These can be started by the skill if missing:
 
 ### 2 — Preflight
 
-Run all checks in parallel via Bash. Stop and report if any **required** prereq fails. Auto-start the optional components.
-
 ```bash
 pgrep -fl AskMac >/dev/null || echo "MISSING: AskMac"
 test -S "$HOME/.ask/sockets/claude-3.sock" || echo "MISSING: claude-3 socket"
 test -S "$HOME/.ask/sockets/codex-3.sock"  || echo "MISSING: codex-3 socket"
-curl -fsS http://localhost:4243/blocks > /dev/null || echo "START: mock server"
-curl -fsS http://localhost:5173/        > /dev/null || echo "START: vite"
+
+# Pick a backend
+if curl -fsS http://localhost:4242/blocks > /dev/null 2>&1; then
+  BACKEND=http://localhost:4242
+  echo "BACKEND: AskMac (4242)"
+elif curl -fsS http://localhost:4243/blocks > /dev/null 2>&1; then
+  BACKEND=http://localhost:4243
+  echo "BACKEND: mock (4243) — agent_session blocks may be stale"
+else
+  # Try to start mock as last resort
+  cd /Users/kevin/Documents/code/ask/web && PORT=4243 npx tsx mock/server.ts > /tmp/mock-server.log 2>&1 &
+  sleep 2
+  curl -fsS http://localhost:4243/blocks > /dev/null && BACKEND=http://localhost:4243 \
+    && echo "BACKEND: mock (4243) — started" \
+    || echo "MISSING: no backend on 4242 or 4243"
+fi
 ```
 
-If `START: mock server` appears, run `cd /Users/kevin/Documents/code/ask/web && PORT=4243 npx tsx mock/server.ts > /tmp/mock-server.log 2>&1 &` and wait until `curl http://localhost:4243/blocks` returns 200.
-
-If `START: vite` appears, run `cd /Users/kevin/Documents/code/ask/web && npx vite > /tmp/vite.log 2>&1 &` and poll until `curl http://localhost:5173/` returns 200.
+Stop and report if any **required** prereq fails.
 
 ### 3 — Pick a target session per agent
 
@@ -98,43 +111,51 @@ PY
 
 ⚠️ **Never target the Claude Code session that this skill is running in** — it's the parent process. Filter out any claude-3 session whose `raw_id` matches `$CLAUDE_SESSION_ID` (the env var the agent is running under), or — if that's not available — whose `tty` is empty AND `tmux_target` is empty (the in-process supervisor session has no routing). Prefer claude-3 sessions with a real `tty` or `tmux_target`.
 
-### 4 — Snapshot the daemon log offset
+### 4 — Verify the agent_session block exists in the backend
 
-For each agent under test, record the current size of its log so we can read just the new lines later:
+The backend's `/blocks` is the single source of truth that the iPhone/web UI sees. If the agent_session block isn't there, the user can't message the session through the UI even though the daemon registry says it's alive.
 
 ```bash
-CLAUDE_OFFSET=$(wc -c < ~/.ask/logs/claude-3.log 2>/dev/null || echo 0)
-CODEX_OFFSET=$(wc -c <  ~/.ask/logs/codex-3.log  2>/dev/null || echo 0)
+SUFFIX="${SESSION_ID##*:}"            # e.g. "104cb45519" — full segment after the colon
+BLOCK_ID="${AGENT_PREFIX}-session-${SUFFIX}"   # claude3-session-... or codex3-session-...
+
+curl -fsS "${BACKEND}/blocks" | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+ids = [b['blockID'] for b in data.get('blocks', [])]
+print('present' if '${BLOCK_ID}' in ids else 'MISSING — UI cannot show this session')
+"
 ```
 
-### 5 — Inject the test message
+If MISSING, mark the agent as `UI-PATH FAIL` but keep going via socket fallback so we still know if routing itself works.
 
-Generate a unique probe string per session so we can grep for it cleanly:
+### 5 — Snapshot the daemon log offset
+
+Record the current size of the daemon's log so we can read just the new lines later:
+
+```bash
+OFFSET=$(wc -c < ~/.ask/logs/${AGENT}.log 2>/dev/null || echo 0)
+```
+
+### 6 — Inject the test message via the backend (UI path)
 
 ```
 PROBE="ask-validate-$(date +%s)-${RANDOM}"
 ```
 
-Send via the **mock server's HTTP endpoint** (this is the same path the iPhone/web UI uses). The skill should NOT call the daemon socket directly — the point is to test the full chain that the user sees.
-
-The mock server resolves the block by `blockID` and looks up its `scriptID` and `session_id` from the payload. The block ID is `<agent>-session-<suffix>`, where `<suffix>` is the **full** segment after the colon in `session_id`:
-
 ```bash
-SUFFIX="${SESSION_ID##*:}"            # e.g. "104cb45519" (claude/codex both use full suffix)
-# claude-3:  block id = claude3-session-${SUFFIX}
-# codex-3:   block id = codex3-session-${SUFFIX}
-BLOCK_ID="${AGENT_PREFIX}-session-${SUFFIX}"
-
-curl -sS -X POST "http://localhost:4243/respond/${BLOCK_ID}" \
+curl -sS -X POST "${BACKEND}/respond/${BLOCK_ID}" \
   -H 'Content-Type: application/json' \
   -d "{\"value\":\"${PROBE}\"}"
 ```
 
-If the block is **not currently in `~/.ask/blocks.json`** (which happens when the daemon hasn't re-emitted the session block yet, or AskMac dropped it on TTL), the mock server's `/respond/<blockID>` endpoint will fall through to its `clearBlock` default. In that case **fall back to direct socket** as a covered failure mode, and report it as a UI-path gap:
+Expected response: `{"ok":true}`. If the response is anything else, the backend rejected the request — read the response body for the reason.
+
+If the agent_session block was MISSING in step 4, the backend can't resolve `scriptID` from `blockID` and will fail. Fall back to direct socket so we can still validate the daemon-and-down portion:
 
 ```bash
 python3 - <<PY
-import socket, json
+import socket, json, os
 sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
 sock.settimeout(5)
 sock.connect(os.path.expanduser('~/.ask/sockets/${AGENT}.sock'))
@@ -144,93 +165,94 @@ print(sock.recv(4096).decode())
 PY
 ```
 
-### 6 — Verify the daemon routed the message
+### 7 — Verify the daemon routed the message
 
-Read the daemon log starting from the offset captured in step 4 and grep for the probe and routing markers:
+Read the daemon log starting from the offset captured in step 5:
 
 ```bash
-tail -c +$((CLAUDE_OFFSET+1)) ~/.ask/logs/claude-3.log | grep -E "${PROBE}|ui_respond|inject_tty|send_text"
+tail -c +$((OFFSET+1)) ~/.ask/logs/${AGENT}.log | grep -E "${PROBE}|ui_respond|block response|inject_tty|send_text|reply session"
 ```
 
-**PASS criteria for routing:**
-- A line matching `socket event type='ui_respond'` for the target session
-- A line containing `reply session=...` with `ok=True`
+**PASS criteria:** a `reply session=...` line with `ok=True` for the target session, plus an entry-point line:
+- `socket event type='ui_respond'` (via mock-server `/respond` → daemon socket), OR
+- `block response block_id='...'` (via AskMac MCP `notifications/message` from `/respond` on port 4242)
 
-If both are present, the message reached the daemon and was routed. If routing failed (`ok=False`), report the routing error and stop.
+The two paths come in through different doors but both must produce `reply session=... ok=True` to count as routed.
 
-### 7 — Verify the agent received the message (tmux only)
+### 8 — Verify the agent received the message (tmux only)
 
-For sessions with `tmux_target`, capture the pane and look for the probe text:
+For sessions with `tmux_target`:
 
 ```bash
 tmux capture-pane -t "${TMUX_TARGET}" -p | grep -F "${PROBE}"
 ```
 
-For tty-only sessions (claude-3 plain-terminal): there's no portable way to read the terminal's scrollback. Skip this check and note "agent-receive verification skipped (no tmux)".
+For tty-only sessions (claude-3 plain-terminal): there's no portable way to read the terminal's scrollback. Skip and note "agent-receive verification skipped (no tmux)".
 
-### 8 — Wait for the hook round-trip
+### 9 — Wait for the hook round-trip
 
-Poll the daemon log (every 1s, up to 8s) for a fresh `user_prompt_submit` event with a session_id that matches the target session's `raw_id`. This is the agent calling its own hook to acknowledge the typed message:
+Poll the daemon log (every 1s, up to 8s) for a fresh `user_prompt_submit` event:
 
 ```bash
 for i in $(seq 1 8); do
-  if tail -c +$((OFFSET+1)) ~/.ask/logs/${AGENT}.log | grep -q "user_prompt_submit.*${RAW_ID:0:11}"; then
-    echo "HOOK FIRED"
+  if tail -c +$((OFFSET+1)) ~/.ask/logs/${AGENT}.log | grep -q "user_prompt_submit"; then
+    echo "HOOK FIRED ($i s)"
     break
   fi
   sleep 1
 done
 ```
 
-**PASS criteria for round-trip:** the hook fires within 8s. **WARN if delayed** (>4s) — agent is alive but slow. **FAIL** if no hook fires within 8s — the message was injected but the agent didn't see it (terminal disconnected, agent crashed, or tmux pane is in a non-input state like a scroll buffer).
+**PASS:** hook fires within 8s. **WARN if delayed** (>4s). **FAIL** if no hook fires within 8s — the message was injected but the agent didn't see it (terminal disconnected, agent crashed, or tmux pane is in a non-input state like a scroll buffer).
 
-### 9 — Verify the block updates in blocks.json
+### 10 — (Advisory) Verify the block payload briefly reflected the probe
 
-After the hook fires, the daemon should call `_emit_session_block` again with the new `last_prompt`/`first_prompt`. Read `~/.ask/blocks.json` and confirm the agent_session block's payload now contains the probe:
+This check is racy: after `_handle_block_response` sets `preview = probe`, the agent's `session_idle` hook fires shortly after and clears `preview = ''`. So this check **must run immediately after step 7** (routing PASS), before step 9. If the agent is fast, the probe will already be gone by the time you re-fetch.
+
+Treat this as **advisory**: if it's `updated`, great. If it's `NOT updated` but routing + hook-back both passed, do not fail the run — log it as a warning and move on.
 
 ```bash
-python3 - <<PY
-import json, os
-data = json.load(open(os.path.expanduser('~/.ask/blocks.json')))
+# Run RIGHT AFTER step 7 (do not sleep)
+curl -fsS "${BACKEND}/blocks" | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
 for b in data.get('blocks', []):
     if b['blockID'] == '${BLOCK_ID}':
-        payload = json.loads(b['payload'])
-        print('last_prompt:', payload.get('last_prompt',''))
-        print('preview:    ', payload.get('preview',''))
+        payload = json.loads(b.get('payload','{}'))
+        text = (payload.get('last_prompt') or '') + (payload.get('preview') or '')
+        print('updated' if '${PROBE}' in text else 'NOT updated (likely already cleared by session_idle)')
         break
 else:
-    print('BLOCK NOT FOUND')
-PY
+    print('block disappeared from backend')
+"
 ```
 
-**PASS criteria for UI update:** `last_prompt` or `preview` contains `${PROBE}`. If `BLOCK NOT FOUND`, the daemon emitted but AskMac didn't persist the block to disk — flag this as a separate problem.
-
-### 10 — Report
+### 11 — Report
 
 Print a single table summarising each tested agent:
 
 ```
-Agent      Session                         Routing  Tmux-recv  Hook-back  Block-updated
-claude-3   claude3:582bdb8a25 (no tty)     PASS     SKIP       PASS       PASS
-codex-3    codex3:104cb45519 (codex:skills)PASS     PASS       PASS (1s)  PASS
+Agent      Session                              Block-in-UI  Routing  Tmux-recv  Hook-back  Block-flash
+claude-3   claude3:582bdb8a25 (no tty)          PASS         PASS     SKIP       PASS (1s)  WARN (cleared)
+codex-3    codex3:104cb45519 (codex:skills.0)   PASS         PASS     PASS       PASS (1s)  PASS
 ```
 
-Then a one-line verdict: `✅ All agents healthy.` or `❌ codex-3 hook timed out — see ~/.ask/logs/codex-3.log:NNN`.
+**Pass criteria for the overall run:** Routing + Hook-back both PASS for every tested agent. Block-flash is advisory — `WARN` is acceptable. Block-in-UI is required for messaging through the UI to work, but the run can still pass with `FAIL` if you fell back to the socket and the rest of the chain works (this signals "daemon side is fine, but a separate UI-emit bug exists").
 
-If anything failed, link to the relevant log file with the byte offset that was captured at step 4 so the user can `tail -c +OFFSET file | less` themselves.
+Then a one-line verdict: `✅ All agents healthy.` or `❌ codex-3 hook timed out — see ~/.ask/logs/codex-3.log @ offset NNN`.
 
-## Common failure modes and what they mean
+## Common failure modes
 
 | Symptom | Likely cause | Where to look |
 |---|---|---|
 | `MISSING: claude-3 socket` after AskMac is up | Daemon crashed on startup | `~/.ask/logs/claude-3.log` head |
+| `Block-in-UI FAIL` for an idle session | Daemon emitted but `_emitted_payloads` cache may be hiding a re-emit; or AskMac was restarted but daemon didn't see it | Restart the script via the AskMac reload button — that drops the daemon's dedup cache |
 | Routing PASS, hook-back FAIL | tmux pane is in scroll/copy mode, or agent crashed | `tmux capture-pane -t ... -p` for the agent's prompt |
 | Routing PASS, tmux-recv FAIL | `inject_tty`/`send_text` returned ok but text never arrived — terminal-manager-agent mismatch | `~/.ask/logs/terminal-manager.log` |
-| Hook-back PASS, block-updated FAIL | Daemon emitted but AskMac dropped the block | AskMac console (Xcode) for `emit_block` errors |
-| `BLOCK NOT FOUND` from the start | Daemon hasn't re-emitted since restart — `_emit_session_block` dedup gating may be skipping a re-emit | Restart the script via the AskMac reload button |
+| Hook-back PASS, block-updated FAIL | Daemon emitted but AskMac dropped the block, or 4243-mock-only run reading stale `blocks.json` | Use port 4242 (real AskMac), not 4243 (mock). |
 
 ## Notes on self-sufficiency
 
-- This skill **does not require an AskMac restart** — daemons reload via the Settings → Actions ↺ button, which Claude can suggest but the user must click. After deployment via `/deploy-scripts`, run this skill instead of asking the user to reinstall.
-- The skill **does not require the iPhone** — it exercises the same `/respond/<blockID>` HTTP endpoint that the iPhone hits via CloudKit + the web bridge. If this skill passes, the iPhone path passes too (assuming iPhone↔CloudKit auth is healthy, which is a separate concern).
-- The skill **must NOT target its own session** — see the warning in step 3.
+- The skill **does not require an AskMac restart** — daemons reload via the Settings → Actions ↺ button, which Claude can suggest but the user must click. After deployment via `/deploy-scripts`, run this skill instead of asking the user to reinstall.
+- The skill **does not require the iPhone** — it exercises the same `/respond/<blockID>` HTTP endpoint that the iPhone hits via CloudKit and the web app hits via the vite `/api` proxy. If this skill passes against `:4242`, the iPhone path passes too (assuming iPhone↔CloudKit auth is healthy, which is a separate concern).
+- The skill **must NOT target its own Claude Code session** — see the warning in step 3.

--- a/AskMac/AskMac.xcodeproj/project.pbxproj
+++ b/AskMac/AskMac.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		0038B1D02FF68672B1F0C367 /* MacFeedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9B898B8784054153152350B /* MacFeedView.swift */; };
 		0675DD58EE11FCC5FB9C0FE9 /* MCPConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D62BC3ACCF548A6926C83A4 /* MCPConnection.swift */; };
 		0D696DD556936DCEC1997BEB /* TerminalMonitorServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F05D2937205C7D5DED51EEA /* TerminalMonitorServiceTests.swift */; };
+		1975CC7073DB9F26E241ABC9 /* AskMacUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDCF52A6340FE16768FB2862 /* AskMacUITests.swift */; };
 		2A8C999FCCA1DDA22786079F /* BlockService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 944903959A55B26822A4701D /* BlockService.swift */; };
 		2DDF70E89F94833C7837389B /* KeychainService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 504764CE87B4791BDD3ABFD8 /* KeychainService.swift */; };
 		318C46CF42445B388B5E6739 /* libAskMacCore.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 52C75A2FE8B8444D42AF146A /* libAskMacCore.a */; };
@@ -73,6 +74,13 @@
 			remoteGlobalIDString = B5A9CAFDC0F194D4B590DD08;
 			remoteInfo = AskMacCore;
 		};
+		4536646E2CA60D64CB7AC2F1 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = B36075E18F257B51F15F8871 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = E59CE13E0F81B53C77683FB1;
+			remoteInfo = AskMac;
+		};
 		6FE9BDFCF593445A9D06CA1D /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = B36075E18F257B51F15F8871 /* Project object */;
@@ -106,6 +114,7 @@
 		402957444B4A25CFEA7F3BBC /* BlockPreviewStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockPreviewStatus.swift; sourceTree = "<group>"; };
 		4067387D7D1B4F65BAB0B74F /* ResponsePoller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResponsePoller.swift; sourceTree = "<group>"; };
 		406DAAC6415E06CCCF55B8BB /* BlockPreviewViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockPreviewViews.swift; sourceTree = "<group>"; };
+		41DF70CF15A12234B2D92BC6 /* AskMacUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AskMacUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		42EC5BBB34D453B2F332AF00 /* CloudKitService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudKitService.swift; sourceTree = "<group>"; };
 		468C8037AACD02ADA46B757B /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		4AF213161B330FC04561C69E /* InstalledScript.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstalledScript.swift; sourceTree = "<group>"; };
@@ -138,6 +147,7 @@
 		C8C66FCA9A17628445E9ECCA /* TaskServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskServiceTests.swift; sourceTree = "<group>"; };
 		CA1CC49C770BDCD1EB75B351 /* ScriptManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScriptManager.swift; sourceTree = "<group>"; };
 		CA7C37B37BDE67ED30528117 /* AppSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSettings.swift; sourceTree = "<group>"; };
+		CDCF52A6340FE16768FB2862 /* AskMacUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AskMacUITests.swift; sourceTree = "<group>"; };
 		CFD416A6077DEA3848608AB1 /* TerminalMonitorService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalMonitorService.swift; sourceTree = "<group>"; };
 		DDBAEE7F7B9B1616758FEDE2 /* ScriptInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScriptInstaller.swift; sourceTree = "<group>"; };
 		E8A9A572F12084AD9797F8B1 /* AppUpdater.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUpdater.swift; sourceTree = "<group>"; };
@@ -238,8 +248,18 @@
 				193160741783FAD848251CCB /* AskMac */,
 				C684A63C98AF3DBF68A15174 /* AskMacCore */,
 				68C19D81F1E89782D63E471F /* AskMacTests */,
+				873A232557D499BAD6340564 /* AskMacUITests */,
 				FB0D7985181B5E1A4D8FBDA2 /* Products */,
 			);
+			sourceTree = "<group>";
+		};
+		873A232557D499BAD6340564 /* AskMacUITests */ = {
+			isa = PBXGroup;
+			children = (
+				CDCF52A6340FE16768FB2862 /* AskMacUITests.swift */,
+			);
+			name = AskMacUITests;
+			path = Tests/AskMacUITests;
 			sourceTree = "<group>";
 		};
 		A2E07FB35B1F8AB22AB98A99 /* Views */ = {
@@ -293,6 +313,7 @@
 			children = (
 				6A9CBCABF50128C52895B960 /* AskMac.app */,
 				00C7F95F08E74502C870234D /* AskMacTests.xctest */,
+				41DF70CF15A12234B2D92BC6 /* AskMacUITests.xctest */,
 				52C75A2FE8B8444D42AF146A /* libAskMacCore.a */,
 			);
 			name = Products;
@@ -360,6 +381,24 @@
 			productReference = 6A9CBCABF50128C52895B960 /* AskMac.app */;
 			productType = "com.apple.product-type.application";
 		};
+		FED633EB1AA4D387EC113039 /* AskMacUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 535DB4D697F8FDF0D331BBD3 /* Build configuration list for PBXNativeTarget "AskMacUITests" */;
+			buildPhases = (
+				809B3EEA075FA2FAFA237B4F /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				F2737D39226F8C740D5E0004 /* PBXTargetDependency */,
+			);
+			name = AskMacUITests;
+			packageProductDependencies = (
+			);
+			productName = AskMacUITests;
+			productReference = 41DF70CF15A12234B2D92BC6 /* AskMacUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -378,6 +417,10 @@
 					E59CE13E0F81B53C77683FB1 = {
 						DevelopmentTeam = B5J28L8ARB;
 						ProvisioningStyle = Manual;
+					};
+					FED633EB1AA4D387EC113039 = {
+						DevelopmentTeam = B5J28L8ARB;
+						TestTargetID = E59CE13E0F81B53C77683FB1;
 					};
 				};
 			};
@@ -401,6 +444,7 @@
 				E59CE13E0F81B53C77683FB1 /* AskMac */,
 				B5A9CAFDC0F194D4B590DD08 /* AskMacCore */,
 				170C9A2D6ECAA9D5B00CB20D /* AskMacTests */,
+				FED633EB1AA4D387EC113039 /* AskMacUITests */,
 			);
 		};
 /* End PBXProject section */
@@ -448,6 +492,14 @@
 				8C30E811B8346325809717AD /* TaskServiceTests.swift in Sources */,
 				0D696DD556936DCEC1997BEB /* TerminalMonitorServiceTests.swift in Sources */,
 				C99AE720C0F4BDEEC032237B /* VersionComparisonTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		809B3EEA075FA2FAFA237B4F /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1975CC7073DB9F26E241ABC9 /* AskMacUITests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -526,6 +578,11 @@
 			isa = PBXTargetDependency;
 			target = B5A9CAFDC0F194D4B590DD08 /* AskMacCore */;
 			targetProxy = 2E13F4F6FED24CBC2519CE9C /* PBXContainerItemProxy */;
+		};
+		F2737D39226F8C740D5E0004 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = E59CE13E0F81B53C77683FB1 /* AskMac */;
+			targetProxy = 4536646E2CA60D64CB7AC2F1 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -707,6 +764,23 @@
 			};
 			name = Release;
 		};
+		8521C470F67698BD8FC8C488 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				COMBINE_HIDPI_IMAGES = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.kevinhill.AskMacUITests;
+				SDKROOT = macosx;
+				TEST_TARGET_NAME = AskMac;
+			};
+			name = Release;
+		};
 		A6BF5F6F1280BA0CFBAC2BF0 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -754,6 +828,23 @@
 			};
 			name = Debug;
 		};
+		F7DD7DB1F26E3190A7E499EE /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				COMBINE_HIDPI_IMAGES = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.kevinhill.AskMacUITests;
+				SDKROOT = macosx;
+				TEST_TARGET_NAME = AskMac;
+			};
+			name = Debug;
+		};
 		FBD3DB60C88E3DA1C0466C03 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -792,6 +883,15 @@
 			buildConfigurations = (
 				7799AB0228C91D865E0193EB /* Debug */,
 				592FA27071A764C2716E13E3 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		535DB4D697F8FDF0D331BBD3 /* Build configuration list for PBXNativeTarget "AskMacUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				F7DD7DB1F26E3190A7E499EE /* Debug */,
+				8521C470F67698BD8FC8C488 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;

--- a/AskMac/Sources/AskMac/Views/SettingsView.swift
+++ b/AskMac/Sources/AskMac/Views/SettingsView.swift
@@ -2367,24 +2367,64 @@ private struct MachineDetailView: View {
                         .font(.caption)
                 } else {
                     ForEach(agentSessions) { s in
-                        VStack(alignment: .leading, spacing: 2) {
-                            HStack {
-                                Text(s.controller).font(.caption).fontWeight(.medium)
-                                Text(s.project).font(.caption).foregroundStyle(.secondary)
+                        VStack(alignment: .leading, spacing: 3) {
+                            // Row 1: controller · title  +  type badge
+                            HStack(alignment: .firstTextBaseline, spacing: 4) {
+                                Text(s.controller)
+                                    .font(.caption).fontWeight(.semibold)
+                                if s.title != s.project {
+                                    Text(s.title)
+                                        .font(.caption).foregroundStyle(.primary)
+                                        .lineLimit(1).truncationMode(.tail)
+                                } else {
+                                    Text(s.project)
+                                        .font(.caption).foregroundStyle(.secondary)
+                                }
                                 Spacer()
-                                Text(s.tty.isEmpty ? "no TTY" : s.tty)
-                                    .font(.caption.monospaced())
-                                    .foregroundStyle(s.tty.isEmpty ? .red : .secondary)
-                                    .textSelection(.enabled)
+                                // Terminal / tmux / no routing badge
+                                Text(s.sessionType)
+                                    .font(.caption2).fontWeight(.semibold)
+                                    .padding(.horizontal, 5).padding(.vertical, 2)
+                                    .background(s.sessionType == "tmux" ? Color.purple.opacity(0.15)
+                                                : s.sessionType == "no routing" ? Color.red.opacity(0.12)
+                                                : Color.secondary.opacity(0.12))
+                                    .foregroundStyle(s.sessionType == "tmux" ? Color.purple
+                                                     : s.sessionType == "no routing" ? Color.red
+                                                     : Color.secondary)
+                                    .clipShape(RoundedRectangle(cornerRadius: 4))
                             }
-                            Text(s.cwd)
-                                .font(.caption2)
-                                .foregroundStyle(.tertiary)
-                                .lineLimit(1)
-                                .truncationMode(.middle)
+                            // Row 2: cwd
+                            Text(s.cwd.isEmpty ? "—" : s.cwd)
+                                .font(.caption2).foregroundStyle(.tertiary)
+                                .lineLimit(1).truncationMode(.middle)
                                 .textSelection(.enabled)
+                            // Row 3: session ID + routing + state
+                            HStack(spacing: 8) {
+                                Text(String(s.sessionID.prefix(22)))
+                                    .font(.caption2.monospaced()).foregroundStyle(.tertiary)
+                                    .textSelection(.enabled)
+                                if !s.routing.isEmpty && s.routing != "—" {
+                                    Text("·").font(.caption2).foregroundStyle(.tertiary)
+                                    Text(s.routing)
+                                        .font(.caption2.monospaced()).foregroundStyle(.secondary)
+                                        .textSelection(.enabled)
+                                }
+                                if !s.state.isEmpty {
+                                    Text("·").font(.caption2).foregroundStyle(.tertiary)
+                                    Text(s.state.replacingOccurrences(of: "_", with: " "))
+                                        .font(.caption2).foregroundStyle(
+                                            s.state == "idle" ? .secondary
+                                            : s.state.contains("tool") ? Color.orange
+                                            : Color.blue)
+                                }
+                                if s.isTransient {
+                                    Text("transient").font(.caption2)
+                                        .foregroundStyle(.tertiary)
+                                        .italic()
+                                }
+                            }
                         }
-                        .padding(.vertical, 1)
+                        .padding(.vertical, 2)
                     }
                 }
             } header: {
@@ -2406,8 +2446,8 @@ private struct MachineDetailView: View {
                         HStack {
                             Text(p.name).font(.caption).fontWeight(.medium)
                             Spacer()
-                            Text("PID \(p.pid)  TTY \(p.tty)")
-                                .font(.caption.monospaced())
+                            Text("PID \(p.pid)   TTY \(p.tty.isEmpty ? "—" : p.tty)")
+                                .font(.caption2.monospaced())
                                 .foregroundStyle(.secondary)
                                 .textSelection(.enabled)
                         }
@@ -2449,23 +2489,30 @@ private struct MachineDetailView: View {
     // MARK: Data loading
 
     private func refreshSessions() {
+        var sessions: [AgentSession] = []
+        var procs: [LiveProcess] = []
+
+        // claudecode-controller and codex-controller status files
         let statusFiles: [(controller: String, path: String)] = [
             ("Claude Code", NSHomeDirectory() + "/.ask/status/claudecode-controller.json"),
             ("Codex",       NSHomeDirectory() + "/.ask/status/codex-controller.json"),
         ]
-        var sessions: [AgentSession] = []
-        var procs: [LiveProcess] = []
         for (controller, path) in statusFiles {
             guard let data = try? Data(contentsOf: URL(fileURLWithPath: path)),
                   let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { continue }
             if let list = json["sessions"] as? [[String: Any]] {
                 for s in list {
+                    let project = s["project"] as? String ?? ""
                     sessions.append(AgentSession(
-                        controller: controller,
-                        sessionID: s["session_id"] as? String ?? "",
-                        project:   s["project"]    as? String ?? "",
-                        cwd:       s["cwd"]        as? String ?? "",
-                        tty:       s["tty"]        as? String ?? ""
+                        controller:  controller,
+                        sessionID:   s["session_id"] as? String ?? "",
+                        project:     project,
+                        title:       project,
+                        cwd:         s["cwd"]        as? String ?? "",
+                        tty:         s["tty"]        as? String ?? "",
+                        tmuxTarget:  "",
+                        state:       "",
+                        isTransient: false
                     ))
                 }
             }
@@ -2483,7 +2530,34 @@ private struct MachineDetailView: View {
                 }
             }
         }
-        agentSessions = sessions
+
+        // claude-3 daemon registry
+        let claude3Path = NSHomeDirectory() + "/.ask/claude3-sessions.json"
+        if let data = try? Data(contentsOf: URL(fileURLWithPath: claude3Path)),
+           let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+            for (_, value) in json {
+                guard let s = value as? [String: Any] else { continue }
+                let state = s["state"] as? String ?? ""
+                guard state != "stopped" else { continue }
+                let project     = s["project"]      as? String ?? ""
+                let firstPrompt = s["first_prompt"]  as? String ?? ""
+                let title = firstPrompt.isEmpty ? project
+                    : "\(project): \(firstPrompt.prefix(50))"
+                sessions.append(AgentSession(
+                    controller:  "Claude 3",
+                    sessionID:   s["session_id"]  as? String ?? "",
+                    project:     project,
+                    title:       title,
+                    cwd:         s["cwd"]         as? String ?? "",
+                    tty:         s["tty"]         as? String ?? "",
+                    tmuxTarget:  s["tmux_target"] as? String ?? "",
+                    state:       state,
+                    isTransient: s["is_transient"] as? Bool ?? false
+                ))
+            }
+        }
+
+        agentSessions = sessions.sorted { $0.controller < $1.controller }
         liveProcesses = procs
     }
 }
@@ -2495,8 +2569,23 @@ private struct AgentSession: Identifiable {
     let controller: String
     let sessionID: String
     let project: String
+    let title: String       // first_prompt or project
     let cwd: String
     let tty: String
+    let tmuxTarget: String
+    let state: String
+    let isTransient: Bool
+
+    var sessionType: String {
+        if !tmuxTarget.isEmpty { return "tmux" }
+        if !tty.isEmpty { return "terminal" }
+        return "no routing"
+    }
+    var routing: String {
+        if !tmuxTarget.isEmpty { return tmuxTarget }
+        if !tty.isEmpty { return tty }
+        return "—"
+    }
 }
 
 private struct LiveProcess: Identifiable {

--- a/AskMac/Sources/AskMacCore/TaskRegistry.swift
+++ b/AskMac/Sources/AskMacCore/TaskRegistry.swift
@@ -23,8 +23,14 @@ public struct TaskRegistryEntry: Codable, Sendable {
 
 /// Thread-safe task state registry. Persists to disk so tasks survive daemon restarts.
 /// Composite key: machineID + "/" + scriptID + "/" + taskID → entry.
+///
+/// The on-disk file is read lazily on first access. Every public method awaits
+/// `ensureLoaded()` first, so an early `incrementMessage` call (which can happen
+/// when a hook event lands before the explicit `load()` completes) cannot race
+/// with the disk read and reset the sequence counter to 1.
 public actor TaskRegistryActor {
     public var entries: [String: TaskRegistryEntry] = [:]
+    private var didLoad = false
 
     private let persistURL: URL
 
@@ -39,7 +45,12 @@ public actor TaskRegistryActor {
         }
     }
 
+    /// Reads the on-disk registry into memory. Idempotent — subsequent calls are no-ops.
+    /// All mutating methods call this internally so the counter never starts fresh
+    /// on a stale in-memory view.
     public func load() {
+        guard !didLoad else { return }
+        didLoad = true
         guard let data = try? Data(contentsOf: persistURL),
               let decoded = try? JSONDecoder().decode([String: TaskRegistryEntry].self, from: data)
         else { return }
@@ -52,12 +63,14 @@ public actor TaskRegistryActor {
     }
 
     public func entry(for key: String) -> TaskRegistryEntry? {
-        entries[key]
+        load()
+        return entries[key]
     }
 
     /// Upserts a task entry, updating title and status. Returns the current entry.
     @discardableResult
     public func upsert(key: String, title: String, status: String) -> TaskRegistryEntry {
+        load()
         var entry = entries[key] ?? TaskRegistryEntry(title: title, status: status)
         entry.title = title
         entry.status = status
@@ -68,6 +81,7 @@ public actor TaskRegistryActor {
 
     /// Increments the message counter and sequence number. Returns the sequence number to use.
     public func incrementMessage(key: String) -> Int {
+        load()
         var entry = entries[key] ?? TaskRegistryEntry(title: "", status: "working")
         let seq = entry.nextSequenceNumber
         entry.messageCount += 1
@@ -78,6 +92,7 @@ public actor TaskRegistryActor {
     }
 
     public func incrementArtifact(key: String) {
+        load()
         guard var entry = entries[key] else { return }
         entry.artifactCount += 1
         entries[key] = entry

--- a/AskMac/project.yml
+++ b/AskMac/project.yml
@@ -95,15 +95,29 @@ targets:
       - target: AskMac
         embed: false
 
+  AskMacUITests:
+    type: bundle.ui-testing
+    platform: macOS
+    sources:
+      - path: Tests/AskMacUITests
+    settings:
+      base:
+        GENERATE_INFOPLIST_FILE: YES
+        TEST_TARGET_NAME: AskMac
+    dependencies:
+      - target: AskMac
+
 schemes:
   AskMac:
     build:
       targets:
         AskMac: all
         AskMacTests: [test]
+        AskMacUITests: [test]
     test:
       targets:
         - AskMacTests
+        - AskMacUITests
     archive:
       config: Release
 

--- a/ask/scripts/claude-3/hooks/user_prompt_submit.py
+++ b/ask/scripts/claude-3/hooks/user_prompt_submit.py
@@ -2,14 +2,69 @@
 """
 Claude Code UserPromptSubmit hook for claude-3.
 Notifies the daemon when the user submits a prompt so it can record it in
-the session's task feed.
+the session's task feed.  Also sends tty/cwd so the daemon can backfill
+routing info if the session was recreated after an eviction.
 """
 import sys
 import json
 import socket
 import os
+import subprocess
 
 SOCKET_PATH = os.environ.get('ASK_SOCKET_PATH', os.path.expanduser('~/.ask/sockets/claude-3.sock'))
+
+
+def _tty_name_to_short(path: str) -> str:
+    name = os.path.basename(path)
+    if name.startswith('tty'):
+        name = name[3:]
+    return name
+
+
+def _get_tty():
+    tty_env = os.environ.get('TTY', '')
+    if tty_env and os.path.exists(tty_env):
+        return _tty_name_to_short(tty_env)
+    for fd in (0, 1, 2):
+        try:
+            return _tty_name_to_short(os.ttyname(fd))
+        except Exception:
+            pass
+    try:
+        pid = os.getpid()
+        for _ in range(10):
+            r = subprocess.run(
+                ['ps', '-p', str(pid), '-o', 'ppid=,tty=,comm='],
+                capture_output=True, text=True, timeout=2,
+            )
+            parts = r.stdout.strip().split(None, 2)
+            if len(parts) < 2:
+                break
+            ppid_str, tty_val = parts[0], parts[1]
+            if tty_val not in ('??', ''):
+                return tty_val
+            pid = int(ppid_str)
+            if pid <= 1:
+                break
+    except Exception:
+        pass
+    return None
+
+
+def _get_tmux_target() -> str:
+    pane_id = os.environ.get('TMUX_PANE', '')
+    if not pane_id:
+        return ''
+    try:
+        r = subprocess.run(
+            ['tmux', 'display-message', '-t', pane_id, '-p',
+             '#{session_name}:#{window_id}'],
+            capture_output=True, text=True, timeout=2,
+        )
+        return r.stdout.strip()
+    except Exception:
+        return ''
+
 
 data    = json.load(sys.stdin)
 session = data.get('session_id', '')
@@ -18,6 +73,9 @@ cwd     = os.getcwd()
 
 if not session or not message:
     sys.exit(0)
+
+tty = _get_tty()
+tmux_target = _get_tmux_target()
 
 try:
     sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
@@ -28,6 +86,8 @@ try:
         'message': message,
         'session_id': session,
         'cwd': cwd,
+        'tty': tty,
+        'tmux_target': tmux_target,
     }).encode())
     sock.close()
 except Exception:

--- a/ask/scripts/claude-3/main.py
+++ b/ask/scripts/claude-3/main.py
@@ -677,9 +677,12 @@ class Claude3:
 
         last_msg = (msg.get('last_message', '') or '').strip()
         if last_msg and last_msg != session.last_message:
+            # Update the live block's preview so the UI shows the latest text,
+            # but DON'T append to chat history here. _handle_session_stop is
+            # the single writer for the assistant turn — otherwise every
+            # text-tool-text-tool segment within one Claude turn becomes a
+            # separate row in the transcript.
             session.last_message = last_msg
-            await self.append_message(session.task_id, 'assistant', last_msg)
-            await self._append_artifact_if_large(session, 'Assistant output', last_msg)
 
         await self._emit_session_block(session)
         await self._emit_tile()
@@ -696,9 +699,9 @@ class Claude3:
 
         last_msg = (msg.get('last_message', '') or '').strip()
         if last_msg and last_msg != session.last_message:
+            # Live preview only — see _handle_pre_tool_use comment above.
+            # _handle_session_stop is the single writer for the assistant turn.
             session.last_message = last_msg
-            await self.append_message(session.task_id, 'assistant', last_msg)
-            await self._append_artifact_if_large(session, 'Assistant output', last_msg)
 
         # Resolve any pending permission that was waiting for this tool
         if session.pending_permission and session.pending_permission.tool == tool_name:
@@ -1242,9 +1245,17 @@ class Claude3:
             _log(f'start_session emit error: {exc}', 'WARN')
 
     async def _heartbeat(self):
+        cycles = 0
         while True:
             await asyncio.sleep(15)
+            cycles += 1
             try:
+                # Every 4 cycles (~1 min), drop the emit dedup cache so any
+                # block AskMac silently dropped (TTL prune, restart, etc.)
+                # gets re-pushed on this refresh. Cheap insurance against the
+                # "block disappeared from UI" symptom.
+                if cycles % 4 == 0:
+                    self._emitted_payloads.clear()
                 await self._refresh_sessions()
             except Exception as exc:
                 _log(f'heartbeat error: {exc}', 'WARN')

--- a/ask/scripts/claude-3/main.py
+++ b/ask/scripts/claude-3/main.py
@@ -1201,21 +1201,11 @@ class Claude3:
                 except Exception:
                     pass
             # Sessions with no routing (no tty, no tmux_target) can't have their
-            # liveness verified. Give them a 5-minute grace period to resolve routing
-            # (via a hook event or process-discovery link), then evict them.
-            if not session.tmux_target and not session.tty:
-                age = datetime.datetime.now().timestamp() - (session.last_seen or 0)
-                if age > 300:
-                    _log(f'session {session.session_id} has no routing after {int(age)}s — evicting')
-                    session.state = 'stopped'
-                    session.stopped_at = datetime.datetime.now().timestamp()
-                    self._registry.remove(session.session_id)
-                    try:
-                        await self._set_task_status(session, 'completed')
-                        await self.clear_block(self._session_block_id(session.session_id))
-                    except Exception as exc:
-                        _log(f'no-routing eviction error for {session.session_id}: {exc}', 'WARN')
-                    continue
+            # liveness verified live, but they include the supervisor Claude Code
+            # session that is the parent of this daemon — by design it has no
+            # tmux/tty routing and goes idle indefinitely between user prompts.
+            # Don't evict here; SESSION_TTL (24h) at registry-load filters out
+            # genuinely abandoned no-routing sessions on the next daemon restart.
             # Only evict TTY sessions if the TTY is confirmed dead.
             if not session.tmux_target and session.tty:
                 alive_result = await self._call_tool('session_alive', {'session_id': session.raw_id})

--- a/ask/scripts/claude-3/main.py
+++ b/ask/scripts/claude-3/main.py
@@ -23,7 +23,7 @@ import uuid
 from typing import Optional
 
 from registry import PendingPermission, SessionRecord, SessionRegistry
-from transport import discover_claude_processes, find_repos, parse_tmux_prompt, tty_is_live
+from transport import find_repos
 
 sys.stdout = open(sys.stdout.fileno(), mode='w', encoding='utf-8', buffering=1, closefd=False)
 
@@ -475,17 +475,30 @@ class Claude3:
             return
         if not session.tty and not session.tmux_target:
             return
+        args: dict = {
+            'session_id': session.raw_id,
+            'app_id': 'claude-3',
+            'tty': session.tty,
+            'tmux_target': session.tmux_target,
+        }
+        if session.pid:
+            args['pid'] = session.pid
+        # For TTY sessions, register the interactive_prompt detector so
+        # detect_tui can replace the local parse_tmux_prompt call.
+        if session.tty and not session.tmux_target:
+            args['hook'] = {
+                'scan_lines': 40,
+                'patterns': [
+                    {'id': 'interactive_prompt', 'detect': {'type': 'interactive_prompt'}},
+                ],
+            }
         try:
             await self._rpc('tools/call', {
                 'name': 'register_session',
-                'arguments': {
-                    'session_id': session.raw_id,
-                    'app_id': 'claude-3',
-                    'tty': session.tty,
-                    'tmux_target': session.tmux_target,
-                },
+                'arguments': args,
             }, timeout=4.0)
-            _log(f'tm_register {session.session_id[:12]} tty={session.tty!r} tmux={session.tmux_target!r}')
+            _log(f'tm_register {session.session_id[:12]} tty={session.tty!r} '
+                 f'tmux={session.tmux_target!r} pid={session.pid}')
         except Exception as e:
             _log(f'tm_register failed: {e}', 'WARN')
 
@@ -512,7 +525,8 @@ class Claude3:
             return ok
         # TTY was unknown — try to discover it, re-register, and retry once.
         if session.cwd:
-            for proc in discover_claude_processes():
+            discovered = await self._call_tool('discover_sessions', {'executable': 'claude'})
+            for proc in (discovered or {}).get('sessions', []):
                 if proc.get('cwd') == session.cwd and proc.get('tty'):
                     session.tty = proc['tty']
                     self._registry._index_aliases(session)
@@ -656,7 +670,7 @@ class Claude3:
         raw_id = msg.get('session_id', '')
         if not raw_id:
             return
-        session = self._registry.ensure(raw_id=raw_id, cwd=msg.get('cwd', ''))
+        session = self._registry.ensure(raw_id=raw_id)
         session.current_tool = msg.get('tool', '')
         session.preview = msg.get('preview', '')[:200]
         session.state = 'running_tool'
@@ -675,7 +689,7 @@ class Claude3:
         raw_id = msg.get('session_id', '')
         if not raw_id:
             return
-        session = self._registry.ensure(raw_id=raw_id, cwd=msg.get('cwd', ''))
+        session = self._registry.ensure(raw_id=raw_id)
         tool_name = msg.get('tool_name', '')
         session.current_tool = tool_name
         session.state = 'running_tool'
@@ -702,7 +716,7 @@ class Claude3:
         raw_id = msg.get('session_id', '')
         if not raw_id:
             return
-        session = self._registry.ensure(raw_id=raw_id, cwd=msg.get('cwd', ''))
+        session = self._registry.ensure(raw_id=raw_id)
         prompt = (msg.get('message', '') or '').strip()
         session.state = 'awaiting_user'
         session.preview = prompt[:200]
@@ -743,7 +757,7 @@ class Claude3:
         summary = (msg.get('summary', '') or '').strip()
         if not raw_id or not summary:
             return
-        session = self._registry.ensure(raw_id=raw_id, cwd=msg.get('cwd', ''))
+        session = self._registry.ensure(raw_id=raw_id)
         self._fire_a2a(self._append_structured_message(session, 'Context compacted', summary))
         _log(f'post_compact raw_id={raw_id[:8]} summary={summary[:60]}')
 
@@ -885,59 +899,67 @@ class Claude3:
                     session.pending_confirmation_tty = None
                 continue
 
-            content = await self._tm_read_output(session, lines=40)
-            if not content:
-                continue
-
-            parsed = parse_tmux_prompt(content)
-            content_hash = _hl.md5(content.encode()).hexdigest()[:8]
-
-            if parsed:
-                if content_hash != last_hash:
-                    last_hash = content_hash
-                    body, options, reply_mode = parsed
-                    active_options = options
-                    # Embed as pending_confirmation in the session block
-                    session.pending_permission = PendingPermission(
-                        request_id=f'tty:{uuid.uuid4().hex[:8]}',
-                        tool='Terminal prompt',
-                        preview=body,
-                        options=options,
-                        suggestions={},
-                        requested_at=datetime.datetime.now().timestamp(),
-                    )
-                    session.state = 'waiting_permission'
-                    fut = asyncio.get_running_loop().create_future()
-                    self._pending_permissions[session.pending_permission.request_id] = fut
-                    await self._emit_session_block(session)
-                    _log(f'TTY prompt surfaced for {session_id[:8]}: {body[:60]}')
-                    try:
-                        value = await asyncio.wait_for(fut, timeout=PERMISSION_TIMEOUT)
-                    except asyncio.TimeoutError:
-                        value = None
-                    finally:
-                        self._pending_permissions.pop(session.pending_permission.request_id, None)
-
-                    if value is not None and value in active_options and reply_mode in ('numbered', 'arrow'):
-                        idx = active_options.index(value)
-                        down_seq = '\x1b[B' * idx
-                        await self._tm_inject_tty(session, down_seq + '\n')
-                    elif value == 'Yes' and reply_mode == 'yn':
-                        await self._tm_inject_tty(session, 'y\n')
-                    elif value == 'No' and reply_mode == 'yn':
-                        await self._tm_inject_tty(session, 'n\n')
-
-                    last_hash = ''
-                    active_options = []
-                    session.pending_permission = None
-                    session.state = 'idle'
-                    await self._emit_session_block(session)
-            else:
+            tui = await self._call_tool('detect_tui', {'session_id': session.raw_id})
+            if not tui or tui.get('pattern_id') != 'interactive_prompt':
                 if last_hash:
                     last_hash = ''
                     active_options = []
                     session.pending_permission = None
                     await self._emit_session_block(session)
+                continue
+
+            prompt_result = tui.get('result') or {}
+            prompt_hash = _hl.md5(str(prompt_result).encode()).hexdigest()[:8]
+
+            if prompt_hash == last_hash:
+                continue  # same prompt still showing, already surfaced
+
+            last_hash = prompt_hash
+            ptype = prompt_result.get('type', 'numbered')
+            if ptype == 'binary':
+                options = ['Yes', 'No']
+                reply_mode = 'yn'
+                body = prompt_result.get('prompt_text', 'Continue?')
+            else:
+                options = prompt_result.get('options', [])
+                reply_mode = ptype  # 'numbered' or 'arrow'
+                body = 'Choose an option'
+            active_options = options
+
+            session.pending_permission = PendingPermission(
+                request_id=f'tty:{uuid.uuid4().hex[:8]}',
+                tool='Terminal prompt',
+                preview=body,
+                options=options,
+                suggestions={},
+                requested_at=datetime.datetime.now().timestamp(),
+            )
+            session.state = 'waiting_permission'
+            fut = asyncio.get_running_loop().create_future()
+            self._pending_permissions[session.pending_permission.request_id] = fut
+            await self._emit_session_block(session)
+            _log(f'TTY prompt surfaced for {session_id[:8]}: {body[:60]}')
+            try:
+                value = await asyncio.wait_for(fut, timeout=PERMISSION_TIMEOUT)
+            except asyncio.TimeoutError:
+                value = None
+            finally:
+                self._pending_permissions.pop(session.pending_permission.request_id, None)
+
+            if value is not None and value in active_options and reply_mode in ('numbered', 'arrow'):
+                idx = active_options.index(value)
+                down_seq = '\x1b[B' * idx
+                await self._tm_inject_tty(session, down_seq + '\n')
+            elif value == 'Yes' and reply_mode == 'yn':
+                await self._tm_inject_tty(session, 'y\n')
+            elif value == 'No' and reply_mode == 'yn':
+                await self._tm_inject_tty(session, 'n\n')
+
+            last_hash = ''
+            active_options = []
+            session.pending_permission = None
+            session.state = 'idle'
+            await self._emit_session_block(session)
 
         self._tty_monitors.discard(session_id)
 
@@ -958,7 +980,8 @@ class Claude3:
         Unknown processes (no TTY or CWD match) are ignored — they will
         self-register via hook events when their next tool or prompt fires.
         """
-        processes = discover_claude_processes()
+        discovered = await self._call_tool('discover_sessions', {'executable': 'claude'})
+        processes = (discovered or {}).get('sessions', [])
         for proc in processes:
             tty = proc['tty']
             cwd = proc.get('cwd', '')
@@ -1194,7 +1217,12 @@ class Claude3:
                         _log(f'no-routing eviction error for {session.session_id}: {exc}', 'WARN')
                     continue
             # Only evict TTY sessions if the TTY is confirmed dead.
-            if not session.tmux_target and session.tty and not tty_is_live(session.tty):
+            if not session.tmux_target and session.tty:
+                alive_result = await self._call_tool('session_alive', {'session_id': session.raw_id})
+                tty_dead = not (alive_result or {}).get('alive', True)
+            else:
+                tty_dead = False
+            if not session.tmux_target and session.tty and tty_dead:
                 _log(f'session {session.session_id} TTY gone — marking stopped')
                 session.state = 'stopped'
                 session.stopped_at = datetime.datetime.now().timestamp()

--- a/ask/scripts/claude-3/manifest.json
+++ b/ask/scripts/claude-3/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "claude-3",
   "name": "Claude 3",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "setup": "setup.py",
   "description": "Feed-first Claude Code session supervisor — routes permissions and session history to iPhone",
   "entry": "main.py",

--- a/ask/scripts/claude-3/manifest.json
+++ b/ask/scripts/claude-3/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "claude-3",
   "name": "Claude 3",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "setup": "setup.py",
   "description": "Feed-first Claude Code session supervisor — routes permissions and session history to iPhone",
   "entry": "main.py",

--- a/ask/scripts/claude-3/manifest.json
+++ b/ask/scripts/claude-3/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "claude-3",
   "name": "Claude 3",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "setup": "setup.py",
   "description": "Feed-first Claude Code session supervisor — routes permissions and session history to iPhone",
   "entry": "main.py",

--- a/ask/scripts/claude-3/manifest.json
+++ b/ask/scripts/claude-3/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "claude-3",
   "name": "Claude 3",
-  "version": "0.3.13",
+  "version": "0.4.2",
   "setup": "setup.py",
   "description": "Feed-first Claude Code session supervisor — routes permissions and session history to iPhone",
   "entry": "main.py",

--- a/ask/scripts/claude-3/registry.py
+++ b/ask/scripts/claude-3/registry.py
@@ -141,9 +141,20 @@ class SessionRegistry:
             self._index_aliases(s)
             return s
 
-        seed = raw_id or tty or cwd or str(time.time())
-        digest = hashlib.sha1(seed.encode()).hexdigest()[:10]
-        sid = f'claude3:{digest}'
+        # Seed priority: cwd → tty → raw_id → time. The same project directory
+        # produces the same digest across CLI restarts, so chat history (keyed by
+        # task_id == session_id) accumulates instead of fragmenting per `claude`
+        # invocation. If two concurrent sessions share a cwd, the first owns the
+        # cwd-derived sid and the second falls back to tty/raw_id.
+        sid = ''
+        for seed in (cwd, tty, raw_id, str(time.time())):
+            if not seed:
+                continue
+            digest = hashlib.sha1(seed.encode()).hexdigest()[:10]
+            candidate = f'claude3:{digest}'
+            if candidate not in self.sessions:
+                sid = candidate
+                break
         s = SessionRecord(
             session_id=sid,
             task_id=sid,

--- a/ask/scripts/claude-3/registry.py
+++ b/ask/scripts/claude-3/registry.py
@@ -50,6 +50,7 @@ class SessionRecord:
     pending_permission: Optional[PendingPermission] = None
     stopped_at: float = 0.0
     last_prompt: str = ''
+    first_prompt: str = ''   # first user message — used as display title
 
     def touch(self):
         self.last_seen = time.time()
@@ -79,6 +80,7 @@ class SessionRecord:
             permission_mode=raw.get('permission_mode', 'supervised'),
             stopped_at=float(raw.get('stopped_at', 0.0)),
             last_prompt=raw.get('last_prompt', ''),
+            first_prompt=raw.get('first_prompt', ''),
         )
         record.pending_permission = PendingPermission.from_dict(raw.get('pending_permission'))
         return record

--- a/ask/scripts/claude-3/test_invariants.py
+++ b/ask/scripts/claude-3/test_invariants.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Invariants for claude-3's session registry. Locks the regressions we
+keep hitting. Run with: python3 -m pytest ask/scripts/claude-3/test_invariants.py
+or just: python3 ask/scripts/claude-3/test_invariants.py
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from registry import SessionRegistry
+
+
+def test_cwd_stable_across_cli_restarts():
+    """Same project directory → same session_id even with different raw_ids."""
+    r = SessionRegistry()
+    s1 = r.ensure(raw_id='UUID-A', tty='ttys001', cwd='/proj/foo')
+    sid1 = s1.session_id
+    r.remove(sid1)  # simulate run 1 ending
+    s2 = r.ensure(raw_id='UUID-B', tty='ttys002', cwd='/proj/foo')
+    assert s1.session_id == s2.session_id, \
+        f'cwd-stable: expected same sid across restarts, got {sid1} vs {s2.session_id}'
+
+
+def test_concurrent_sessions_in_same_cwd_get_different_sids():
+    """Two live claude runs in the same cwd must not collide."""
+    r = SessionRegistry()
+    a = r.ensure(raw_id='UUID-A', tty='ttys001', cwd='/proj/foo')
+    b = r.ensure(raw_id='UUID-B', tty='ttys002', cwd='/proj/foo')
+    assert a.session_id != b.session_id, 'concurrent same-cwd sessions collided'
+
+
+def test_hook_after_transient_discovery_merges():
+    """If discovery creates a transient session by tty, a later hook with
+    raw_id should bind to the same session, not create a new one."""
+    r = SessionRegistry()
+    transient = r.ensure(tty='ttys005', cwd='/proj/bar', is_transient=True)
+    # Hook fires later with raw_id
+    real = r.ensure(raw_id='UUID-X', tty='ttys005', cwd='/proj/bar')
+    assert transient.session_id == real.session_id, \
+        f'transient/hook merge failed: transient={transient.session_id} hook={real.session_id}'
+    assert real.raw_id == 'UUID-X', 'raw_id should be backfilled from the hook'
+
+
+def test_resolve_by_raw_id_alias():
+    """A session created with raw_id must be resolvable by that raw_id."""
+    r = SessionRegistry()
+    s = r.ensure(raw_id='UUID-Z', tty='ttys009', cwd='/proj/baz')
+    assert r.resolve(raw_id='UUID-Z') == s.session_id
+
+
+def test_remove_purges_aliases():
+    """After remove(), no alias should still resolve to the dead sid."""
+    r = SessionRegistry()
+    s = r.ensure(raw_id='UUID-Q', tty='ttys010', cwd='/proj/qux')
+    sid = s.session_id
+    r.remove(sid)
+    assert r.resolve(raw_id='UUID-Q') == ''
+    assert r.resolve(tty='ttys010') == ''
+    # And the cwd-derived sid slot must be free for re-use
+    s2 = r.ensure(raw_id='UUID-R', tty='ttys011', cwd='/proj/qux')
+    assert s2.session_id == sid, 'cwd-derived sid should be reusable after remove'
+
+
+def test_no_routing_session_persists():
+    """A session with no tty and no tmux_target (e.g. the supervisor Claude)
+    must not be auto-evicted just for lack of routing."""
+    r = SessionRegistry()
+    s = r.ensure(raw_id='UUID-NO-ROUTE')
+    assert s.session_id in r.sessions
+    # last_seen exists; nothing in the registry alone should remove it
+    assert r.resolve(raw_id='UUID-NO-ROUTE') == s.session_id
+
+
+if __name__ == '__main__':
+    tests = [v for k, v in globals().items() if k.startswith('test_')]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f'  PASS  {t.__name__}')
+        except AssertionError as e:
+            print(f'  FAIL  {t.__name__}: {e}')
+            failed += 1
+    print()
+    print(f'{len(tests)-failed}/{len(tests)} passed')
+    sys.exit(1 if failed else 0)

--- a/ask/scripts/codex-3/main.py
+++ b/ask/scripts/codex-3/main.py
@@ -461,11 +461,12 @@ class Codex3:
         for session in list(self._registry.sessions.values()):
             if session.state == 'stopped':
                 continue
-            alive = False
             if session.tmux_target:
                 alive = pane_exists(session.tmux_target)
             elif session.tty:
                 alive = tty_exists(session.tty)
+            else:
+                alive = True  # no routing info yet — assume alive to avoid false eviction
             if alive:
                 if session.tty:
                     asyncio.create_task(self._tm_register(session))

--- a/ask/scripts/codex-3/main.py
+++ b/ask/scripts/codex-3/main.py
@@ -496,9 +496,15 @@ class Codex3:
         await self._discover_active_processes()
 
     async def _heartbeat(self):
+        cycles = 0
         while True:
             await asyncio.sleep(15)
+            cycles += 1
             try:
+                # Every 4 cycles (~1 min) drop the emit dedup cache so any
+                # block AskMac silently dropped gets re-pushed.
+                if cycles % 4 == 0:
+                    self._emitted_payloads.clear()
                 await self._refresh_sessions()
             except Exception as exc:
                 _log(f'heartbeat error: {exc}', 'WARN')

--- a/ask/scripts/codex-3/main.py
+++ b/ask/scripts/codex-3/main.py
@@ -703,7 +703,8 @@ class Codex3:
         ok = await self._route_text(session, text)
         if not ok:
             return {'error': 'session is not routable'}
-        await self.append_message(session.task_id, 'user', text)
+        # Don't append the user message here — the agent's UserPromptSubmit hook
+        # fires _handle_user_prompt which is the single writer for user turns.
         session.state = 'running_tool'
         session.preview = text[:200]
         await self._set_task_status(session, 'working')
@@ -786,7 +787,8 @@ class Codex3:
             ok = await self._route_text(session, value)
             _log(f'reply session={session.session_id!r} ok={ok} text={value[:80]!r}')
             if ok:
-                self._fire_a2a(self.append_message(session.task_id, 'user', value))
+                # Don't append the user message here — _handle_user_prompt is
+                # the single writer (fires from the agent's UserPromptSubmit hook).
                 session.state = 'running_tool'
                 session.preview = value[:200]
                 self._fire_a2a(self._set_task_status(session, 'working'))

--- a/ask/scripts/codex-3/manifest.json
+++ b/ask/scripts/codex-3/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "codex-3",
   "name": "Codex 3",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "description": "Feed-first Codex session supervisor with tmux transport and task-backed history",
   "entry": "main.py",
   "icon": "sparkles",

--- a/ask/scripts/codex-3/manifest.json
+++ b/ask/scripts/codex-3/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "codex-3",
   "name": "Codex 3",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "description": "Feed-first Codex session supervisor with tmux transport and task-backed history",
   "entry": "main.py",
   "icon": "sparkles",

--- a/ask/scripts/codex-3/manifest.json
+++ b/ask/scripts/codex-3/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "codex-3",
   "name": "Codex 3",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "Feed-first Codex session supervisor with tmux transport and task-backed history",
   "entry": "main.py",
   "icon": "sparkles",

--- a/ask/scripts/codex-3/manifest.json
+++ b/ask/scripts/codex-3/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "codex-3",
   "name": "Codex 3",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "description": "Feed-first Codex session supervisor with tmux transport and task-backed history",
   "entry": "main.py",
   "icon": "sparkles",

--- a/ask/scripts/codex-3/registry.py
+++ b/ask/scripts/codex-3/registry.py
@@ -149,9 +149,20 @@ class SessionRegistry:
             self._index_aliases(session)
             return session
 
-        seed = raw_id or tmux_target or tty or cwd or str(time.time())
-        digest = hashlib.sha1(seed.encode()).hexdigest()[:10]
-        sid = f'codex3:{digest}'
+        # Seed priority: cwd → tmux_target → tty → raw_id → time. The same project
+        # directory produces the same digest across CLI restarts, so chat history
+        # (keyed by task_id == session_id) accumulates instead of fragmenting per
+        # `codex` invocation. If two concurrent sessions share a cwd, the first
+        # owns the cwd-derived sid and the second falls back to tmux/tty/raw_id.
+        sid = ''
+        for seed in (cwd, tmux_target, tty, raw_id, str(time.time())):
+            if not seed:
+                continue
+            digest = hashlib.sha1(seed.encode()).hexdigest()[:10]
+            candidate = f'codex3:{digest}'
+            if candidate not in self.sessions:
+                sid = candidate
+                break
         session = SessionRecord(
             session_id=sid,
             task_id=sid,

--- a/ask/scripts/codex-3/transport.py
+++ b/ask/scripts/codex-3/transport.py
@@ -103,7 +103,8 @@ def discover_codex_processes() -> list[dict]:
 
 
 def tty_exists(tty: str) -> bool:
-    return os.path.exists(f'/dev/{tty}')
+    # macOS ps reports TTY as 's004'; the device is at /dev/ttys004
+    return os.path.exists(f'/dev/{tty}') or os.path.exists(f'/dev/tty{tty}')
 
 
 def discover_codex_panes(exclude_targets: Optional[Set[str]] = None) -> list[dict]:

--- a/docs/specs/manual-script-test-plan-dev-design.md
+++ b/docs/specs/manual-script-test-plan-dev-design.md
@@ -1,0 +1,213 @@
+# Manual Script Test Plan — Dev Design
+
+**Companion to:** `docs/specs/manual-script-test-plan.md`
+**Status:** in progress
+**Branch:** `fix/session-persistence` (continuing the dashboard line)
+
+## Approach
+
+Layer plans **on top** of the existing run storage. Do not migrate or rip out
+the current slideshow. Two principles:
+
+- **Backward compatible:** every existing run keeps its current path
+  (`web/.review/runs/<id>/story/<spec>/...`). Old `feedback.json` and
+  `review.json` continue to work. A run without a `planId` is filed under a
+  synthetic "Legacy runs" plan so the new IA still renders it.
+- **Additive routes:** `#/run/<id>` continues to work as today. New routes
+  (`#/`, `#/plan/<id>`, `#/plan/<id>/run/<id>`, `#/plan/<id>/run/<id>/<case-id>`)
+  are added alongside.
+
+## Phases
+
+| Phase | What ships |
+|---|---|
+| 1 (this PR) | Plan model, seed plan JSON, plan/run/case API routes, plans index, plan detail, run detail (case rollup), case slideshow (breadcrumb only), legacy `#/run/<id>` redirect, `tested{}` snapshot, one working hello-world web case |
+| 2 | Per-script Playwright specs for the rest of the catalog |
+| 3 | Computer-use driver for AskMac surface; AskMac cases per script |
+| 4 | Reporting polish: sparklines, diff vs. last run, open-issues panel |
+| 5 | Subset-run UI, plan editor UI |
+
+## Data model
+
+### Plan file: `web/review-plans/<id>.json`
+
+(Plans are source artifacts and live in git. Runs stay under
+`web/.review/runs/` which remains gitignored.)
+
+```json
+{
+  "id": "manual-script-sweep",
+  "title": "Manual script sweep",
+  "version": "1.0.0",
+  "description": "Per-script regression: web + AskMac.",
+  "cases": [
+    {
+      "id": "hello-world-web",
+      "scriptId": "hello-world",
+      "surface": "web",
+      "title": "Hello World · Web",
+      "spec": "scripts/hello-world.web.spec.ts",
+      "deps": [],
+      "status": "implemented"
+    },
+    {
+      "id": "hello-world-mac",
+      "scriptId": "hello-world",
+      "surface": "askmac",
+      "title": "Hello World · AskMac",
+      "driver": "computer-use",
+      "deps": [],
+      "status": "pending"
+    }
+  ]
+}
+```
+
+`status` is `implemented | pending | skipped`. Pending cases render as
+greyed-out rows in the plan detail view; they don't run.
+
+### Run schema (extended)
+
+```ts
+interface Run {
+  id: string
+  planId: string | null         // NEW; null = legacy
+  planVersion: string | null    // NEW
+  scope: 'all' | { caseIds: string[] }   // NEW; defaults to 'all' for legacy
+  tested: TestedSnapshot | null // NEW
+  spec: string
+  startedAt: number
+  endedAt: number | null
+  exitCode: number | null
+  screenshotCount: number
+  status: 'running' | 'awaiting-review' | 'reviewed'
+  review: Review | null
+  gitHead: string | null
+  caseResults?: CaseResult[]    // NEW; computed at run end
+}
+
+interface TestedSnapshot {
+  git: { head: string; shortHead: string; branch: string; dirty: boolean }
+  askmac?: { version: string; source: string }
+  scripts: Array<{ id: string; version: string; enabled: boolean }>
+  vault: 'dev' | 'prod' | 'unknown'
+}
+
+interface CaseResult {
+  caseId: string
+  status: 'passed' | 'failed' | 'skipped' | 'pending'
+  storyPath: string | null      // existing per-spec story dir
+  stepCount: number
+  feedback: { kind: string; count: number }[]
+  decision: 'approved' | 'changes-requested' | 'rejected' | null
+}
+```
+
+Per-case decisions live in `feedback.json` companions
+(`runs/<id>/cases/<caseId>/review.json`) for new runs. Legacy runs keep
+their flat `runs/<id>/review.json`.
+
+### Storage layout (new + legacy side by side)
+
+```
+web/
+  review-plans/                             ← NEW: source-controlled plans
+    manual-script-sweep.json
+  .review/                                  ← gitignored (run output)
+    runs.json                               ← unchanged (run index)
+  runs/
+    <run-id>/
+      meta.json                             ← NEW: planId, planVersion, scope, tested
+      output.txt
+      ── new-style (planId set):
+      cases/
+        <case-id>/
+          story.json
+          NN-*.png + NN-*.html
+          feedback.json                     ← scoped to one case
+          review.json                       ← case-level decision
+      ── legacy (planId null):
+      story/<spec>/...                      ← unchanged
+      feedback.json                         ← unchanged
+      review.json                           ← unchanged
+```
+
+The story recorder writes into whichever layout the runner declares. The
+review-server reads both and synthesizes a uniform `caseResults[]` for the
+UI.
+
+## API surface
+
+| Method | Route | Purpose |
+|---|---|---|
+| GET | `/api/plans` | All plans |
+| GET | `/api/plans/:id` | One plan |
+| GET | `/api/plans/:id/runs` | Runs for a plan, newest first |
+| POST | `/api/plans/:id/runs` | Start a new run; body: `{ scope: 'all' \| { caseIds: [...] } }` |
+| GET | `/api/runs/:id` | Run detail (existing — extended with caseResults) |
+| GET | `/api/runs/:id/cases/:caseId` | Case slice (story + feedback + review) |
+| POST | `/api/runs/:id/cases/:caseId/review` | Case-level decision |
+| GET | `/api/tested-snapshot` | Capture current `tested{}` block (used at run start) |
+
+Existing `/api/runs/:id/feedback` keeps its path; for new-style runs it now
+takes a `caseId` query param to scope to a case.
+
+## Routes (UI)
+
+| Hash | Render |
+|---|---|
+| `#/` | Plans index |
+| `#/plan/:id` | Plan detail |
+| `#/plan/:id/run/:runId` | Run detail with case rollup |
+| `#/plan/:id/run/:runId/:caseId` | Case slideshow (existing per-step UI) |
+| `#/run/:id` | Backward compat — redirect to plan/run if `planId` set, else render in legacy mode |
+
+## Phase 1 cut-list
+
+In scope for this PR:
+
+1. Add types + storage helpers for plans
+2. Seed `web/review-plans/manual-script-sweep.json` with every script as a
+   case (most `pending`, hello-world web as `implemented`)
+3. Implement `/api/plans*` routes
+4. Capture `tested{}` snapshot at run start
+5. Plans-index UI replaces today's runs-table at `#/`
+6. Plan-detail UI: cases table + run history table
+7. Run-detail UI: case rollup (uses existing slideshow for case drill-in)
+8. Legacy `#/run/<id>` route stays, with a banner when the run has a planId
+9. One hello-world web spec wired through the new runner
+10. Functional spec changelog updated; this dev design committed
+
+Out of scope until later phases:
+
+- Sparklines, diff-vs-last, open-issues panel
+- Subset-run UI (Phase 1 always runs the plan's `implemented` cases)
+- Computer-use AskMac walkthroughs
+- Plan editor UI
+
+## Risks
+
+- **Slideshow regressions** — the slideshow code is freshly stable from the
+  pin/HTML-toggle work. We add a `caseId` query for new-style runs but
+  otherwise leave it untouched.
+- **Storage migration** — none. New runs use the new layout, old runs read
+  unchanged. No batch moves.
+- **Computer-use scope creep** — explicitly punted to Phase 3.
+
+## Test plan for this PR
+
+- Plans index renders with one plan.
+- Plan detail shows the seed cases; pending cases are visible and not runnable.
+- Starting a run from plan detail produces a new run id, captures `tested{}`,
+  invokes the hello-world spec, and writes to `cases/hello-world-web/`.
+- Run detail shows the case rollup; clicking the case opens the slideshow
+  with pins/HTML toggle working.
+- Legacy `#/run/<id>` for a pre-plan run still renders the old slideshow.
+- Lint clean (`npm run lint` in `web/`).
+
+## Change log
+
+| Date | Note |
+|---|---|
+| 2026-05-03 | Initial dev design for Phase 1 foundation |
+| 2026-05-03 | Phase 1 implementation landed: plan + case + run-meta types, /api/plans*, plans index / plan detail / run rollup / case slideshow scoping, story recorder caseId support, hello-world web spec (one implemented case) |

--- a/docs/specs/manual-script-test-plan-dev-design.md
+++ b/docs/specs/manual-script-test-plan-dev-design.md
@@ -211,3 +211,4 @@ Out of scope until later phases:
 |---|---|
 | 2026-05-03 | Initial dev design for Phase 1 foundation |
 | 2026-05-03 | Phase 1 implementation landed: plan + case + run-meta types, /api/plans*, plans index / plan detail / run rollup / case slideshow scoping, story recorder caseId support, hello-world web spec (one implemented case) |
+| 2026-05-03 | Phase 2: startRun accepts specs[]; shared `_walkthrough.ts` helper; 9 new per-script web specs land (brew-monitor, github, ollama, gdocs-history, web-traffic, task-demo, terminal-snapshot, claude-3, codex-3); plan now reports 10/20 implemented |

--- a/docs/specs/manual-script-test-plan-dev-design.md
+++ b/docs/specs/manual-script-test-plan-dev-design.md
@@ -212,3 +212,4 @@ Out of scope until later phases:
 | 2026-05-03 | Initial dev design for Phase 1 foundation |
 | 2026-05-03 | Phase 1 implementation landed: plan + case + run-meta types, /api/plans*, plans index / plan detail / run rollup / case slideshow scoping, story recorder caseId support, hello-world web spec (one implemented case) |
 | 2026-05-03 | Phase 2: startRun accepts specs[]; shared `_walkthrough.ts` helper; 9 new per-script web specs land (brew-monitor, github, ollama, gdocs-history, web-traffic, task-demo, terminal-snapshot, claude-3, codex-3); plan now reports 10/20 implemented |
+| 2026-05-03 | Phase 2.5: PlanCase gains `description` and `steps[]`; PlanStep with id/title/description/nav/waitMs; new `/api/plans/:id/cases/:caseId` route returning declared case + run history; `#/plan/:id/case/:caseId` UI; plan-detail case rows now clickable; `_walkthrough.ts` reads steps from plan JSON so specs shrink to 4 lines |

--- a/docs/specs/manual-script-test-plan.md
+++ b/docs/specs/manual-script-test-plan.md
@@ -326,3 +326,4 @@ A **plan is current** when its latest run is clean and not flagged as drifted
 | 2026-05-03 | Decided: launch with one plan but support many; cases can be subset-run; AskMac driven by computer-use automation |
 | 2026-05-03 | Phase 1 shipped: plan model, /api/plans*, plans index, plan detail, run rollup, case slideshow scoping, hello-world web case wired through new runner |
 | 2026-05-03 | Phase 2 shipped: multi-spec runner; all 10 web cases implemented (hello-world, brew-monitor, github, ollama, gdocs-history, web-traffic, task-demo, terminal-snapshot, claude-3, codex-3) via a shared 8-step walkthrough helper |
+| 2026-05-03 | Phase 2.5 shipped: plan JSON owns each case's description + declared steps (titles, descriptions, nav/wait directives); case detail view at #/plan/:id/case/:caseId; case rows clickable; specs are now thin wrappers that read steps from the plan |

--- a/docs/specs/manual-script-test-plan.md
+++ b/docs/specs/manual-script-test-plan.md
@@ -1,0 +1,327 @@
+# Manual Script Test Plan — Functional Spec
+
+**Status:** DRAFT — awaiting review
+**Owner:** Kevin
+**Last updated:** 2026-05-03
+
+## 1. Purpose
+
+Provide a structured, repeatable manual-test pass that isolates **one script at a
+time** and exercises it through both surfaces (the iPhone webview at
+`localhost:5173` and the native AskMac app). The pass produces step-by-step
+screenshots that are reviewed in the existing localhost review dashboard, where
+issues can be pinned with comments (UI/UX, layout, performance) for triage.
+
+The dashboard is reorganized so **test plans are the entry point**. Every run
+belongs to a plan, every case in a run rolls up to that plan's coverage view,
+and every pin is anchored to a specific git head and tested-version snapshot.
+
+This is an **enhancement to** today's manual testing — it does not replace
+exploratory testing or release smoke tests. It adds a deterministic, per-script
+walkthrough that always covers the same surfaces in the same order, plus
+plan-level reporting to spot regressions across runs.
+
+## 2. Goals
+
+- Per-script regression coverage that catches UI/UX, layout, and performance regressions
+- Single source of evidence: every issue is anchored to a step screenshot with a pin
+- Dependency-aware isolation so script-on-script interactions do not muddy results
+- Parity check: every script is exercised on **both** the web surface and AskMac
+- Plan-first reporting: coverage, run history, and trend lines per plan
+- Reproducibility: every run captures the git head, branch, dirty flag, AskMac
+  build, iOS build, and active script versions
+- Low-friction execution: one command should drive a full per-plan or
+  per-case pass
+- Multi-plan support from day one, with a single launch plan; subset-runs
+  (any selection of cases within a plan) are a first-class operation
+- Native AskMac walkthroughs are automated through computer-use so they
+  produce the same per-step artifacts as web walkthroughs
+
+## 3. Scope
+
+### 3.1 In scope (scripts under test)
+
+Tile / feed / utility scripts that present a UI:
+
+| Script | Surfaces | Hard dependencies |
+|---|---|---|
+| hello-world | web feed/tile | — |
+| brew-monitor | web feed | brew installed |
+| github | web feed/tile | git repos under `~` |
+| ollama | web feed | ollama installed |
+| gdocs-history | web feed | Safari/Chrome history |
+| web-traffic | web feed | browser history |
+| task-demo | web feed | — |
+| terminal-snapshot | web tile | **terminal-manager** |
+| claude-3 | web feed + chat | **terminal-manager** |
+| codex-3 | web feed + chat | **terminal-manager**, tmux, codex CLI |
+| claudecode-controller | web tile | claude-3 |
+| opencode-controller | web tile | (TBD — design only today) |
+
+System scripts exercised only as dependencies, not directly under test:
+
+- terminal-manager (system, headless registry — verified through dependents)
+
+### 3.2 Out of scope
+
+- Push-notification delivery to a real iPhone (covered by `/validate-messaging`)
+- CloudKit sync correctness on real hardware (covered by paused iOS-vs-web project)
+- Onboarding / install flow (covered by release smoke tests)
+- Performance benchmarking with numeric SLAs — this pass surfaces *visible* perf
+  issues only (jank, slow first paint, spinner stuck, etc.)
+
+## 4. Test environment requirements
+
+- Web app reachable at `http://localhost:5173`
+- AskMac running locally (launched from Xcode for dev vault) and reachable at
+  `http://localhost:4242`
+- Review dashboard reachable at `http://localhost:4244`
+- Review dashboard supports plans, cases, runs, pins, and reporting (this spec)
+- A clean script vault state: each pass begins with **all scripts disabled**
+  except the script under test plus its declared dependencies
+
+## 5. Information architecture (plan-first)
+
+The dashboard pivots from run-centric to plan-centric. Four nested concepts:
+
+```
+Test Plan
+  └─ Test Case               (one script × one surface)
+       └─ Run                (one execution at a given git head)
+            └─ Step          (one slide: image + HTML + pins)
+```
+
+A **Plan** owns a set of cases. A **Run** is one execution of one or more cases
+under a plan, against a single git head. A **Case Result** is the per-case
+slice of a run.
+
+### 5.1 Routes
+
+```
+#/                                              Plans index — default landing
+#/plan/<plan-id>                                Plan detail — scope, cases, run history
+#/plan/<plan-id>/run/<run-id>                   Run detail — per-case rollup
+#/plan/<plan-id>/run/<run-id>/<case-id>         Case slideshow — today's per-step UI
+#/run/<run-id>                                  Legacy redirect to the new path
+```
+
+### 5.2 Reporting layers
+
+**Layer 1 — Plans index (the new home)**
+
+A table of every plan with: title, # cases, last run timestamp, last-run pass
+rate, last-run decision, drift status (any source files changed since last
+approval).
+
+**Layer 2 — Plan detail**
+
+- Plan metadata (title, description, version, scope summary)
+- **Coverage table** — every declared case, last result, last decision, and a
+  sparkline of the last N runs so regressions are visible at a glance
+- **Run history table** — every run with git context, tested versions, tally,
+  and decision; click to drill in
+- **Open issues** — every unresolved `bug` / `confusing` pin in the most
+  recent run, grouped by case
+
+**Layer 3 — Run detail**
+
+- Header strip: plan @ version, `git.shortHead` + branch + dirty marker,
+  AskMac vN, iOS vN, started/ended, scope (`all` or `case:<id>`)
+- **Diff vs. last run on this plan** — cases that regressed (passed → failed
+  or new bug pins) highlighted
+- **Per-case rollup table:** case, status (passed / failed / skipped /
+  pending), step count, pin counts split by kind, case-level decision, link
+  to the slideshow
+- **Run output** (collapsed `<details>`)
+
+**Layer 4 — Case slideshow** — the per-step UI we have today, breadcrumbed
+back to its plan and run.
+
+### 5.3 Decision rollup
+
+Per-case decisions are authored in the case slideshow (approve /
+changes-requested / rejected, with optional summary). The run's decision is
+**computed** from its cases:
+
+- All cases approved → run `approved`
+- Any case rejected → run `rejected`
+- Otherwise → run `changes-requested`
+
+A plan does not itself carry a decision — its reporting reflects the rollup of
+its most recent run.
+
+## 6. Test isolation model
+
+For each case in a run, the pass shall:
+
+1. Disable every other script in the vault
+2. Enable the case's script and any scripts it declares as dependencies
+3. Wait for the vault to settle (manifests reloaded, hooks installed)
+4. Run the per-case walkthrough on the declared surface (web or AskMac)
+5. Restore the prior vault state when the case ends (or on abort)
+
+Dependency map used by isolation:
+
+- `claude-3 → terminal-manager`
+- `codex-3 → terminal-manager`
+- `terminal-snapshot → terminal-manager`
+- `claudecode-controller → claude-3 → terminal-manager`
+- `opencode-controller → (per its manifest, when published)`
+
+## 7. Per-case walkthrough — common steps
+
+Every case's walkthrough must capture the following steps (extra script-specific
+steps are added on top). Each step produces a screenshot **plus** the captured
+HTML (web only) so issues can be pinned and shipped to a coding agent.
+
+### 7.1 Web surface (iPhone webview)
+
+1. **Cold open** — feed view with the script just installed
+2. **Tile/feed entry** rendered for the script
+3. **Tap into detail** — primary script surface opens
+4. **Empty state** — what the user sees with no data yet
+5. **Populated state** — script with realistic data
+6. **Primary action** — the most-used action runs end-to-end
+7. **Error / refused state** — denied permission, missing dependency, or offline
+8. **Back-out** — return to the feed; verify the feed reflects the new state
+
+### 7.2 AskMac surface
+
+1. **Cold open** — Settings ▸ Scripts shows the script enabled
+2. **Script row** — version, manifest summary, enable/disable toggle
+3. **Permissions sheet** — the script's declared permissions are listed
+4. **Block view** (if the script publishes blocks) — block renders correctly
+5. **Logs / errors pane** — recent log lines, no red errors
+6. **Disable / re-enable** — verify the script tears down and re-installs cleanly
+
+### 7.3 Script-specific extensions
+
+Each case appends its own steps. Examples (non-exhaustive):
+
+- **claude-3** — start a new session, send a message, see the reply, see the
+  permission prompt round-trip
+- **codex-3** — open existing tmux session, send a message, see scrollback
+- **brew-monitor** — show outdated list, run "upgrade" from feed, see status update
+- **github** — list repos, run pull/push, see commit feedback
+- **ollama** — show model list, surface available update
+- **gdocs-history** — list of recently viewed docs, group by source
+- **web-traffic** — list visits, switch browser source, group by day
+- **terminal-snapshot** — pick a pane, capture text, capture image, verify both
+
+## 8. Plans as authored artifacts
+
+Plans are authored as files in source control under
+`web/review-plans/<plan-id>.json`. A plan declares its cases without requiring
+each spec to be implemented up-front; cases without an implementation render in
+the dashboard as `pending` so missing coverage is reportable.
+
+Each plan record carries:
+
+- `id`, `title`, `description`, `version`
+- `cases[]` — each case has `id`, `scriptId`, `surface` (`web` | `askmac`),
+  `spec` (path to the Playwright spec) or `driver` (for non-Playwright
+  walkthroughs), and declared `deps`
+
+The narrative spec (this document) and the plan JSON file stay in sync via
+the change-log rule. The plan JSON is the executable contract; this document
+is the human-readable rationale.
+
+## 9. Reproducibility — what every run captures
+
+Every run record shall include a `tested` snapshot:
+
+- **Git context:** head sha, short sha, branch name, dirty flag, summary of
+  changed files since the previous run on the same plan
+- **AskMac:** version, source (Xcode dev build / `/Applications` / DMG)
+- **iOS:** version, target (simulator / device), if any iOS step exists in the run
+- **Scripts:** every active script's id and version at run start
+- **Vault:** dev or prod
+
+This snapshot is shown on the run-detail header and used for staleness
+detection on plan and case views.
+
+## 10. Issue capture model
+
+For every step screenshot, the reviewer can attach one or more **pins**. Pins
+already support these kinds:
+
+- `bug` — functional defect
+- `style` — visual / theming issue
+- `copy` — text content or wording
+- `confusing` — UX / IA problem
+- `slow` — observed performance issue
+- `ok` / `comment` — confirmations and freeform notes
+
+Each pin shall include:
+
+- A natural-fraction (x, y) location on the image
+- Free-text description
+- A "Copy step context" hand-off that bundles step title, description, all
+  comments, and the captured HTML for paste into a coding-agent chat
+
+Pin counts roll up to the case (per kind), to the run (per kind), and to the
+plan's last run (per kind, in the open-issues panel). Issues are not
+auto-filed to GitHub; the reviewer decides which pins escalate.
+
+## 11. Acceptance criteria
+
+A **case pass** is complete when:
+
+- All required common steps captured (web or AskMac, per the case's surface)
+- All script-specific steps captured
+- Every step screenshot is present and readable in the case slideshow
+- The case is browseable at `#/plan/<plan-id>/run/<run-id>/<case-id>`
+
+A **case pass is clean** when:
+
+- Zero pins of kind `bug` or `confusing`
+- All `slow` pins triaged with a follow-up note
+- A case-level decision of `approved` is recorded
+
+A **run is complete** when every selected case in the run has a case pass.
+A **run is clean** when its computed decision is `approved`.
+
+A **plan is current** when its latest run is clean and not flagged as drifted
+(no source-tree changes under `web/src/` or `ask/scripts/` since approval).
+
+## 12. Cadence
+
+- **Pre-release** — full plan run before each Mac and iOS release
+- **Per-feature** — single-case run for any script touched in a PR
+- **Ad hoc** — anytime a UI/UX regression is suspected
+
+## 13. Decisions and open questions
+
+**Decided 2026-05-03:**
+
+- **Multiple plans, start with one.** The IA is built to host any number of
+  plans from day one. We launch with a single plan (`manual-script-sweep`)
+  and add more (release smoke, markdown render, send-message round-trip) as
+  needed. The dashboard must support running an arbitrary subset of cases
+  within a plan — full sweeps are not always required.
+- **AskMac driver is computer-use automation.** AskMac walkthroughs are
+  driven by the `mcp__computer-use__*` tools so they are repeatable and
+  produce the same per-step screenshots as the web walkthroughs. Manual
+  hand-driven uploads are not the default path.
+
+**Still open:**
+
+1. **claudecode-controller** — the directory exists but has no source. Is
+   this feature still active, or should it be removed from scope?
+2. **opencode-controller** — design-only today. Skip it, or declare it as a
+   `pending` case so the coverage gap is visible?
+3. **task-demo** — currently auto-runs on install. Should the case treat
+   that as the populated state, or trigger a manual run?
+4. **Dependency teardown** — when a dependency is enabled solely for a
+   case, disable it again at the end, or leave it enabled?
+5. **iOS surface** — when the paused iOS-vs-web comparison resumes, do iOS
+   cases live in this same plan or a sibling plan?
+
+## 14. Change log
+
+| Date | Note |
+|---|---|
+| 2026-05-03 | Initial draft for review |
+| 2026-05-03 | Plan-first IA, four-layer reporting, expanded run reproducibility snapshot |
+| 2026-05-03 | Decided: launch with one plan but support many; cases can be subset-run; AskMac driven by computer-use automation |
+| 2026-05-03 | Phase 1 shipped: plan model, /api/plans*, plans index, plan detail, run rollup, case slideshow scoping, hello-world web case wired through new runner |

--- a/docs/specs/manual-script-test-plan.md
+++ b/docs/specs/manual-script-test-plan.md
@@ -325,3 +325,4 @@ A **plan is current** when its latest run is clean and not flagged as drifted
 | 2026-05-03 | Plan-first IA, four-layer reporting, expanded run reproducibility snapshot |
 | 2026-05-03 | Decided: launch with one plan but support many; cases can be subset-run; AskMac driven by computer-use automation |
 | 2026-05-03 | Phase 1 shipped: plan model, /api/plans*, plans index, plan detail, run rollup, case slideshow scoping, hello-world web case wired through new runner |
+| 2026-05-03 | Phase 2 shipped: multi-spec runner; all 10 web cases implemented (hello-world, brew-monitor, github, ollama, gdocs-history, web-traffic, task-demo, terminal-snapshot, claude-3, codex-3) via a shared 8-step walkthrough helper |

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -1,0 +1,4 @@
+
+# Playwright
+playwright-report/
+test-results/

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -3,3 +3,6 @@
 playwright-report/
 test-results/
 e2e/screenshots/
+
+# Review dashboard runs
+.review/

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -2,3 +2,4 @@
 # Playwright
 playwright-report/
 test-results/
+e2e/screenshots/

--- a/web/e2e/helpers/story.ts
+++ b/web/e2e/helpers/story.ts
@@ -1,0 +1,84 @@
+/**
+ * Step-by-step "story" recorder for e2e specs.
+ *
+ *   import { newStory, step } from './helpers/story'
+ *   const story = newStory(testInfo)
+ *   await step(story, page, 'Open home', '/')
+ *   await step(story, page, 'Click first session', async () => {
+ *     await page.locator('...').click()
+ *   })
+ *
+ * Each call:
+ *   - performs the action (navigate to a path / run a function / no-op for label-only)
+ *   - takes a screenshot named NN-<slug>.png
+ *   - appends an entry to story.json
+ *
+ * Output lives in:
+ *   e2e/screenshots/__story/<test-slug>/
+ *
+ * The review dashboard freezes that directory into the run's frozen
+ * storage and renders it as a vertical timeline with per-step feedback.
+ */
+import type { Page, TestInfo } from '@playwright/test'
+import fs from 'fs'
+import path from 'path'
+import { fileURLToPath } from 'url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const ROOT = path.resolve(__dirname, '..', 'screenshots', '__story')
+
+export interface StoryStep {
+  idx: number
+  name: string
+  file: string
+  at: number
+  durationMs: number
+}
+
+export interface Story {
+  dir: string
+  testTitle: string
+  startedAt: number
+  steps: StoryStep[]
+}
+
+function slug(s: string): string {
+  return s.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '').slice(0, 60)
+}
+
+export function newStory(testInfo: TestInfo): Story {
+  const testSlug = slug(testInfo.titlePath.join(' '))
+  const dir = path.join(ROOT, testSlug)
+  // Reset on every run so old steps don't leak in
+  fs.rmSync(dir, { recursive: true, force: true })
+  fs.mkdirSync(dir, { recursive: true })
+  return { dir, testTitle: testInfo.titlePath.join(' › '), startedAt: Date.now(), steps: [] }
+}
+
+type StepAction = string | (() => Promise<void> | void) | undefined
+
+export async function step(story: Story, page: Page, name: string, action?: StepAction): Promise<void> {
+  const t0 = Date.now()
+  if (typeof action === 'string') {
+    await page.goto(action)
+  } else if (typeof action === 'function') {
+    await action()
+  }
+  // Tiny settle so Playwright's auto-screenshot catches post-action state.
+  await page.waitForTimeout(150)
+
+  const idx = story.steps.length
+  const file = `${String(idx).padStart(2, '0')}-${slug(name)}.png`
+  await page.screenshot({ path: path.join(story.dir, file), fullPage: false })
+  story.steps.push({
+    idx,
+    name,
+    file,
+    at: Date.now(),
+    durationMs: Date.now() - t0,
+  })
+  fs.writeFileSync(
+    path.join(story.dir, 'story.json'),
+    JSON.stringify({ testTitle: story.testTitle, startedAt: story.startedAt, steps: story.steps }, null, 2),
+  )
+}

--- a/web/e2e/helpers/story.ts
+++ b/web/e2e/helpers/story.ts
@@ -2,22 +2,25 @@
  * Step-by-step "story" recorder for e2e specs.
  *
  *   import { newStory, step } from './helpers/story'
- *   const story = newStory(testInfo)
- *   await step(story, page, 'Open home', '/')
- *   await step(story, page, 'Click first session', async () => {
- *     await page.locator('...').click()
+ *
+ *   const story = newStory(testInfo, {
+ *     title: 'Sending a new message to a live Codex agent',
+ *     description: 'Types a probe into the chat, presses Enter, and ' +
+ *       'confirms both the daemon log and the tmux pane received it.',
  *   })
  *
- * Each call:
- *   - performs the action (navigate to a path / run a function / no-op for label-only)
- *   - takes a screenshot named NN-<slug>.png
- *   - appends an entry to story.json
+ *   await step(story, page, {
+ *     title: 'Open the Codex chat',
+ *     description: 'Expect the conversation history with prior turns ' +
+ *       'and a reply input pinned at the bottom.',
+ *   }, '/script/codex-3/session/<id>')
  *
- * Output lives in:
- *   e2e/screenshots/__story/<test-slug>/
+ * For brevity, a plain string step also works (title only):
+ *   await step(story, page, 'Click the reply input', () => input.click())
  *
- * The review dashboard freezes that directory into the run's frozen
- * storage and renders it as a vertical timeline with per-step feedback.
+ * Each step performs the action (navigate / function / no-op for label-only),
+ * takes a screenshot, and appends to story.json. The review dashboard
+ * renders this as a vertical timeline + a sticky horizontal mini-map.
  */
 import type { Page, TestInfo } from '@playwright/test'
 import fs from 'fs'
@@ -29,7 +32,8 @@ const ROOT = path.resolve(__dirname, '..', 'screenshots', '__story')
 
 export interface StoryStep {
   idx: number
-  name: string
+  title: string
+  description: string
   file: string
   at: number
   durationMs: number
@@ -37,48 +41,77 @@ export interface StoryStep {
 
 export interface Story {
   dir: string
-  testTitle: string
+  testTitle: string             // legacy — full Playwright test title path
+  title: string                 // friendly run title
+  description: string           // friendly run description
   startedAt: number
   steps: StoryStep[]
 }
+
+export interface StepInfo { title: string; description?: string }
 
 function slug(s: string): string {
   return s.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '').slice(0, 60)
 }
 
-export function newStory(testInfo: TestInfo): Story {
+export function newStory(testInfo: TestInfo, info?: { title?: string; description?: string }): Story {
   const testSlug = slug(testInfo.titlePath.join(' '))
   const dir = path.join(ROOT, testSlug)
-  // Reset on every run so old steps don't leak in
   fs.rmSync(dir, { recursive: true, force: true })
   fs.mkdirSync(dir, { recursive: true })
-  return { dir, testTitle: testInfo.titlePath.join(' › '), startedAt: Date.now(), steps: [] }
+  return {
+    dir,
+    testTitle: testInfo.titlePath.join(' › '),
+    title: info?.title ?? testInfo.title,
+    description: info?.description ?? '',
+    startedAt: Date.now(),
+    steps: [],
+  }
 }
 
 type StepAction = string | (() => Promise<void> | void) | undefined
 
-export async function step(story: Story, page: Page, name: string, action?: StepAction): Promise<void> {
+function persist(story: Story) {
+  fs.writeFileSync(
+    path.join(story.dir, 'story.json'),
+    JSON.stringify({
+      testTitle: story.testTitle,
+      title: story.title,
+      description: story.description,
+      startedAt: story.startedAt,
+      steps: story.steps,
+    }, null, 2),
+  )
+}
+
+export async function step(
+  story: Story,
+  page: Page,
+  info: string | StepInfo,
+  action?: StepAction,
+): Promise<void> {
+  const { title, description } = typeof info === 'string'
+    ? { title: info, description: '' }
+    : { title: info.title, description: info.description ?? '' }
+
   const t0 = Date.now()
   if (typeof action === 'string') {
     await page.goto(action)
   } else if (typeof action === 'function') {
     await action()
   }
-  // Tiny settle so Playwright's auto-screenshot catches post-action state.
   await page.waitForTimeout(150)
 
   const idx = story.steps.length
-  const file = `${String(idx).padStart(2, '0')}-${slug(name)}.png`
+  const file = `${String(idx).padStart(2, '0')}-${slug(title)}.png`
   await page.screenshot({ path: path.join(story.dir, file), fullPage: false })
   story.steps.push({
     idx,
-    name,
+    title,
+    description,
     file,
     at: Date.now(),
     durationMs: Date.now() - t0,
   })
-  fs.writeFileSync(
-    path.join(story.dir, 'story.json'),
-    JSON.stringify({ testTitle: story.testTitle, startedAt: story.startedAt, steps: story.steps }, null, 2),
-  )
+  persist(story)
 }

--- a/web/e2e/helpers/story.ts
+++ b/web/e2e/helpers/story.ts
@@ -45,6 +45,7 @@ export interface Story {
   testTitle: string             // legacy — full Playwright test title path
   title: string                 // friendly run title
   description: string           // friendly run description
+  caseId?: string               // when set, ties this story to a plan's case
   startedAt: number
   steps: StoryStep[]
 }
@@ -55,8 +56,11 @@ function slug(s: string): string {
   return s.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '').slice(0, 60)
 }
 
-export function newStory(testInfo: TestInfo, info?: { title?: string; description?: string }): Story {
-  const testSlug = slug(testInfo.titlePath.join(' '))
+export function newStory(testInfo: TestInfo, info?: { title?: string; description?: string; caseId?: string }): Story {
+  // Story slug becomes the on-disk folder name and the storyPath the dashboard
+  // uses to look the run up. When this story belongs to a plan's case, the
+  // caseId is the canonical slug so the dashboard can map case <-> story.
+  const testSlug = info?.caseId ?? slug(testInfo.titlePath.join(' '))
   const dir = path.join(ROOT, testSlug)
   fs.rmSync(dir, { recursive: true, force: true })
   fs.mkdirSync(dir, { recursive: true })
@@ -65,6 +69,7 @@ export function newStory(testInfo: TestInfo, info?: { title?: string; descriptio
     testTitle: testInfo.titlePath.join(' › '),
     title: info?.title ?? testInfo.title,
     description: info?.description ?? '',
+    caseId: info?.caseId,
     startedAt: Date.now(),
     steps: [],
   }
@@ -79,6 +84,7 @@ function persist(story: Story) {
       testTitle: story.testTitle,
       title: story.title,
       description: story.description,
+      caseId: story.caseId,
       startedAt: story.startedAt,
       steps: story.steps,
     }, null, 2),

--- a/web/e2e/helpers/story.ts
+++ b/web/e2e/helpers/story.ts
@@ -35,6 +35,7 @@ export interface StoryStep {
   title: string
   description: string
   file: string
+  htmlFile?: string
   at: number
   durationMs: number
 }
@@ -103,13 +104,22 @@ export async function step(
   await page.waitForTimeout(150)
 
   const idx = story.steps.length
-  const file = `${String(idx).padStart(2, '0')}-${slug(title)}.png`
+  const base = `${String(idx).padStart(2, '0')}-${slug(title)}`
+  const file = `${base}.png`
+  const htmlFile = `${base}.html`
   await page.screenshot({ path: path.join(story.dir, file), fullPage: false })
+  // Also capture the live HTML so the dashboard can offer an Image/HTML
+  // toggle and a "Copy step context" hand-off to a coding agent.
+  try {
+    const html = await page.content()
+    fs.writeFileSync(path.join(story.dir, htmlFile), html)
+  } catch { /* non-fatal — page may have navigated */ }
   story.steps.push({
     idx,
     title,
     description,
     file,
+    htmlFile,
     at: Date.now(),
     durationMs: Date.now() - t0,
   })

--- a/web/e2e/home-and-script-detail.spec.ts
+++ b/web/e2e/home-and-script-detail.spec.ts
@@ -1,0 +1,91 @@
+import { test, expect } from '@playwright/test'
+
+// These tests run against the live web app at http://localhost:5173/
+// (vite dev server) which proxies /api to whatever BACKEND_PORT is set.
+// In normal dev that's AskMac's LocalHTTPServer on 4242.
+
+test.describe('home screen', () => {
+  test('renders inside the simulated phone frame at the default size', async ({ page }) => {
+    await page.goto('/')
+    // The phone frame should be in the DOM and fully visible
+    const frame = page.locator('#phone-frame')
+    await expect(frame).toBeVisible({ timeout: 5000 })
+
+    // The screen interior should be 390 × 844 (iPhone 16 Pro logical size).
+    // We can't assert clientHeight directly because of the zoom-based scaling,
+    // but the inline-styled container exists.
+    const screen = page.locator('#phone-screen')
+    await expect(screen).toBeVisible()
+  })
+
+  test('phone fits without bottom clipping after window resize', async ({ page }) => {
+    await page.goto('/')
+    const frame = page.locator('#phone-frame')
+    await expect(frame).toBeVisible()
+
+    // Shrink the viewport to 1100x600 (smaller than the unscaled phone).
+    // The fix in usePhoneScale should rescale so the frame stays fully on-screen.
+    await page.setViewportSize({ width: 1100, height: 600 })
+    await page.waitForTimeout(300)  // let ResizeObserver fire
+
+    const box = await frame.boundingBox()
+    if (!box) throw new Error('frame has no bounding box')
+    expect(box.y).toBeGreaterThanOrEqual(0)
+    expect(box.y + box.height).toBeLessThanOrEqual(600 + 1)  // 1px slack for sub-pixel rounding
+  })
+})
+
+test.describe('script detail screen', () => {
+  test('claude-3 detail page loads and shows "in-process" badge for non-tmux/non-tty session', async ({ page }) => {
+    await page.goto('/script/claude-3')
+    // Page chrome
+    await expect(page.getByText(/SESSIONS/i)).toBeVisible({ timeout: 5000 })
+    // The supervisor session has neither tmux_target nor tty — so the badge
+    // should read "in-process", NOT "headless" (this is the fix from
+    // ScriptDetailScreen.tsx).
+    // Note: the debug badge is gated on a setting (`showBlockDebugInfo`), so
+    // skip the assertion when the badge is absent rather than failing the run.
+    const badges = page.getByText(/^(tmux|terminal|in-process|headless)$/)
+    const count = await badges.count()
+    if (count > 0) {
+      // If any badge is shown, none of the visible no-routing sessions
+      // should be labelled "headless".
+      const headlessCount = await page.getByText(/^headless$/).count()
+      expect(headlessCount).toBe(0)
+    }
+  })
+})
+
+test.describe('messages api', () => {
+  test('getTaskMessages returns time-sorted history', async ({ page, request }) => {
+    // Pull the live blocks from AskMac:4242 via the vite proxy
+    const blocksResp = await request.get('/api/blocks')
+    expect(blocksResp.ok()).toBeTruthy()
+    const data = await blocksResp.json() as { blocks: Array<{ blockID: string; payload: string }> }
+    const sessionBlock = data.blocks.find(b => b.blockID.startsWith('claude3-session-') || b.blockID.startsWith('codex3-session-'))
+    if (!sessionBlock) {
+      test.skip(true, 'no agent_session block live; nothing to verify')
+      return
+    }
+    const payload = JSON.parse(sessionBlock.payload) as { task_id: string }
+    const taskID = payload.task_id
+
+    // Fetch messages directly through the same code the SessionChatScreen uses
+    await page.goto('/')
+    const sorted = await page.evaluate(async (tid: string) => {
+      const r = await fetch(`/api/tasks/${encodeURIComponent(tid)}/messages`)
+      const j = await r.json() as { messages?: Array<{ timestamp: string; sequenceNumber: number }> }
+      const ms = (j.messages ?? []).slice().sort((a, b) => {
+        const t = (a.timestamp ?? '').localeCompare(b.timestamp ?? '')
+        if (t !== 0) return t
+        return (a.sequenceNumber ?? 0) - (b.sequenceNumber ?? 0)
+      })
+      return ms.map(m => m.timestamp)
+    }, taskID)
+
+    // Each timestamp should be >= the previous one (chronological order)
+    for (let i = 1; i < sorted.length; i++) {
+      expect(sorted[i] >= sorted[i - 1]).toBeTruthy()
+    }
+  })
+})

--- a/web/e2e/markdown-dev-showcase.spec.ts
+++ b/web/e2e/markdown-dev-showcase.spec.ts
@@ -1,0 +1,31 @@
+import { test } from '@playwright/test'
+import fs from 'fs'
+import path from 'path'
+import { fileURLToPath } from 'url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const SHOTS = path.join(__dirname, 'screenshots', 'markdown-showcase')
+fs.mkdirSync(SHOTS, { recursive: true })
+
+test('markdown showcase — renders every styled element via /dev/markdown', async ({ page }) => {
+  await page.goto('/dev/markdown')
+  await page.waitForTimeout(800)
+
+  // Capture only the inner scroll container of the phone screen, in
+  // segments — the frame itself is fixed-height so fullPage doesn't help.
+  const inner = page.locator('#phone-screen .overflow-y-auto').first()
+  await inner.evaluate((el) => { el.scrollTop = 0 })
+  await page.screenshot({ path: path.join(SHOTS, 'after-1-top.png'), fullPage: false, clip: await inner.boundingBox() ?? undefined })
+
+  await inner.evaluate((el) => { el.scrollTop = el.scrollHeight / 3 })
+  await page.waitForTimeout(200)
+  await page.screenshot({ path: path.join(SHOTS, 'after-2-mid.png'), fullPage: false, clip: await inner.boundingBox() ?? undefined })
+
+  await inner.evaluate((el) => { el.scrollTop = (el.scrollHeight * 2) / 3 })
+  await page.waitForTimeout(200)
+  await page.screenshot({ path: path.join(SHOTS, 'after-3-mid2.png'), fullPage: false, clip: await inner.boundingBox() ?? undefined })
+
+  await inner.evaluate((el) => { el.scrollTop = el.scrollHeight })
+  await page.waitForTimeout(200)
+  await page.screenshot({ path: path.join(SHOTS, 'after-4-bottom.png'), fullPage: false, clip: await inner.boundingBox() ?? undefined })
+})

--- a/web/e2e/markdown-render-check.spec.ts
+++ b/web/e2e/markdown-render-check.spec.ts
@@ -1,0 +1,68 @@
+import { test } from '@playwright/test'
+import fs from 'fs'
+import path from 'path'
+import { fileURLToPath } from 'url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const SHOTS = path.join(__dirname, 'screenshots', 'annotated')
+fs.mkdirSync(SHOTS, { recursive: true })
+
+// Annotated screenshot: navigate to a live codex session, then have the page
+// outline every rendered markdown element produced by react-markdown so we
+// can SEE that <code>, <strong>, <pre>, <h1>...<h3> are actually there in the
+// DOM (not raw asterisks/backticks). Output saved to e2e/screenshots/annotated/.
+
+test('markdown renders in assistant messages — annotated proof', async ({ page, request }) => {
+  const blocks = (await (await request.get('/api/blocks')).json()) as { blocks: Array<{ blockID: string; payload: string }> }
+  const sb = blocks.blocks.find(b => b.blockID.startsWith('codex3-session-')) || blocks.blocks.find(b => b.blockID.startsWith('claude3-session-'))
+  test.skip(!sb, 'no live agent_session block')
+  if (!sb) return
+
+  const payload = JSON.parse(sb.payload) as { session_id: string }
+  const scriptID = sb.blockID.startsWith('claude3-') ? 'claude-3' : 'codex-3'
+  await page.goto(`/script/${scriptID}/session/${encodeURIComponent(payload.session_id)}`)
+  await page.waitForTimeout(1500)
+
+  // Inject overlays: outline + label every rendered markdown element type.
+  // If markdown WERE NOT rendering, the page would have raw asterisks and
+  // backticks as plain text and these selectors would match nothing.
+  const summary = await page.evaluate(() => {
+    const colors: Record<string, string> = {
+      'strong':     '#ff3b30',  // red
+      'em':         '#ff9500',  // orange
+      'code':       '#34c759',  // green — inline code
+      'pre':        '#007aff',  // blue — code block
+      'h1, h2, h3': '#af52de',  // purple — headings
+      'ul, ol':     '#5ac8fa',  // cyan — lists
+      'blockquote': '#ffcc00',  // yellow — quotes
+      'a':          '#ff2d55',  // pink — links
+    }
+    const counts: Record<string, number> = {}
+    for (const [sel, color] of Object.entries(colors)) {
+      const els = document.querySelectorAll(sel)
+      counts[sel] = els.length
+      els.forEach(el => {
+        ;(el as HTMLElement).style.outline = `2px solid ${color}`
+        ;(el as HTMLElement).style.outlineOffset = '2px'
+      })
+    }
+    // Add a legend in the top-left corner
+    const legend = document.createElement('div')
+    legend.style.cssText = `
+      position: fixed; top: 8px; left: 8px; z-index: 99999;
+      background: rgba(20,20,20,0.95); color: #fff; font: 12px/1.4 ui-monospace,monospace;
+      padding: 10px 12px; border-radius: 8px; box-shadow: 0 4px 12px rgba(0,0,0,0.4);
+    `
+    legend.innerHTML = `
+      <div style="font-weight:700;margin-bottom:6px">Rendered markdown elements found:</div>
+      ${Object.entries(colors).map(([sel, color]) =>
+        `<div><span style="display:inline-block;width:10px;height:10px;background:${color};margin-right:6px;border-radius:2px"></span><code style="color:#fff">${sel}</code> — <strong>${counts[sel]}</strong></div>`
+      ).join('')}
+    `
+    document.body.appendChild(legend)
+    return counts
+  })
+
+  console.log('markdown element counts:', summary)
+  await page.screenshot({ path: path.join(SHOTS, 'markdown-rendered.png'), fullPage: true })
+})

--- a/web/e2e/screenshot-tour.spec.ts
+++ b/web/e2e/screenshot-tour.spec.ts
@@ -1,0 +1,38 @@
+import { test } from '@playwright/test'
+import fs from 'fs'
+import path from 'path'
+import { fileURLToPath } from 'url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+
+// Visits every primary route and writes a full-page PNG to e2e/screenshots/.
+// Read these from the agent (or browse them locally) to spot UI regressions
+// at a glance. The agent uses the Read tool with the .png path to actually
+// view the rendering — text-only API checks miss visual bugs like the
+// "headless" badge mislabel that prompted this skill.
+
+const OUT_DIR = path.join(__dirname, 'screenshots')
+fs.mkdirSync(OUT_DIR, { recursive: true })
+
+async function tour(page: import('@playwright/test').Page, route: string, filename: string) {
+  await page.goto(route)
+  await page.waitForTimeout(800)  // let SSE seed + initial fetches resolve
+  await page.screenshot({ path: path.join(OUT_DIR, filename), fullPage: true })
+}
+
+test.describe('screenshot tour @manual', () => {
+  test('iOS theme — every primary route', async ({ page }) => {
+    // Default theme is iOS. Routes: /, /home, /tasks, /settings, /script/<id>
+    await tour(page, '/',         '01-root.png')
+    await tour(page, '/home',     '02-home.png')
+    await tour(page, '/tasks',    '03-tasks.png')
+    await tour(page, '/settings', '04-settings.png')
+    await tour(page, '/script/claude-3', '05-script-claude-3.png')
+    await tour(page, '/script/codex-3',  '06-script-codex-3.png')
+  })
+
+  test('script detail at narrow viewport — frame must not clip', async ({ page }) => {
+    await page.setViewportSize({ width: 1100, height: 600 })
+    await tour(page, '/script/claude-3', '07-narrow-claude-3.png')
+  })
+})

--- a/web/e2e/send-message-roundtrip.spec.ts
+++ b/web/e2e/send-message-roundtrip.spec.ts
@@ -8,11 +8,15 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const HOME = process.env.HOME!
 const CODEX_LOG = path.join(HOME, '.ask/logs/codex-3.log')
 
-// Records a per-step "story" of what we did, with a screenshot at each
-// step. The review dashboard renders this as a vertical timeline so a
-// human can see the actions taken between screens, not just an end state.
 test('codex agent_session — type a probe in the UI, daemon routes it', async ({ page, request }, testInfo) => {
-  const story = newStory(testInfo)
+  const story = newStory(testInfo, {
+    title: 'Sending a message to a live Codex session from the web app',
+    description:
+      'Drives the same chat UI a user would touch on the iPhone or browser — ' +
+      'navigates into the live Codex session, types a probe, presses Enter, ' +
+      'and confirms the daemon routed it and the tmux pane received the keystrokes. ' +
+      'A green run here means the iPhone → AskMac → daemon → tmux path is healthy end-to-end.',
+  })
 
   const blocks = (await (await request.get('/api/blocks')).json()) as { blocks: Array<{ blockID: string; payload: string }> }
   const sessionBlock = blocks.blocks.find(b => b.blockID.startsWith('codex3-session-'))
@@ -25,23 +29,41 @@ test('codex agent_session — type a probe in the UI, daemon routes it', async (
   const PROBE = `ui-probe-${Date.now()}-${Math.floor(Math.random() * 1e4)}`
   const offset = fs.statSync(CODEX_LOG).size
 
-  await step(story, page, 'Open codex chat for the live session',
-    `/script/codex-3/session/${encodeURIComponent(SESSION_ID)}`)
+  await step(story, page, {
+    title: 'Open the Codex chat',
+    description:
+      'Land on the conversation thread for the live session. Expect to see the ' +
+      'prior chat history and a reply input pinned at the bottom.',
+  }, `/script/codex-3/session/${encodeURIComponent(SESSION_ID)}`)
 
   const input = page.getByPlaceholder(/Message Codex|Reply|Message Claude/i).first()
   await expect(input).toBeVisible({ timeout: 5000 })
 
-  await step(story, page, 'Focus the reply input', async () => {
+  await step(story, page, {
+    title: 'Click into the reply input',
+    description: 'The cursor should land in the message box; placeholder fades.',
+  }, async () => {
     await input.click()
   })
 
-  await step(story, page, `Type the probe text "${PROBE}"`, async () => {
+  await step(story, page, {
+    title: 'Type a test message',
+    description:
+      'A short probe string is typed character-by-character. The blue user-bubble ' +
+      'will only appear after submission, so this step is mostly verifying that ' +
+      'the input accepts text.',
+  }, async () => {
     await input.fill(PROBE)
   })
 
-  await step(story, page, 'Press Enter to submit', async () => {
+  await step(story, page, {
+    title: 'Send the message',
+    description:
+      'Pressing Enter ships the message through to the daemon. Within a couple ' +
+      'of seconds you should see the user bubble and a "Working…" indicator below.',
+  }, async () => {
     await input.press('Enter')
-    await page.waitForTimeout(2000)   // round trip + assistant first-token
+    await page.waitForTimeout(2000)
   })
 
   // ----- assertions: daemon log, tmux pane, plus a final story shot -----
@@ -53,5 +75,12 @@ test('codex agent_session — type a probe in the UI, daemon routes it', async (
   const tmuxOutput = execSync(`tmux capture-pane -t '${TMUX_TARGET}' -p`).toString()
   expect(tmuxOutput).toContain(PROBE)
 
-  await step(story, page, 'Verified: probe received in tmux + daemon log routed it')
+  await step(story, page, {
+    title: 'Confirm Codex received the message',
+    description:
+      'Behind the scenes we just checked the codex-3 daemon log for "reply ok=True" ' +
+      'and captured the codex tmux pane to confirm the probe text actually arrived. ' +
+      'If you see this step, the full chain — UI → AskMac HTTP → daemon socket → ' +
+      'terminal-manager → tmux → agent — is working.',
+  })
 })

--- a/web/e2e/send-message-roundtrip.spec.ts
+++ b/web/e2e/send-message-roundtrip.spec.ts
@@ -1,0 +1,59 @@
+import { test, expect } from '@playwright/test'
+import fs from 'fs'
+import path from 'path'
+import { fileURLToPath } from 'url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const SHOTS = path.join(__dirname, 'screenshots', 'roundtrip')
+fs.mkdirSync(SHOTS, { recursive: true })
+
+const HOME = process.env.HOME!
+const CODEX_LOG = path.join(HOME, '.ask/logs/codex-3.log')
+
+// Real "manual" round trip via the UI:
+//   open /  →  navigate to a codex session  →  type a probe  →  hit send
+//   →  verify the daemon log shows it routed
+//   →  verify the tmux pane received the keystrokes
+// Screenshots before/after every step land in screenshots/roundtrip/.
+
+test('codex agent_session — type a probe in the UI, daemon routes it', async ({ page, request }) => {
+  // Pick a live codex agent_session block via the API (whatever the backend says is live)
+  const blocks = (await (await request.get('/api/blocks')).json()) as { blocks: Array<{ blockID: string; payload: string }> }
+  const sessionBlock = blocks.blocks.find(b => b.blockID.startsWith('codex3-session-'))
+  test.skip(!sessionBlock, 'no live codex agent_session block; nothing to drive')
+  if (!sessionBlock) return
+
+  const payload = JSON.parse(sessionBlock.payload) as { session_id: string; tmux_target?: string | null }
+  const SESSION_ID = payload.session_id
+  const TMUX_TARGET = payload.tmux_target || 'codex:skills.0'
+  const PROBE = `ui-probe-${Date.now()}-${Math.floor(Math.random() * 1e4)}`
+  const offset = fs.statSync(CODEX_LOG).size
+
+  // Navigate to the session chat screen (the real route the UI uses)
+  await page.goto(`/script/codex-3/session/${encodeURIComponent(SESSION_ID)}`)
+  await page.waitForTimeout(1000)
+  await page.screenshot({ path: path.join(SHOTS, '01-chat-loaded.png'), fullPage: true })
+
+  // Find the reply input. The placeholder text in the codex agent_session
+  // block is set by the daemon; fall back to a generic Message…/Reply… match.
+  const input = page.getByPlaceholder(/Message Codex|Reply|Message Claude/i).first()
+  await expect(input).toBeVisible({ timeout: 5000 })
+  await input.fill(PROBE)
+  await page.screenshot({ path: path.join(SHOTS, '02-probe-typed.png'), fullPage: true })
+
+  // Submit. iOS variant has the input + a circular send button next to it
+  // (via SessionChatScreen.tsx); the simplest trigger is Enter.
+  await input.press('Enter')
+  await page.waitForTimeout(2000) // round trip + assistant first-token
+  await page.screenshot({ path: path.join(SHOTS, '03-after-send.png'), fullPage: true })
+
+  // Verify the daemon routed it
+  const newLog = fs.readFileSync(CODEX_LOG).slice(offset).toString()
+  expect(newLog).toMatch(/block response/)
+  expect(newLog).toMatch(new RegExp(`reply session=.*ok=True.*${PROBE}`))
+
+  // Verify the tmux pane received the probe text
+  const { execSync } = await import('child_process')
+  const tmux = execSync(`tmux capture-pane -t '${TMUX_TARGET}' -p`).toString()
+  expect(tmux).toContain(PROBE)
+})

--- a/web/e2e/send-message-roundtrip.spec.ts
+++ b/web/e2e/send-message-roundtrip.spec.ts
@@ -2,25 +2,21 @@ import { test, expect } from '@playwright/test'
 import fs from 'fs'
 import path from 'path'
 import { fileURLToPath } from 'url'
+import { newStory, step } from './helpers/story'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
-const SHOTS = path.join(__dirname, 'screenshots', 'roundtrip')
-fs.mkdirSync(SHOTS, { recursive: true })
-
 const HOME = process.env.HOME!
 const CODEX_LOG = path.join(HOME, '.ask/logs/codex-3.log')
 
-// Real "manual" round trip via the UI:
-//   open /  →  navigate to a codex session  →  type a probe  →  hit send
-//   →  verify the daemon log shows it routed
-//   →  verify the tmux pane received the keystrokes
-// Screenshots before/after every step land in screenshots/roundtrip/.
+// Records a per-step "story" of what we did, with a screenshot at each
+// step. The review dashboard renders this as a vertical timeline so a
+// human can see the actions taken between screens, not just an end state.
+test('codex agent_session — type a probe in the UI, daemon routes it', async ({ page, request }, testInfo) => {
+  const story = newStory(testInfo)
 
-test('codex agent_session — type a probe in the UI, daemon routes it', async ({ page, request }) => {
-  // Pick a live codex agent_session block via the API (whatever the backend says is live)
   const blocks = (await (await request.get('/api/blocks')).json()) as { blocks: Array<{ blockID: string; payload: string }> }
   const sessionBlock = blocks.blocks.find(b => b.blockID.startsWith('codex3-session-'))
-  test.skip(!sessionBlock, 'no live codex agent_session block; nothing to drive')
+  test.skip(!sessionBlock, 'no live codex agent_session block')
   if (!sessionBlock) return
 
   const payload = JSON.parse(sessionBlock.payload) as { session_id: string; tmux_target?: string | null }
@@ -29,31 +25,33 @@ test('codex agent_session — type a probe in the UI, daemon routes it', async (
   const PROBE = `ui-probe-${Date.now()}-${Math.floor(Math.random() * 1e4)}`
   const offset = fs.statSync(CODEX_LOG).size
 
-  // Navigate to the session chat screen (the real route the UI uses)
-  await page.goto(`/script/codex-3/session/${encodeURIComponent(SESSION_ID)}`)
-  await page.waitForTimeout(1000)
-  await page.screenshot({ path: path.join(SHOTS, '01-chat-loaded.png'), fullPage: true })
+  await step(story, page, 'Open codex chat for the live session',
+    `/script/codex-3/session/${encodeURIComponent(SESSION_ID)}`)
 
-  // Find the reply input. The placeholder text in the codex agent_session
-  // block is set by the daemon; fall back to a generic Message…/Reply… match.
   const input = page.getByPlaceholder(/Message Codex|Reply|Message Claude/i).first()
   await expect(input).toBeVisible({ timeout: 5000 })
-  await input.fill(PROBE)
-  await page.screenshot({ path: path.join(SHOTS, '02-probe-typed.png'), fullPage: true })
 
-  // Submit. iOS variant has the input + a circular send button next to it
-  // (via SessionChatScreen.tsx); the simplest trigger is Enter.
-  await input.press('Enter')
-  await page.waitForTimeout(2000) // round trip + assistant first-token
-  await page.screenshot({ path: path.join(SHOTS, '03-after-send.png'), fullPage: true })
+  await step(story, page, 'Focus the reply input', async () => {
+    await input.click()
+  })
 
-  // Verify the daemon routed it
+  await step(story, page, `Type the probe text "${PROBE}"`, async () => {
+    await input.fill(PROBE)
+  })
+
+  await step(story, page, 'Press Enter to submit', async () => {
+    await input.press('Enter')
+    await page.waitForTimeout(2000)   // round trip + assistant first-token
+  })
+
+  // ----- assertions: daemon log, tmux pane, plus a final story shot -----
   const newLog = fs.readFileSync(CODEX_LOG).slice(offset).toString()
   expect(newLog).toMatch(/block response/)
   expect(newLog).toMatch(new RegExp(`reply session=.*ok=True.*${PROBE}`))
 
-  // Verify the tmux pane received the probe text
   const { execSync } = await import('child_process')
-  const tmux = execSync(`tmux capture-pane -t '${TMUX_TARGET}' -p`).toString()
-  expect(tmux).toContain(PROBE)
+  const tmuxOutput = execSync(`tmux capture-pane -t '${TMUX_TARGET}' -p`).toString()
+  expect(tmuxOutput).toContain(PROBE)
+
+  await step(story, page, 'Verified: probe received in tmux + daemon log routed it')
 })

--- a/web/e2e/specs/scripts/_walkthrough.ts
+++ b/web/e2e/specs/scripts/_walkthrough.ts
@@ -1,71 +1,67 @@
 /**
- * Shared 8-step walkthrough for a script's web surface. Each per-script spec
- * imports this and supplies the script id + case id. Customisations (e.g.
- * additional script-specific steps) are appended by the caller via `extra`.
+ * Plan-driven walkthrough executor.
  *
- * The eight common steps follow §7.1 of docs/specs/manual-script-test-plan.md.
+ * The plan JSON at web/review-plans/manual-script-sweep.json is the single
+ * source of truth for per-case steps (titles, descriptions, and execution
+ * directives like `nav` or `waitMs`). A spec passes its caseId; the helper
+ * looks the case up, opens a story, and walks the declared steps in order.
+ *
+ * This means the dashboard's case-detail page and the slideshow show the
+ * same step list — declared steps, executed steps, and pinned-comment
+ * targets all agree.
  */
 import type { Page, TestInfo } from '@playwright/test'
+import fs from 'fs'
+import path from 'path'
+import { fileURLToPath } from 'url'
 import { newStory, step } from '../../helpers/story'
 
-export interface WalkthroughOpts {
-  caseId: string
-  scriptId: string
-  scriptName: string
-  /** Optional script-specific steps to run between "Populated state" and "Back-out". */
-  extra?: (page: Page, story: ReturnType<typeof newStory>) => Promise<void>
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const PLAN_PATH = path.resolve(__dirname, '..', '..', '..', 'review-plans', 'manual-script-sweep.json')
+
+interface PlanStep {
+  id: string
+  title: string
+  description: string
+  nav?: string
+  waitMs?: number
+}
+interface PlanCase {
+  id: string
+  surface: 'web' | 'askmac'
+  title: string
+  description?: string
+  steps?: PlanStep[]
+}
+interface Plan { cases: PlanCase[] }
+
+function loadPlan(): Plan {
+  return JSON.parse(fs.readFileSync(PLAN_PATH, 'utf-8')) as Plan
 }
 
-export async function runWebWalkthrough(
-  page: Page,
-  testInfo: TestInfo,
-  opts: WalkthroughOpts,
-): Promise<void> {
+export function getCase(caseId: string): PlanCase {
+  const plan = loadPlan()
+  const c = plan.cases.find(x => x.id === caseId)
+  if (!c) throw new Error(`case "${caseId}" not declared in plan ${PLAN_PATH}`)
+  return c
+}
+
+/** Walk a web case's declared steps. Each step is one screenshot + HTML. */
+export async function runWebCase(page: Page, testInfo: TestInfo, caseId: string): Promise<void> {
+  const c = getCase(caseId)
+  if (c.surface !== 'web') throw new Error(`case "${caseId}" surface=${c.surface}, expected web`)
+  if (!c.steps?.length) throw new Error(`case "${caseId}" has no declared steps`)
+
   const story = newStory(testInfo, {
-    caseId: opts.caseId,
-    title: `${opts.scriptName} · Web walkthrough`,
-    description: `Cold open through back-out for the ${opts.scriptId} script on the iPhone webview.`,
+    caseId: c.id,
+    title: c.title,
+    description: c.description ?? '',
   })
 
-  await step(story, page, {
-    title: 'Cold open',
-    description: 'Open the home feed at /home with no other interaction; expect the script list to render.',
-  }, '/home')
-
-  await step(story, page, {
-    title: 'Tile / feed entry',
-    description: `The ${opts.scriptId} tile or feed entry renders with its icon and name in the home feed.`,
-  }, async () => { await page.waitForTimeout(300) })
-
-  await step(story, page, {
-    title: 'Tap into detail',
-    description: `Navigate to /script/${opts.scriptId} — the script's primary surface.`,
-  }, `/script/${opts.scriptId}`)
-
-  await step(story, page, {
-    title: 'Empty state',
-    description: 'Detail screen on first paint — what the user sees before data arrives.',
-  }, async () => { await page.waitForTimeout(300) })
-
-  await step(story, page, {
-    title: 'Populated state',
-    description: 'Same screen after a brief settle — captures whatever blocks the script publishes.',
-  }, async () => { await page.waitForTimeout(900) })
-
-  if (opts.extra) await opts.extra(page, story)
-
-  await step(story, page, {
-    title: 'Primary action',
-    description: `Visit /tasks to confirm any tasks emitted by ${opts.scriptId} are in the feed.`,
-  }, '/tasks')
-
-  await step(story, page, {
-    title: 'Error / refused state',
-    description: `Visit /settings to confirm ${opts.scriptId} permissions and toggles render correctly.`,
-  }, '/settings')
-
-  await step(story, page, {
-    title: 'Back-out',
-    description: 'Return to the home feed; verify the tile state survives navigation.',
-  }, '/home')
+  for (const s of c.steps) {
+    await step(story, page, { title: s.title, description: s.description }, async () => {
+      if (s.nav) await page.goto(s.nav)
+      if (typeof s.waitMs === 'number') await page.waitForTimeout(s.waitMs)
+    })
+  }
 }

--- a/web/e2e/specs/scripts/_walkthrough.ts
+++ b/web/e2e/specs/scripts/_walkthrough.ts
@@ -1,0 +1,71 @@
+/**
+ * Shared 8-step walkthrough for a script's web surface. Each per-script spec
+ * imports this and supplies the script id + case id. Customisations (e.g.
+ * additional script-specific steps) are appended by the caller via `extra`.
+ *
+ * The eight common steps follow §7.1 of docs/specs/manual-script-test-plan.md.
+ */
+import type { Page, TestInfo } from '@playwright/test'
+import { newStory, step } from '../../helpers/story'
+
+export interface WalkthroughOpts {
+  caseId: string
+  scriptId: string
+  scriptName: string
+  /** Optional script-specific steps to run between "Populated state" and "Back-out". */
+  extra?: (page: Page, story: ReturnType<typeof newStory>) => Promise<void>
+}
+
+export async function runWebWalkthrough(
+  page: Page,
+  testInfo: TestInfo,
+  opts: WalkthroughOpts,
+): Promise<void> {
+  const story = newStory(testInfo, {
+    caseId: opts.caseId,
+    title: `${opts.scriptName} · Web walkthrough`,
+    description: `Cold open through back-out for the ${opts.scriptId} script on the iPhone webview.`,
+  })
+
+  await step(story, page, {
+    title: 'Cold open',
+    description: 'Open the home feed at /home with no other interaction; expect the script list to render.',
+  }, '/home')
+
+  await step(story, page, {
+    title: 'Tile / feed entry',
+    description: `The ${opts.scriptId} tile or feed entry renders with its icon and name in the home feed.`,
+  }, async () => { await page.waitForTimeout(300) })
+
+  await step(story, page, {
+    title: 'Tap into detail',
+    description: `Navigate to /script/${opts.scriptId} — the script's primary surface.`,
+  }, `/script/${opts.scriptId}`)
+
+  await step(story, page, {
+    title: 'Empty state',
+    description: 'Detail screen on first paint — what the user sees before data arrives.',
+  }, async () => { await page.waitForTimeout(300) })
+
+  await step(story, page, {
+    title: 'Populated state',
+    description: 'Same screen after a brief settle — captures whatever blocks the script publishes.',
+  }, async () => { await page.waitForTimeout(900) })
+
+  if (opts.extra) await opts.extra(page, story)
+
+  await step(story, page, {
+    title: 'Primary action',
+    description: `Visit /tasks to confirm any tasks emitted by ${opts.scriptId} are in the feed.`,
+  }, '/tasks')
+
+  await step(story, page, {
+    title: 'Error / refused state',
+    description: `Visit /settings to confirm ${opts.scriptId} permissions and toggles render correctly.`,
+  }, '/settings')
+
+  await step(story, page, {
+    title: 'Back-out',
+    description: 'Return to the home feed; verify the tile state survives navigation.',
+  }, '/home')
+}

--- a/web/e2e/specs/scripts/brew-monitor.web.spec.ts
+++ b/web/e2e/specs/scripts/brew-monitor.web.spec.ts
@@ -1,14 +1,10 @@
 /**
- * Manual-test walkthrough for `brew-monitor` on the web surface.
- * Plan: manual-script-sweep · Case: brew-monitor-web
+ * Web case · brew-monitor
+ * Steps are declared in web/review-plans/manual-script-sweep.json.
  */
 import { test } from '@playwright/test'
-import { runWebWalkthrough } from './_walkthrough'
+import { runWebCase } from './_walkthrough'
 
 test('brew-monitor-web', async ({ page }, testInfo) => {
-  await runWebWalkthrough(page, testInfo, {
-    caseId: 'brew-monitor-web',
-    scriptId: 'brew-monitor',
-    scriptName: 'Homebrew',
-  })
+  await runWebCase(page, testInfo, 'brew-monitor-web')
 })

--- a/web/e2e/specs/scripts/brew-monitor.web.spec.ts
+++ b/web/e2e/specs/scripts/brew-monitor.web.spec.ts
@@ -1,0 +1,14 @@
+/**
+ * Manual-test walkthrough for `brew-monitor` on the web surface.
+ * Plan: manual-script-sweep · Case: brew-monitor-web
+ */
+import { test } from '@playwright/test'
+import { runWebWalkthrough } from './_walkthrough'
+
+test('brew-monitor-web', async ({ page }, testInfo) => {
+  await runWebWalkthrough(page, testInfo, {
+    caseId: 'brew-monitor-web',
+    scriptId: 'brew-monitor',
+    scriptName: 'Homebrew',
+  })
+})

--- a/web/e2e/specs/scripts/claude-3.web.spec.ts
+++ b/web/e2e/specs/scripts/claude-3.web.spec.ts
@@ -1,26 +1,10 @@
 /**
- * Manual-test walkthrough for `claude-3` on the web surface.
- * Plan: manual-script-sweep · Case: claude-3-web
- * Hard dep: terminal-manager (system script — must be enabled in vault)
- *
- * Claude 3 is a session supervisor — its detail screen shows a session list
- * and tapping a session opens a chat thread. The walkthrough adds an extra
- * "session list" step between populated state and the primary action.
+ * Web case · claude-3
+ * Steps are declared in web/review-plans/manual-script-sweep.json.
  */
 import { test } from '@playwright/test'
-import { runWebWalkthrough } from './_walkthrough'
-import { step } from '../../helpers/story'
+import { runWebCase } from './_walkthrough'
 
 test('claude-3-web', async ({ page }, testInfo) => {
-  await runWebWalkthrough(page, testInfo, {
-    caseId: 'claude-3-web',
-    scriptId: 'claude-3',
-    scriptName: 'Claude 3',
-    extra: async (page, story) => {
-      await step(story, page, {
-        title: 'Session list',
-        description: 'The detail screen lists active and recent Claude Code sessions; verify the badges (tmux/in-process/headless) render correctly.',
-      }, async () => { await page.waitForTimeout(500) })
-    },
-  })
+  await runWebCase(page, testInfo, 'claude-3-web')
 })

--- a/web/e2e/specs/scripts/claude-3.web.spec.ts
+++ b/web/e2e/specs/scripts/claude-3.web.spec.ts
@@ -1,0 +1,26 @@
+/**
+ * Manual-test walkthrough for `claude-3` on the web surface.
+ * Plan: manual-script-sweep · Case: claude-3-web
+ * Hard dep: terminal-manager (system script — must be enabled in vault)
+ *
+ * Claude 3 is a session supervisor — its detail screen shows a session list
+ * and tapping a session opens a chat thread. The walkthrough adds an extra
+ * "session list" step between populated state and the primary action.
+ */
+import { test } from '@playwright/test'
+import { runWebWalkthrough } from './_walkthrough'
+import { step } from '../../helpers/story'
+
+test('claude-3-web', async ({ page }, testInfo) => {
+  await runWebWalkthrough(page, testInfo, {
+    caseId: 'claude-3-web',
+    scriptId: 'claude-3',
+    scriptName: 'Claude 3',
+    extra: async (page, story) => {
+      await step(story, page, {
+        title: 'Session list',
+        description: 'The detail screen lists active and recent Claude Code sessions; verify the badges (tmux/in-process/headless) render correctly.',
+      }, async () => { await page.waitForTimeout(500) })
+    },
+  })
+})

--- a/web/e2e/specs/scripts/codex-3.web.spec.ts
+++ b/web/e2e/specs/scripts/codex-3.web.spec.ts
@@ -1,0 +1,26 @@
+/**
+ * Manual-test walkthrough for `codex-3` on the web surface.
+ * Plan: manual-script-sweep · Case: codex-3-web
+ * Hard deps: terminal-manager (system), tmux + codex CLI
+ *
+ * Codex 3 mirrors claude-3: a session supervisor with tmux transport. The
+ * walkthrough adds a "session list" step between populated state and the
+ * primary action.
+ */
+import { test } from '@playwright/test'
+import { runWebWalkthrough } from './_walkthrough'
+import { step } from '../../helpers/story'
+
+test('codex-3-web', async ({ page }, testInfo) => {
+  await runWebWalkthrough(page, testInfo, {
+    caseId: 'codex-3-web',
+    scriptId: 'codex-3',
+    scriptName: 'Codex 3',
+    extra: async (page, story) => {
+      await step(story, page, {
+        title: 'Session list',
+        description: 'The detail screen lists active and recent Codex sessions with tmux targets; verify the session pill renders.',
+      }, async () => { await page.waitForTimeout(500) })
+    },
+  })
+})

--- a/web/e2e/specs/scripts/codex-3.web.spec.ts
+++ b/web/e2e/specs/scripts/codex-3.web.spec.ts
@@ -1,26 +1,10 @@
 /**
- * Manual-test walkthrough for `codex-3` on the web surface.
- * Plan: manual-script-sweep · Case: codex-3-web
- * Hard deps: terminal-manager (system), tmux + codex CLI
- *
- * Codex 3 mirrors claude-3: a session supervisor with tmux transport. The
- * walkthrough adds a "session list" step between populated state and the
- * primary action.
+ * Web case · codex-3
+ * Steps are declared in web/review-plans/manual-script-sweep.json.
  */
 import { test } from '@playwright/test'
-import { runWebWalkthrough } from './_walkthrough'
-import { step } from '../../helpers/story'
+import { runWebCase } from './_walkthrough'
 
 test('codex-3-web', async ({ page }, testInfo) => {
-  await runWebWalkthrough(page, testInfo, {
-    caseId: 'codex-3-web',
-    scriptId: 'codex-3',
-    scriptName: 'Codex 3',
-    extra: async (page, story) => {
-      await step(story, page, {
-        title: 'Session list',
-        description: 'The detail screen lists active and recent Codex sessions with tmux targets; verify the session pill renders.',
-      }, async () => { await page.waitForTimeout(500) })
-    },
-  })
+  await runWebCase(page, testInfo, 'codex-3-web')
 })

--- a/web/e2e/specs/scripts/gdocs-history.web.spec.ts
+++ b/web/e2e/specs/scripts/gdocs-history.web.spec.ts
@@ -1,14 +1,10 @@
 /**
- * Manual-test walkthrough for `gdocs-history` on the web surface.
- * Plan: manual-script-sweep · Case: gdocs-history-web
+ * Web case · gdocs-history
+ * Steps are declared in web/review-plans/manual-script-sweep.json.
  */
 import { test } from '@playwright/test'
-import { runWebWalkthrough } from './_walkthrough'
+import { runWebCase } from './_walkthrough'
 
 test('gdocs-history-web', async ({ page }, testInfo) => {
-  await runWebWalkthrough(page, testInfo, {
-    caseId: 'gdocs-history-web',
-    scriptId: 'gdocs-history',
-    scriptName: 'Google Docs History',
-  })
+  await runWebCase(page, testInfo, 'gdocs-history-web')
 })

--- a/web/e2e/specs/scripts/gdocs-history.web.spec.ts
+++ b/web/e2e/specs/scripts/gdocs-history.web.spec.ts
@@ -1,0 +1,14 @@
+/**
+ * Manual-test walkthrough for `gdocs-history` on the web surface.
+ * Plan: manual-script-sweep · Case: gdocs-history-web
+ */
+import { test } from '@playwright/test'
+import { runWebWalkthrough } from './_walkthrough'
+
+test('gdocs-history-web', async ({ page }, testInfo) => {
+  await runWebWalkthrough(page, testInfo, {
+    caseId: 'gdocs-history-web',
+    scriptId: 'gdocs-history',
+    scriptName: 'Google Docs History',
+  })
+})

--- a/web/e2e/specs/scripts/github.web.spec.ts
+++ b/web/e2e/specs/scripts/github.web.spec.ts
@@ -1,14 +1,10 @@
 /**
- * Manual-test walkthrough for `github` on the web surface.
- * Plan: manual-script-sweep · Case: github-web
+ * Web case · github
+ * Steps are declared in web/review-plans/manual-script-sweep.json.
  */
 import { test } from '@playwright/test'
-import { runWebWalkthrough } from './_walkthrough'
+import { runWebCase } from './_walkthrough'
 
 test('github-web', async ({ page }, testInfo) => {
-  await runWebWalkthrough(page, testInfo, {
-    caseId: 'github-web',
-    scriptId: 'github',
-    scriptName: 'Git Repos',
-  })
+  await runWebCase(page, testInfo, 'github-web')
 })

--- a/web/e2e/specs/scripts/github.web.spec.ts
+++ b/web/e2e/specs/scripts/github.web.spec.ts
@@ -1,0 +1,14 @@
+/**
+ * Manual-test walkthrough for `github` on the web surface.
+ * Plan: manual-script-sweep · Case: github-web
+ */
+import { test } from '@playwright/test'
+import { runWebWalkthrough } from './_walkthrough'
+
+test('github-web', async ({ page }, testInfo) => {
+  await runWebWalkthrough(page, testInfo, {
+    caseId: 'github-web',
+    scriptId: 'github',
+    scriptName: 'Git Repos',
+  })
+})

--- a/web/e2e/specs/scripts/hello-world.web.spec.ts
+++ b/web/e2e/specs/scripts/hello-world.web.spec.ts
@@ -1,0 +1,75 @@
+/**
+ * Manual-test walkthrough for the `hello-world` script on the web surface.
+ *
+ * Belongs to plan: manual-script-sweep
+ * Case id:       hello-world-web
+ *
+ * Walks the eight common steps from §7.1 of docs/specs/manual-script-test-plan.md
+ * (cold open, tile entry, tap into detail, empty state, populated state,
+ * primary action, error/refused, back-out). Each step is captured as a
+ * screenshot + HTML snapshot via the story recorder so the dashboard can
+ * pin issues with location and "Copy step context" hand-off.
+ *
+ * Phase 1 caveats:
+ *   - Vault isolation is not yet automated; tester must ensure other
+ *     scripts are disabled before kicking off the run.
+ *   - Hello-world has no real "primary action" or "error state" — for those
+ *     steps we capture the home screen and the settings screen as
+ *     informative placeholders so the case shape stays uniform.
+ */
+import { test } from '@playwright/test'
+import { newStory, step } from '../../helpers/story'
+
+test('hello-world-web', async ({ page }, testInfo) => {
+  const story = newStory(testInfo, {
+    caseId: 'hello-world-web',
+    title: 'Hello World · Web walkthrough',
+    description: 'Cold open through back-out for the hello-world script on the iPhone webview.',
+  })
+
+  await step(story, page, {
+    title: 'Cold open',
+    description: 'Open the home feed at /home with no other interaction; expect the script list to render and the hello-world tile to be present.',
+  }, '/home')
+
+  await step(story, page, {
+    title: 'Tile / feed entry',
+    description: 'The hello-world tile renders with its icon and name in the home feed.',
+  }, async () => {
+    await page.waitForTimeout(250)
+  })
+
+  await step(story, page, {
+    title: 'Tap into detail',
+    description: 'Navigate to the script detail screen for hello-world.',
+  }, '/script/hello-world')
+
+  await step(story, page, {
+    title: 'Empty state',
+    description: 'Detail screen with no recent runs / no recorded blocks — verifies the empty layout.',
+  }, async () => {
+    await page.waitForTimeout(250)
+  })
+
+  await step(story, page, {
+    title: 'Populated state',
+    description: 'Same screen after a brief settle — captures whatever blocks the script publishes by default.',
+  }, async () => {
+    await page.waitForTimeout(800)
+  })
+
+  await step(story, page, {
+    title: 'Primary action',
+    description: 'Hello-world has no interactive primary action; capture the settings screen as a representative cross-link the user might tap from detail.',
+  }, '/settings')
+
+  await step(story, page, {
+    title: 'Error / refused state',
+    description: 'Hello-world declares no permissions; capture the tasks list as the closest analog of a "nothing to act on" surface.',
+  }, '/tasks')
+
+  await step(story, page, {
+    title: 'Back-out',
+    description: 'Return to the home feed; verify the tile state survives navigation.',
+  }, '/home')
+})

--- a/web/e2e/specs/scripts/hello-world.web.spec.ts
+++ b/web/e2e/specs/scripts/hello-world.web.spec.ts
@@ -1,75 +1,14 @@
 /**
- * Manual-test walkthrough for the `hello-world` script on the web surface.
- *
- * Belongs to plan: manual-script-sweep
- * Case id:       hello-world-web
- *
- * Walks the eight common steps from §7.1 of docs/specs/manual-script-test-plan.md
- * (cold open, tile entry, tap into detail, empty state, populated state,
- * primary action, error/refused, back-out). Each step is captured as a
- * screenshot + HTML snapshot via the story recorder so the dashboard can
- * pin issues with location and "Copy step context" hand-off.
- *
- * Phase 1 caveats:
- *   - Vault isolation is not yet automated; tester must ensure other
- *     scripts are disabled before kicking off the run.
- *   - Hello-world has no real "primary action" or "error state" — for those
- *     steps we capture the home screen and the settings screen as
- *     informative placeholders so the case shape stays uniform.
+ * Manual-test walkthrough for `hello-world` on the web surface.
+ * Plan: manual-script-sweep · Case: hello-world-web
  */
 import { test } from '@playwright/test'
-import { newStory, step } from '../../helpers/story'
+import { runWebWalkthrough } from './_walkthrough'
 
 test('hello-world-web', async ({ page }, testInfo) => {
-  const story = newStory(testInfo, {
+  await runWebWalkthrough(page, testInfo, {
     caseId: 'hello-world-web',
-    title: 'Hello World · Web walkthrough',
-    description: 'Cold open through back-out for the hello-world script on the iPhone webview.',
+    scriptId: 'hello-world',
+    scriptName: 'Hello World',
   })
-
-  await step(story, page, {
-    title: 'Cold open',
-    description: 'Open the home feed at /home with no other interaction; expect the script list to render and the hello-world tile to be present.',
-  }, '/home')
-
-  await step(story, page, {
-    title: 'Tile / feed entry',
-    description: 'The hello-world tile renders with its icon and name in the home feed.',
-  }, async () => {
-    await page.waitForTimeout(250)
-  })
-
-  await step(story, page, {
-    title: 'Tap into detail',
-    description: 'Navigate to the script detail screen for hello-world.',
-  }, '/script/hello-world')
-
-  await step(story, page, {
-    title: 'Empty state',
-    description: 'Detail screen with no recent runs / no recorded blocks — verifies the empty layout.',
-  }, async () => {
-    await page.waitForTimeout(250)
-  })
-
-  await step(story, page, {
-    title: 'Populated state',
-    description: 'Same screen after a brief settle — captures whatever blocks the script publishes by default.',
-  }, async () => {
-    await page.waitForTimeout(800)
-  })
-
-  await step(story, page, {
-    title: 'Primary action',
-    description: 'Hello-world has no interactive primary action; capture the settings screen as a representative cross-link the user might tap from detail.',
-  }, '/settings')
-
-  await step(story, page, {
-    title: 'Error / refused state',
-    description: 'Hello-world declares no permissions; capture the tasks list as the closest analog of a "nothing to act on" surface.',
-  }, '/tasks')
-
-  await step(story, page, {
-    title: 'Back-out',
-    description: 'Return to the home feed; verify the tile state survives navigation.',
-  }, '/home')
 })

--- a/web/e2e/specs/scripts/hello-world.web.spec.ts
+++ b/web/e2e/specs/scripts/hello-world.web.spec.ts
@@ -1,14 +1,10 @@
 /**
- * Manual-test walkthrough for `hello-world` on the web surface.
- * Plan: manual-script-sweep · Case: hello-world-web
+ * Web case · hello-world
+ * Steps are declared in web/review-plans/manual-script-sweep.json.
  */
 import { test } from '@playwright/test'
-import { runWebWalkthrough } from './_walkthrough'
+import { runWebCase } from './_walkthrough'
 
 test('hello-world-web', async ({ page }, testInfo) => {
-  await runWebWalkthrough(page, testInfo, {
-    caseId: 'hello-world-web',
-    scriptId: 'hello-world',
-    scriptName: 'Hello World',
-  })
+  await runWebCase(page, testInfo, 'hello-world-web')
 })

--- a/web/e2e/specs/scripts/ollama.web.spec.ts
+++ b/web/e2e/specs/scripts/ollama.web.spec.ts
@@ -1,0 +1,14 @@
+/**
+ * Manual-test walkthrough for `ollama` on the web surface.
+ * Plan: manual-script-sweep · Case: ollama-web
+ */
+import { test } from '@playwright/test'
+import { runWebWalkthrough } from './_walkthrough'
+
+test('ollama-web', async ({ page }, testInfo) => {
+  await runWebWalkthrough(page, testInfo, {
+    caseId: 'ollama-web',
+    scriptId: 'ollama',
+    scriptName: 'Ollama',
+  })
+})

--- a/web/e2e/specs/scripts/ollama.web.spec.ts
+++ b/web/e2e/specs/scripts/ollama.web.spec.ts
@@ -1,14 +1,10 @@
 /**
- * Manual-test walkthrough for `ollama` on the web surface.
- * Plan: manual-script-sweep · Case: ollama-web
+ * Web case · ollama
+ * Steps are declared in web/review-plans/manual-script-sweep.json.
  */
 import { test } from '@playwright/test'
-import { runWebWalkthrough } from './_walkthrough'
+import { runWebCase } from './_walkthrough'
 
 test('ollama-web', async ({ page }, testInfo) => {
-  await runWebWalkthrough(page, testInfo, {
-    caseId: 'ollama-web',
-    scriptId: 'ollama',
-    scriptName: 'Ollama',
-  })
+  await runWebCase(page, testInfo, 'ollama-web')
 })

--- a/web/e2e/specs/scripts/task-demo.web.spec.ts
+++ b/web/e2e/specs/scripts/task-demo.web.spec.ts
@@ -1,0 +1,14 @@
+/**
+ * Manual-test walkthrough for `task-demo` on the web surface.
+ * Plan: manual-script-sweep · Case: task-demo-web
+ */
+import { test } from '@playwright/test'
+import { runWebWalkthrough } from './_walkthrough'
+
+test('task-demo-web', async ({ page }, testInfo) => {
+  await runWebWalkthrough(page, testInfo, {
+    caseId: 'task-demo-web',
+    scriptId: 'task-demo',
+    scriptName: 'Task Demo',
+  })
+})

--- a/web/e2e/specs/scripts/task-demo.web.spec.ts
+++ b/web/e2e/specs/scripts/task-demo.web.spec.ts
@@ -1,14 +1,10 @@
 /**
- * Manual-test walkthrough for `task-demo` on the web surface.
- * Plan: manual-script-sweep · Case: task-demo-web
+ * Web case · task-demo
+ * Steps are declared in web/review-plans/manual-script-sweep.json.
  */
 import { test } from '@playwright/test'
-import { runWebWalkthrough } from './_walkthrough'
+import { runWebCase } from './_walkthrough'
 
 test('task-demo-web', async ({ page }, testInfo) => {
-  await runWebWalkthrough(page, testInfo, {
-    caseId: 'task-demo-web',
-    scriptId: 'task-demo',
-    scriptName: 'Task Demo',
-  })
+  await runWebCase(page, testInfo, 'task-demo-web')
 })

--- a/web/e2e/specs/scripts/terminal-snapshot.web.spec.ts
+++ b/web/e2e/specs/scripts/terminal-snapshot.web.spec.ts
@@ -1,15 +1,10 @@
 /**
- * Manual-test walkthrough for `terminal-snapshot` on the web surface.
- * Plan: manual-script-sweep · Case: terminal-snapshot-web
- * Hard dep: terminal-manager (system script — must be enabled in vault)
+ * Web case · terminal-snapshot
+ * Steps are declared in web/review-plans/manual-script-sweep.json.
  */
 import { test } from '@playwright/test'
-import { runWebWalkthrough } from './_walkthrough'
+import { runWebCase } from './_walkthrough'
 
 test('terminal-snapshot-web', async ({ page }, testInfo) => {
-  await runWebWalkthrough(page, testInfo, {
-    caseId: 'terminal-snapshot-web',
-    scriptId: 'terminal-snapshot',
-    scriptName: 'Terminal Snapshot',
-  })
+  await runWebCase(page, testInfo, 'terminal-snapshot-web')
 })

--- a/web/e2e/specs/scripts/terminal-snapshot.web.spec.ts
+++ b/web/e2e/specs/scripts/terminal-snapshot.web.spec.ts
@@ -1,0 +1,15 @@
+/**
+ * Manual-test walkthrough for `terminal-snapshot` on the web surface.
+ * Plan: manual-script-sweep · Case: terminal-snapshot-web
+ * Hard dep: terminal-manager (system script — must be enabled in vault)
+ */
+import { test } from '@playwright/test'
+import { runWebWalkthrough } from './_walkthrough'
+
+test('terminal-snapshot-web', async ({ page }, testInfo) => {
+  await runWebWalkthrough(page, testInfo, {
+    caseId: 'terminal-snapshot-web',
+    scriptId: 'terminal-snapshot',
+    scriptName: 'Terminal Snapshot',
+  })
+})

--- a/web/e2e/specs/scripts/web-traffic.web.spec.ts
+++ b/web/e2e/specs/scripts/web-traffic.web.spec.ts
@@ -1,14 +1,10 @@
 /**
- * Manual-test walkthrough for `web-traffic` on the web surface.
- * Plan: manual-script-sweep · Case: web-traffic-web
+ * Web case · web-traffic
+ * Steps are declared in web/review-plans/manual-script-sweep.json.
  */
 import { test } from '@playwright/test'
-import { runWebWalkthrough } from './_walkthrough'
+import { runWebCase } from './_walkthrough'
 
 test('web-traffic-web', async ({ page }, testInfo) => {
-  await runWebWalkthrough(page, testInfo, {
-    caseId: 'web-traffic-web',
-    scriptId: 'web-traffic',
-    scriptName: 'Web Traffic',
-  })
+  await runWebCase(page, testInfo, 'web-traffic-web')
 })

--- a/web/e2e/specs/scripts/web-traffic.web.spec.ts
+++ b/web/e2e/specs/scripts/web-traffic.web.spec.ts
@@ -1,0 +1,14 @@
+/**
+ * Manual-test walkthrough for `web-traffic` on the web surface.
+ * Plan: manual-script-sweep · Case: web-traffic-web
+ */
+import { test } from '@playwright/test'
+import { runWebWalkthrough } from './_walkthrough'
+
+test('web-traffic-web', async ({ page }, testInfo) => {
+  await runWebWalkthrough(page, testInfo, {
+    caseId: 'web-traffic-web',
+    scriptId: 'web-traffic',
+    scriptName: 'Web Traffic',
+  })
+})

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -20,6 +20,7 @@
         "remark-gfm": "^4.0.0"
       },
       "devDependencies": {
+        "@playwright/test": "^1.59.1",
         "@types/node": "^22.10.2",
         "@types/react": "^18.3.12",
         "@types/react-dom": "^18.3.1",
@@ -1265,6 +1266,22 @@
       "peerDependencies": {
         "react": ">= 16.8",
         "react-dom": ">= 16.8"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@popperjs/core": {
@@ -4029,6 +4046,53 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/web/package.json
+++ b/web/package.json
@@ -8,7 +8,10 @@
     "dev:mock": "concurrently -n mock,vite -c cyan,blue \"PORT=4243 tsx watch mock/server.ts\" \"BACKEND_PORT=4243 vite\"",
     "mock": "PORT=4243 tsx watch mock/server.ts",
     "build": "tsc && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "e2e": "playwright test",
+    "e2e:ui": "playwright test --ui",
+    "e2e:headed": "playwright test --headed"
   },
   "dependencies": {
     "@emotion/react": "^11.14.0",
@@ -23,6 +26,7 @@
     "remark-gfm": "^4.0.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.59.1",
     "@types/node": "^22.10.2",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",

--- a/web/package.json
+++ b/web/package.json
@@ -11,7 +11,8 @@
     "preview": "vite preview",
     "e2e": "playwright test",
     "e2e:ui": "playwright test --ui",
-    "e2e:headed": "playwright test --headed"
+    "e2e:headed": "playwright test --headed",
+    "review": "tsx scripts/review-server.ts"
   },
   "dependencies": {
     "@emotion/react": "^11.14.0",

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -1,0 +1,30 @@
+import { defineConfig, devices } from '@playwright/test'
+
+// E2E config — runs against the live AskMac on port 4242 via the vite proxy
+// at localhost:5173. The vite dev server is assumed to already be running
+// (the user's normal dev workflow). If you're running these in CI without a
+// live AskMac, point BACKEND_PORT at the mock server (see web/mock/server.ts)
+// and start vite with that env var.
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: false,    // shared backend state — keep tests serial
+  retries: 0,
+  workers: 1,
+  reporter: [['list'], ['html', { open: 'never', outputFolder: 'playwright-report' }]],
+  use: {
+    baseURL: 'http://localhost:5173',
+    trace: 'retain-on-failure',
+    video: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+  },
+  projects: [
+    {
+      name: 'desktop',
+      use: {
+        ...devices['Desktop Chrome'],
+        viewport: { width: 1400, height: 900 },
+      },
+    },
+  ],
+})

--- a/web/review-plans/manual-script-sweep.json
+++ b/web/review-plans/manual-script-sweep.json
@@ -29,7 +29,7 @@
       "title": "Homebrew · Web",
       "spec": "specs/scripts/brew-monitor.web.spec.ts",
       "deps": [],
-      "status": "pending"
+      "status": "implemented"
     },
     {
       "id": "brew-monitor-mac",
@@ -47,7 +47,7 @@
       "title": "Git Repos · Web",
       "spec": "specs/scripts/github.web.spec.ts",
       "deps": [],
-      "status": "pending"
+      "status": "implemented"
     },
     {
       "id": "github-mac",
@@ -65,7 +65,7 @@
       "title": "Ollama · Web",
       "spec": "specs/scripts/ollama.web.spec.ts",
       "deps": [],
-      "status": "pending"
+      "status": "implemented"
     },
     {
       "id": "ollama-mac",
@@ -83,7 +83,7 @@
       "title": "Google Docs History · Web",
       "spec": "specs/scripts/gdocs-history.web.spec.ts",
       "deps": [],
-      "status": "pending"
+      "status": "implemented"
     },
     {
       "id": "gdocs-history-mac",
@@ -101,7 +101,7 @@
       "title": "Web Traffic · Web",
       "spec": "specs/scripts/web-traffic.web.spec.ts",
       "deps": [],
-      "status": "pending"
+      "status": "implemented"
     },
     {
       "id": "web-traffic-mac",
@@ -119,7 +119,7 @@
       "title": "Task Demo · Web",
       "spec": "specs/scripts/task-demo.web.spec.ts",
       "deps": [],
-      "status": "pending"
+      "status": "implemented"
     },
     {
       "id": "task-demo-mac",
@@ -139,7 +139,7 @@
       "deps": [
         "terminal-manager"
       ],
-      "status": "pending"
+      "status": "implemented"
     },
     {
       "id": "terminal-snapshot-mac",
@@ -161,7 +161,7 @@
       "deps": [
         "terminal-manager"
       ],
-      "status": "pending"
+      "status": "implemented"
     },
     {
       "id": "claude-3-mac",
@@ -183,7 +183,7 @@
       "deps": [
         "terminal-manager"
       ],
-      "status": "pending"
+      "status": "implemented"
     },
     {
       "id": "codex-3-mac",

--- a/web/review-plans/manual-script-sweep.json
+++ b/web/review-plans/manual-script-sweep.json
@@ -1,7 +1,7 @@
 {
   "id": "manual-script-sweep",
   "title": "Manual script sweep",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Per-script regression: walk every Ask script through its golden path and edge cases on the iPhone webview, then on the AskMac native app. Each case isolates one script (disables others, enables only declared deps). Issues are pinned with kind + (x, y) location and the captured HTML for hand-off to a coding agent.",
   "cases": [
     {
@@ -9,192 +9,1044 @@
       "scriptId": "hello-world",
       "surface": "web",
       "title": "Hello World · Web",
+      "description": "Walk every primary surface for Hello World on the iPhone webview. A simple Hello World demo script — exercises the bare minimum of the script chrome. Surfaces visited: home feed, script detail, tasks, settings.",
       "spec": "specs/scripts/hello-world.web.spec.ts",
       "deps": [],
-      "status": "implemented"
+      "status": "implemented",
+      "steps": [
+        {
+          "id": "cold-open",
+          "title": "Cold open",
+          "description": "Open the home feed at /home with no other interaction; expect the script list to render.",
+          "nav": "/home"
+        },
+        {
+          "id": "tile-entry",
+          "title": "Tile / feed entry",
+          "description": "The hello-world tile or feed entry renders with its icon and name in the home feed.",
+          "waitMs": 300
+        },
+        {
+          "id": "tap-detail",
+          "title": "Tap into detail",
+          "description": "Navigate to /script/hello-world — the script's primary surface.",
+          "nav": "/script/hello-world"
+        },
+        {
+          "id": "empty-state",
+          "title": "Empty state",
+          "description": "Detail screen on first paint — what the user sees before data arrives.",
+          "waitMs": 300
+        },
+        {
+          "id": "populated-state",
+          "title": "Populated state",
+          "description": "Same screen after a brief settle — captures whatever blocks the script publishes.",
+          "waitMs": 900
+        },
+        {
+          "id": "primary-action",
+          "title": "Primary action",
+          "description": "Visit /tasks to confirm any tasks emitted by hello-world are in the feed.",
+          "nav": "/tasks"
+        },
+        {
+          "id": "error-refused",
+          "title": "Error / refused state",
+          "description": "Visit /settings to confirm hello-world permissions and toggles render correctly.",
+          "nav": "/settings"
+        },
+        {
+          "id": "back-out",
+          "title": "Back-out",
+          "description": "Return to the home feed; verify the tile state survives navigation.",
+          "nav": "/home"
+        }
+      ]
     },
     {
       "id": "hello-world-mac",
       "scriptId": "hello-world",
       "surface": "askmac",
       "title": "Hello World · AskMac",
+      "description": "Walk Settings ▸ Scripts ▸ Hello World on the AskMac native app. A simple Hello World demo script — exercises the bare minimum of the script chrome. Surfaces visited: scripts list, script row, permissions, blocks, logs.",
       "driver": "computer-use",
       "deps": [],
-      "status": "pending"
+      "status": "pending",
+      "steps": [
+        {
+          "id": "cold-open",
+          "title": "Cold open",
+          "description": "Open AskMac and confirm Settings ▸ Scripts shows hello-world as enabled."
+        },
+        {
+          "id": "script-row",
+          "title": "Script row",
+          "description": "The hello-world row shows the manifest version, summary, and an enable/disable toggle."
+        },
+        {
+          "id": "permissions-sheet",
+          "title": "Permissions sheet",
+          "description": "The script's declared permissions are listed correctly for hello-world."
+        },
+        {
+          "id": "block-view",
+          "title": "Block view",
+          "description": "If hello-world publishes blocks, they render in the AskMac viewer with no errors."
+        },
+        {
+          "id": "logs-pane",
+          "title": "Logs / errors pane",
+          "description": "Recent log lines for hello-world appear; no red error rows."
+        },
+        {
+          "id": "disable-reenable",
+          "title": "Disable / re-enable",
+          "description": "Toggle hello-world off then on; verify clean teardown and re-installation."
+        }
+      ]
     },
     {
       "id": "brew-monitor-web",
       "scriptId": "brew-monitor",
       "surface": "web",
       "title": "Homebrew · Web",
+      "description": "Walk every primary surface for Homebrew on the iPhone webview. Checks for outdated Homebrew packages and lets you upgrade from iPhone. Surfaces visited: home feed, script detail, tasks, settings.",
       "spec": "specs/scripts/brew-monitor.web.spec.ts",
       "deps": [],
-      "status": "implemented"
+      "status": "implemented",
+      "steps": [
+        {
+          "id": "cold-open",
+          "title": "Cold open",
+          "description": "Open the home feed at /home with no other interaction; expect the script list to render.",
+          "nav": "/home"
+        },
+        {
+          "id": "tile-entry",
+          "title": "Tile / feed entry",
+          "description": "The brew-monitor tile or feed entry renders with its icon and name in the home feed.",
+          "waitMs": 300
+        },
+        {
+          "id": "tap-detail",
+          "title": "Tap into detail",
+          "description": "Navigate to /script/brew-monitor — the script's primary surface.",
+          "nav": "/script/brew-monitor"
+        },
+        {
+          "id": "empty-state",
+          "title": "Empty state",
+          "description": "Detail screen on first paint — what the user sees before data arrives.",
+          "waitMs": 300
+        },
+        {
+          "id": "populated-state",
+          "title": "Populated state",
+          "description": "Same screen after a brief settle — captures whatever blocks the script publishes.",
+          "waitMs": 900
+        },
+        {
+          "id": "primary-action",
+          "title": "Primary action",
+          "description": "Visit /tasks to confirm any tasks emitted by brew-monitor are in the feed.",
+          "nav": "/tasks"
+        },
+        {
+          "id": "error-refused",
+          "title": "Error / refused state",
+          "description": "Visit /settings to confirm brew-monitor permissions and toggles render correctly.",
+          "nav": "/settings"
+        },
+        {
+          "id": "back-out",
+          "title": "Back-out",
+          "description": "Return to the home feed; verify the tile state survives navigation.",
+          "nav": "/home"
+        }
+      ]
     },
     {
       "id": "brew-monitor-mac",
       "scriptId": "brew-monitor",
       "surface": "askmac",
       "title": "Homebrew · AskMac",
+      "description": "Walk Settings ▸ Scripts ▸ Homebrew on the AskMac native app. Checks for outdated Homebrew packages and lets you upgrade from iPhone. Surfaces visited: scripts list, script row, permissions, blocks, logs.",
       "driver": "computer-use",
       "deps": [],
-      "status": "pending"
+      "status": "pending",
+      "steps": [
+        {
+          "id": "cold-open",
+          "title": "Cold open",
+          "description": "Open AskMac and confirm Settings ▸ Scripts shows brew-monitor as enabled."
+        },
+        {
+          "id": "script-row",
+          "title": "Script row",
+          "description": "The brew-monitor row shows the manifest version, summary, and an enable/disable toggle."
+        },
+        {
+          "id": "permissions-sheet",
+          "title": "Permissions sheet",
+          "description": "The script's declared permissions are listed correctly for brew-monitor."
+        },
+        {
+          "id": "block-view",
+          "title": "Block view",
+          "description": "If brew-monitor publishes blocks, they render in the AskMac viewer with no errors."
+        },
+        {
+          "id": "logs-pane",
+          "title": "Logs / errors pane",
+          "description": "Recent log lines for brew-monitor appear; no red error rows."
+        },
+        {
+          "id": "disable-reenable",
+          "title": "Disable / re-enable",
+          "description": "Toggle brew-monitor off then on; verify clean teardown and re-installation."
+        }
+      ]
     },
     {
       "id": "github-web",
       "scriptId": "github",
       "surface": "web",
       "title": "Git Repos · Web",
+      "description": "Walk every primary surface for Git Repos on the iPhone webview. Monitor local git repos and push/pull changes from iPhone. Surfaces visited: home feed, script detail, tasks, settings.",
       "spec": "specs/scripts/github.web.spec.ts",
       "deps": [],
-      "status": "implemented"
+      "status": "implemented",
+      "steps": [
+        {
+          "id": "cold-open",
+          "title": "Cold open",
+          "description": "Open the home feed at /home with no other interaction; expect the script list to render.",
+          "nav": "/home"
+        },
+        {
+          "id": "tile-entry",
+          "title": "Tile / feed entry",
+          "description": "The github tile or feed entry renders with its icon and name in the home feed.",
+          "waitMs": 300
+        },
+        {
+          "id": "tap-detail",
+          "title": "Tap into detail",
+          "description": "Navigate to /script/github — the script's primary surface.",
+          "nav": "/script/github"
+        },
+        {
+          "id": "empty-state",
+          "title": "Empty state",
+          "description": "Detail screen on first paint — what the user sees before data arrives.",
+          "waitMs": 300
+        },
+        {
+          "id": "populated-state",
+          "title": "Populated state",
+          "description": "Same screen after a brief settle — captures whatever blocks the script publishes.",
+          "waitMs": 900
+        },
+        {
+          "id": "primary-action",
+          "title": "Primary action",
+          "description": "Visit /tasks to confirm any tasks emitted by github are in the feed.",
+          "nav": "/tasks"
+        },
+        {
+          "id": "error-refused",
+          "title": "Error / refused state",
+          "description": "Visit /settings to confirm github permissions and toggles render correctly.",
+          "nav": "/settings"
+        },
+        {
+          "id": "back-out",
+          "title": "Back-out",
+          "description": "Return to the home feed; verify the tile state survives navigation.",
+          "nav": "/home"
+        }
+      ]
     },
     {
       "id": "github-mac",
       "scriptId": "github",
       "surface": "askmac",
       "title": "Git Repos · AskMac",
+      "description": "Walk Settings ▸ Scripts ▸ Git Repos on the AskMac native app. Monitor local git repos and push/pull changes from iPhone. Surfaces visited: scripts list, script row, permissions, blocks, logs.",
       "driver": "computer-use",
       "deps": [],
-      "status": "pending"
+      "status": "pending",
+      "steps": [
+        {
+          "id": "cold-open",
+          "title": "Cold open",
+          "description": "Open AskMac and confirm Settings ▸ Scripts shows github as enabled."
+        },
+        {
+          "id": "script-row",
+          "title": "Script row",
+          "description": "The github row shows the manifest version, summary, and an enable/disable toggle."
+        },
+        {
+          "id": "permissions-sheet",
+          "title": "Permissions sheet",
+          "description": "The script's declared permissions are listed correctly for github."
+        },
+        {
+          "id": "block-view",
+          "title": "Block view",
+          "description": "If github publishes blocks, they render in the AskMac viewer with no errors."
+        },
+        {
+          "id": "logs-pane",
+          "title": "Logs / errors pane",
+          "description": "Recent log lines for github appear; no red error rows."
+        },
+        {
+          "id": "disable-reenable",
+          "title": "Disable / re-enable",
+          "description": "Toggle github off then on; verify clean teardown and re-installation."
+        }
+      ]
     },
     {
       "id": "ollama-web",
       "scriptId": "ollama",
       "surface": "web",
       "title": "Ollama · Web",
+      "description": "Walk every primary surface for Ollama on the iPhone webview. Monitors Ollama status and surfaces available updates. Surfaces visited: home feed, script detail, tasks, settings.",
       "spec": "specs/scripts/ollama.web.spec.ts",
       "deps": [],
-      "status": "implemented"
+      "status": "implemented",
+      "steps": [
+        {
+          "id": "cold-open",
+          "title": "Cold open",
+          "description": "Open the home feed at /home with no other interaction; expect the script list to render.",
+          "nav": "/home"
+        },
+        {
+          "id": "tile-entry",
+          "title": "Tile / feed entry",
+          "description": "The ollama tile or feed entry renders with its icon and name in the home feed.",
+          "waitMs": 300
+        },
+        {
+          "id": "tap-detail",
+          "title": "Tap into detail",
+          "description": "Navigate to /script/ollama — the script's primary surface.",
+          "nav": "/script/ollama"
+        },
+        {
+          "id": "empty-state",
+          "title": "Empty state",
+          "description": "Detail screen on first paint — what the user sees before data arrives.",
+          "waitMs": 300
+        },
+        {
+          "id": "populated-state",
+          "title": "Populated state",
+          "description": "Same screen after a brief settle — captures whatever blocks the script publishes.",
+          "waitMs": 900
+        },
+        {
+          "id": "primary-action",
+          "title": "Primary action",
+          "description": "Visit /tasks to confirm any tasks emitted by ollama are in the feed.",
+          "nav": "/tasks"
+        },
+        {
+          "id": "error-refused",
+          "title": "Error / refused state",
+          "description": "Visit /settings to confirm ollama permissions and toggles render correctly.",
+          "nav": "/settings"
+        },
+        {
+          "id": "back-out",
+          "title": "Back-out",
+          "description": "Return to the home feed; verify the tile state survives navigation.",
+          "nav": "/home"
+        }
+      ]
     },
     {
       "id": "ollama-mac",
       "scriptId": "ollama",
       "surface": "askmac",
       "title": "Ollama · AskMac",
+      "description": "Walk Settings ▸ Scripts ▸ Ollama on the AskMac native app. Monitors Ollama status and surfaces available updates. Surfaces visited: scripts list, script row, permissions, blocks, logs.",
       "driver": "computer-use",
       "deps": [],
-      "status": "pending"
+      "status": "pending",
+      "steps": [
+        {
+          "id": "cold-open",
+          "title": "Cold open",
+          "description": "Open AskMac and confirm Settings ▸ Scripts shows ollama as enabled."
+        },
+        {
+          "id": "script-row",
+          "title": "Script row",
+          "description": "The ollama row shows the manifest version, summary, and an enable/disable toggle."
+        },
+        {
+          "id": "permissions-sheet",
+          "title": "Permissions sheet",
+          "description": "The script's declared permissions are listed correctly for ollama."
+        },
+        {
+          "id": "block-view",
+          "title": "Block view",
+          "description": "If ollama publishes blocks, they render in the AskMac viewer with no errors."
+        },
+        {
+          "id": "logs-pane",
+          "title": "Logs / errors pane",
+          "description": "Recent log lines for ollama appear; no red error rows."
+        },
+        {
+          "id": "disable-reenable",
+          "title": "Disable / re-enable",
+          "description": "Toggle ollama off then on; verify clean teardown and re-installation."
+        }
+      ]
     },
     {
       "id": "gdocs-history-web",
       "scriptId": "gdocs-history",
       "surface": "web",
       "title": "Google Docs History · Web",
+      "description": "Walk every primary surface for Google Docs History on the iPhone webview. Shows Google Docs viewed in the last 30 days from Safari and Chrome. Surfaces visited: home feed, script detail, tasks, settings.",
       "spec": "specs/scripts/gdocs-history.web.spec.ts",
       "deps": [],
-      "status": "implemented"
+      "status": "implemented",
+      "steps": [
+        {
+          "id": "cold-open",
+          "title": "Cold open",
+          "description": "Open the home feed at /home with no other interaction; expect the script list to render.",
+          "nav": "/home"
+        },
+        {
+          "id": "tile-entry",
+          "title": "Tile / feed entry",
+          "description": "The gdocs-history tile or feed entry renders with its icon and name in the home feed.",
+          "waitMs": 300
+        },
+        {
+          "id": "tap-detail",
+          "title": "Tap into detail",
+          "description": "Navigate to /script/gdocs-history — the script's primary surface.",
+          "nav": "/script/gdocs-history"
+        },
+        {
+          "id": "empty-state",
+          "title": "Empty state",
+          "description": "Detail screen on first paint — what the user sees before data arrives.",
+          "waitMs": 300
+        },
+        {
+          "id": "populated-state",
+          "title": "Populated state",
+          "description": "Same screen after a brief settle — captures whatever blocks the script publishes.",
+          "waitMs": 900
+        },
+        {
+          "id": "primary-action",
+          "title": "Primary action",
+          "description": "Visit /tasks to confirm any tasks emitted by gdocs-history are in the feed.",
+          "nav": "/tasks"
+        },
+        {
+          "id": "error-refused",
+          "title": "Error / refused state",
+          "description": "Visit /settings to confirm gdocs-history permissions and toggles render correctly.",
+          "nav": "/settings"
+        },
+        {
+          "id": "back-out",
+          "title": "Back-out",
+          "description": "Return to the home feed; verify the tile state survives navigation.",
+          "nav": "/home"
+        }
+      ]
     },
     {
       "id": "gdocs-history-mac",
       "scriptId": "gdocs-history",
       "surface": "askmac",
       "title": "Google Docs History · AskMac",
+      "description": "Walk Settings ▸ Scripts ▸ Google Docs History on the AskMac native app. Shows Google Docs viewed in the last 30 days from Safari and Chrome. Surfaces visited: scripts list, script row, permissions, blocks, logs.",
       "driver": "computer-use",
       "deps": [],
-      "status": "pending"
+      "status": "pending",
+      "steps": [
+        {
+          "id": "cold-open",
+          "title": "Cold open",
+          "description": "Open AskMac and confirm Settings ▸ Scripts shows gdocs-history as enabled."
+        },
+        {
+          "id": "script-row",
+          "title": "Script row",
+          "description": "The gdocs-history row shows the manifest version, summary, and an enable/disable toggle."
+        },
+        {
+          "id": "permissions-sheet",
+          "title": "Permissions sheet",
+          "description": "The script's declared permissions are listed correctly for gdocs-history."
+        },
+        {
+          "id": "block-view",
+          "title": "Block view",
+          "description": "If gdocs-history publishes blocks, they render in the AskMac viewer with no errors."
+        },
+        {
+          "id": "logs-pane",
+          "title": "Logs / errors pane",
+          "description": "Recent log lines for gdocs-history appear; no red error rows."
+        },
+        {
+          "id": "disable-reenable",
+          "title": "Disable / re-enable",
+          "description": "Toggle gdocs-history off then on; verify clean teardown and re-installation."
+        }
+      ]
     },
     {
       "id": "web-traffic-web",
       "scriptId": "web-traffic",
       "surface": "web",
       "title": "Web Traffic · Web",
+      "description": "Walk every primary surface for Web Traffic on the iPhone webview. Parses browser history to show websites visited daily — Safari, Chrome, Brave, Firefox, Arc. Surfaces visited: home feed, script detail, tasks, settings.",
       "spec": "specs/scripts/web-traffic.web.spec.ts",
       "deps": [],
-      "status": "implemented"
+      "status": "implemented",
+      "steps": [
+        {
+          "id": "cold-open",
+          "title": "Cold open",
+          "description": "Open the home feed at /home with no other interaction; expect the script list to render.",
+          "nav": "/home"
+        },
+        {
+          "id": "tile-entry",
+          "title": "Tile / feed entry",
+          "description": "The web-traffic tile or feed entry renders with its icon and name in the home feed.",
+          "waitMs": 300
+        },
+        {
+          "id": "tap-detail",
+          "title": "Tap into detail",
+          "description": "Navigate to /script/web-traffic — the script's primary surface.",
+          "nav": "/script/web-traffic"
+        },
+        {
+          "id": "empty-state",
+          "title": "Empty state",
+          "description": "Detail screen on first paint — what the user sees before data arrives.",
+          "waitMs": 300
+        },
+        {
+          "id": "populated-state",
+          "title": "Populated state",
+          "description": "Same screen after a brief settle — captures whatever blocks the script publishes.",
+          "waitMs": 900
+        },
+        {
+          "id": "primary-action",
+          "title": "Primary action",
+          "description": "Visit /tasks to confirm any tasks emitted by web-traffic are in the feed.",
+          "nav": "/tasks"
+        },
+        {
+          "id": "error-refused",
+          "title": "Error / refused state",
+          "description": "Visit /settings to confirm web-traffic permissions and toggles render correctly.",
+          "nav": "/settings"
+        },
+        {
+          "id": "back-out",
+          "title": "Back-out",
+          "description": "Return to the home feed; verify the tile state survives navigation.",
+          "nav": "/home"
+        }
+      ]
     },
     {
       "id": "web-traffic-mac",
       "scriptId": "web-traffic",
       "surface": "askmac",
       "title": "Web Traffic · AskMac",
+      "description": "Walk Settings ▸ Scripts ▸ Web Traffic on the AskMac native app. Parses browser history to show websites visited daily — Safari, Chrome, Brave, Firefox, Arc. Surfaces visited: scripts list, script row, permissions, blocks, logs.",
       "driver": "computer-use",
       "deps": [],
-      "status": "pending"
+      "status": "pending",
+      "steps": [
+        {
+          "id": "cold-open",
+          "title": "Cold open",
+          "description": "Open AskMac and confirm Settings ▸ Scripts shows web-traffic as enabled."
+        },
+        {
+          "id": "script-row",
+          "title": "Script row",
+          "description": "The web-traffic row shows the manifest version, summary, and an enable/disable toggle."
+        },
+        {
+          "id": "permissions-sheet",
+          "title": "Permissions sheet",
+          "description": "The script's declared permissions are listed correctly for web-traffic."
+        },
+        {
+          "id": "block-view",
+          "title": "Block view",
+          "description": "If web-traffic publishes blocks, they render in the AskMac viewer with no errors."
+        },
+        {
+          "id": "logs-pane",
+          "title": "Logs / errors pane",
+          "description": "Recent log lines for web-traffic appear; no red error rows."
+        },
+        {
+          "id": "disable-reenable",
+          "title": "Disable / re-enable",
+          "description": "Toggle web-traffic off then on; verify clean teardown and re-installation."
+        }
+      ]
     },
     {
       "id": "task-demo-web",
       "scriptId": "task-demo",
       "surface": "web",
       "title": "Task Demo · Web",
+      "description": "Walk every primary surface for Task Demo on the iPhone webview. End-to-end demo of the A2A task protocol: open_task, append_message, put_artifact. Surfaces visited: home feed, script detail, tasks, settings.",
       "spec": "specs/scripts/task-demo.web.spec.ts",
       "deps": [],
-      "status": "implemented"
+      "status": "implemented",
+      "steps": [
+        {
+          "id": "cold-open",
+          "title": "Cold open",
+          "description": "Open the home feed at /home with no other interaction; expect the script list to render.",
+          "nav": "/home"
+        },
+        {
+          "id": "tile-entry",
+          "title": "Tile / feed entry",
+          "description": "The task-demo tile or feed entry renders with its icon and name in the home feed.",
+          "waitMs": 300
+        },
+        {
+          "id": "tap-detail",
+          "title": "Tap into detail",
+          "description": "Navigate to /script/task-demo — the script's primary surface.",
+          "nav": "/script/task-demo"
+        },
+        {
+          "id": "empty-state",
+          "title": "Empty state",
+          "description": "Detail screen on first paint — what the user sees before data arrives.",
+          "waitMs": 300
+        },
+        {
+          "id": "populated-state",
+          "title": "Populated state",
+          "description": "Same screen after a brief settle — captures whatever blocks the script publishes.",
+          "waitMs": 900
+        },
+        {
+          "id": "primary-action",
+          "title": "Primary action",
+          "description": "Visit /tasks to confirm any tasks emitted by task-demo are in the feed.",
+          "nav": "/tasks"
+        },
+        {
+          "id": "error-refused",
+          "title": "Error / refused state",
+          "description": "Visit /settings to confirm task-demo permissions and toggles render correctly.",
+          "nav": "/settings"
+        },
+        {
+          "id": "back-out",
+          "title": "Back-out",
+          "description": "Return to the home feed; verify the tile state survives navigation.",
+          "nav": "/home"
+        }
+      ]
     },
     {
       "id": "task-demo-mac",
       "scriptId": "task-demo",
       "surface": "askmac",
       "title": "Task Demo · AskMac",
+      "description": "Walk Settings ▸ Scripts ▸ Task Demo on the AskMac native app. End-to-end demo of the A2A task protocol: open_task, append_message, put_artifact. Surfaces visited: scripts list, script row, permissions, blocks, logs.",
       "driver": "computer-use",
       "deps": [],
-      "status": "pending"
+      "status": "pending",
+      "steps": [
+        {
+          "id": "cold-open",
+          "title": "Cold open",
+          "description": "Open AskMac and confirm Settings ▸ Scripts shows task-demo as enabled."
+        },
+        {
+          "id": "script-row",
+          "title": "Script row",
+          "description": "The task-demo row shows the manifest version, summary, and an enable/disable toggle."
+        },
+        {
+          "id": "permissions-sheet",
+          "title": "Permissions sheet",
+          "description": "The script's declared permissions are listed correctly for task-demo."
+        },
+        {
+          "id": "block-view",
+          "title": "Block view",
+          "description": "If task-demo publishes blocks, they render in the AskMac viewer with no errors."
+        },
+        {
+          "id": "logs-pane",
+          "title": "Logs / errors pane",
+          "description": "Recent log lines for task-demo appear; no red error rows."
+        },
+        {
+          "id": "disable-reenable",
+          "title": "Disable / re-enable",
+          "description": "Toggle task-demo off then on; verify clean teardown and re-installation."
+        }
+      ]
     },
     {
       "id": "terminal-snapshot-web",
       "scriptId": "terminal-snapshot",
       "surface": "web",
       "title": "Terminal Snapshot · Web",
+      "description": "Walk every primary surface for Terminal Snapshot on the iPhone webview. Capture the current state of any tmux terminal pane — text and image. Surfaces visited: home feed, script detail, tasks, settings.",
       "spec": "specs/scripts/terminal-snapshot.web.spec.ts",
       "deps": [
         "terminal-manager"
       ],
-      "status": "implemented"
+      "status": "implemented",
+      "steps": [
+        {
+          "id": "cold-open",
+          "title": "Cold open",
+          "description": "Open the home feed at /home with no other interaction; expect the script list to render.",
+          "nav": "/home"
+        },
+        {
+          "id": "tile-entry",
+          "title": "Tile / feed entry",
+          "description": "The terminal-snapshot tile or feed entry renders with its icon and name in the home feed.",
+          "waitMs": 300
+        },
+        {
+          "id": "tap-detail",
+          "title": "Tap into detail",
+          "description": "Navigate to /script/terminal-snapshot — the script's primary surface.",
+          "nav": "/script/terminal-snapshot"
+        },
+        {
+          "id": "empty-state",
+          "title": "Empty state",
+          "description": "Detail screen on first paint — what the user sees before data arrives.",
+          "waitMs": 300
+        },
+        {
+          "id": "populated-state",
+          "title": "Populated state",
+          "description": "Same screen after a brief settle — captures whatever blocks the script publishes.",
+          "waitMs": 900
+        },
+        {
+          "id": "primary-action",
+          "title": "Primary action",
+          "description": "Visit /tasks to confirm any tasks emitted by terminal-snapshot are in the feed.",
+          "nav": "/tasks"
+        },
+        {
+          "id": "error-refused",
+          "title": "Error / refused state",
+          "description": "Visit /settings to confirm terminal-snapshot permissions and toggles render correctly.",
+          "nav": "/settings"
+        },
+        {
+          "id": "back-out",
+          "title": "Back-out",
+          "description": "Return to the home feed; verify the tile state survives navigation.",
+          "nav": "/home"
+        }
+      ]
     },
     {
       "id": "terminal-snapshot-mac",
       "scriptId": "terminal-snapshot",
       "surface": "askmac",
       "title": "Terminal Snapshot · AskMac",
+      "description": "Walk Settings ▸ Scripts ▸ Terminal Snapshot on the AskMac native app. Capture the current state of any tmux terminal pane — text and image. Surfaces visited: scripts list, script row, permissions, blocks, logs.",
       "driver": "computer-use",
       "deps": [
         "terminal-manager"
       ],
-      "status": "pending"
+      "status": "pending",
+      "steps": [
+        {
+          "id": "cold-open",
+          "title": "Cold open",
+          "description": "Open AskMac and confirm Settings ▸ Scripts shows terminal-snapshot as enabled."
+        },
+        {
+          "id": "script-row",
+          "title": "Script row",
+          "description": "The terminal-snapshot row shows the manifest version, summary, and an enable/disable toggle."
+        },
+        {
+          "id": "permissions-sheet",
+          "title": "Permissions sheet",
+          "description": "The script's declared permissions are listed correctly for terminal-snapshot."
+        },
+        {
+          "id": "block-view",
+          "title": "Block view",
+          "description": "If terminal-snapshot publishes blocks, they render in the AskMac viewer with no errors."
+        },
+        {
+          "id": "logs-pane",
+          "title": "Logs / errors pane",
+          "description": "Recent log lines for terminal-snapshot appear; no red error rows."
+        },
+        {
+          "id": "disable-reenable",
+          "title": "Disable / re-enable",
+          "description": "Toggle terminal-snapshot off then on; verify clean teardown and re-installation."
+        }
+      ]
     },
     {
       "id": "claude-3-web",
       "scriptId": "claude-3",
       "surface": "web",
       "title": "Claude 3 · Web",
+      "description": "Walk every primary surface for Claude 3 on the iPhone webview. Feed-first Claude Code session supervisor — routes permissions and session history to iPhone. Surfaces visited: home feed, script detail, tasks, settings.",
       "spec": "specs/scripts/claude-3.web.spec.ts",
       "deps": [
         "terminal-manager"
       ],
-      "status": "implemented"
+      "status": "implemented",
+      "steps": [
+        {
+          "id": "cold-open",
+          "title": "Cold open",
+          "description": "Open the home feed at /home with no other interaction; expect the script list to render.",
+          "nav": "/home"
+        },
+        {
+          "id": "tile-entry",
+          "title": "Tile / feed entry",
+          "description": "The claude-3 tile or feed entry renders with its icon and name in the home feed.",
+          "waitMs": 300
+        },
+        {
+          "id": "tap-detail",
+          "title": "Tap into detail",
+          "description": "Navigate to /script/claude-3 — the script's primary surface.",
+          "nav": "/script/claude-3"
+        },
+        {
+          "id": "empty-state",
+          "title": "Empty state",
+          "description": "Detail screen on first paint — what the user sees before data arrives.",
+          "waitMs": 300
+        },
+        {
+          "id": "populated-state",
+          "title": "Populated state",
+          "description": "Same screen after a brief settle — captures whatever blocks the script publishes.",
+          "waitMs": 900
+        },
+        {
+          "id": "session-list",
+          "title": "Session list",
+          "description": "The detail screen lists active and recent Claude Code sessions; verify the badges (tmux/in-process/headless) render correctly.",
+          "waitMs": 500
+        },
+        {
+          "id": "primary-action",
+          "title": "Primary action",
+          "description": "Visit /tasks to confirm any tasks emitted by claude-3 are in the feed.",
+          "nav": "/tasks"
+        },
+        {
+          "id": "error-refused",
+          "title": "Error / refused state",
+          "description": "Visit /settings to confirm claude-3 permissions and toggles render correctly.",
+          "nav": "/settings"
+        },
+        {
+          "id": "back-out",
+          "title": "Back-out",
+          "description": "Return to the home feed; verify the tile state survives navigation.",
+          "nav": "/home"
+        }
+      ]
     },
     {
       "id": "claude-3-mac",
       "scriptId": "claude-3",
       "surface": "askmac",
       "title": "Claude 3 · AskMac",
+      "description": "Walk Settings ▸ Scripts ▸ Claude 3 on the AskMac native app. Feed-first Claude Code session supervisor — routes permissions and session history to iPhone. Surfaces visited: scripts list, script row, permissions, blocks, logs.",
       "driver": "computer-use",
       "deps": [
         "terminal-manager"
       ],
-      "status": "pending"
+      "status": "pending",
+      "steps": [
+        {
+          "id": "cold-open",
+          "title": "Cold open",
+          "description": "Open AskMac and confirm Settings ▸ Scripts shows claude-3 as enabled."
+        },
+        {
+          "id": "script-row",
+          "title": "Script row",
+          "description": "The claude-3 row shows the manifest version, summary, and an enable/disable toggle."
+        },
+        {
+          "id": "permissions-sheet",
+          "title": "Permissions sheet",
+          "description": "The script's declared permissions are listed correctly for claude-3."
+        },
+        {
+          "id": "block-view",
+          "title": "Block view",
+          "description": "If claude-3 publishes blocks, they render in the AskMac viewer with no errors."
+        },
+        {
+          "id": "logs-pane",
+          "title": "Logs / errors pane",
+          "description": "Recent log lines for claude-3 appear; no red error rows."
+        },
+        {
+          "id": "disable-reenable",
+          "title": "Disable / re-enable",
+          "description": "Toggle claude-3 off then on; verify clean teardown and re-installation."
+        }
+      ]
     },
     {
       "id": "codex-3-web",
       "scriptId": "codex-3",
       "surface": "web",
       "title": "Codex 3 · Web",
+      "description": "Walk every primary surface for Codex 3 on the iPhone webview. Feed-first Codex session supervisor with tmux transport and task-backed history. Surfaces visited: home feed, script detail, tasks, settings.",
       "spec": "specs/scripts/codex-3.web.spec.ts",
       "deps": [
         "terminal-manager"
       ],
-      "status": "implemented"
+      "status": "implemented",
+      "steps": [
+        {
+          "id": "cold-open",
+          "title": "Cold open",
+          "description": "Open the home feed at /home with no other interaction; expect the script list to render.",
+          "nav": "/home"
+        },
+        {
+          "id": "tile-entry",
+          "title": "Tile / feed entry",
+          "description": "The codex-3 tile or feed entry renders with its icon and name in the home feed.",
+          "waitMs": 300
+        },
+        {
+          "id": "tap-detail",
+          "title": "Tap into detail",
+          "description": "Navigate to /script/codex-3 — the script's primary surface.",
+          "nav": "/script/codex-3"
+        },
+        {
+          "id": "empty-state",
+          "title": "Empty state",
+          "description": "Detail screen on first paint — what the user sees before data arrives.",
+          "waitMs": 300
+        },
+        {
+          "id": "populated-state",
+          "title": "Populated state",
+          "description": "Same screen after a brief settle — captures whatever blocks the script publishes.",
+          "waitMs": 900
+        },
+        {
+          "id": "session-list",
+          "title": "Session list",
+          "description": "The detail screen lists active and recent Codex sessions with tmux targets; verify the session pill renders.",
+          "waitMs": 500
+        },
+        {
+          "id": "primary-action",
+          "title": "Primary action",
+          "description": "Visit /tasks to confirm any tasks emitted by codex-3 are in the feed.",
+          "nav": "/tasks"
+        },
+        {
+          "id": "error-refused",
+          "title": "Error / refused state",
+          "description": "Visit /settings to confirm codex-3 permissions and toggles render correctly.",
+          "nav": "/settings"
+        },
+        {
+          "id": "back-out",
+          "title": "Back-out",
+          "description": "Return to the home feed; verify the tile state survives navigation.",
+          "nav": "/home"
+        }
+      ]
     },
     {
       "id": "codex-3-mac",
       "scriptId": "codex-3",
       "surface": "askmac",
       "title": "Codex 3 · AskMac",
+      "description": "Walk Settings ▸ Scripts ▸ Codex 3 on the AskMac native app. Feed-first Codex session supervisor with tmux transport and task-backed history. Surfaces visited: scripts list, script row, permissions, blocks, logs.",
       "driver": "computer-use",
       "deps": [
         "terminal-manager"
       ],
-      "status": "pending"
+      "status": "pending",
+      "steps": [
+        {
+          "id": "cold-open",
+          "title": "Cold open",
+          "description": "Open AskMac and confirm Settings ▸ Scripts shows codex-3 as enabled."
+        },
+        {
+          "id": "script-row",
+          "title": "Script row",
+          "description": "The codex-3 row shows the manifest version, summary, and an enable/disable toggle."
+        },
+        {
+          "id": "permissions-sheet",
+          "title": "Permissions sheet",
+          "description": "The script's declared permissions are listed correctly for codex-3."
+        },
+        {
+          "id": "block-view",
+          "title": "Block view",
+          "description": "If codex-3 publishes blocks, they render in the AskMac viewer with no errors."
+        },
+        {
+          "id": "logs-pane",
+          "title": "Logs / errors pane",
+          "description": "Recent log lines for codex-3 appear; no red error rows."
+        },
+        {
+          "id": "disable-reenable",
+          "title": "Disable / re-enable",
+          "description": "Toggle codex-3 off then on; verify clean teardown and re-installation."
+        }
+      ]
     }
   ]
 }

--- a/web/review-plans/manual-script-sweep.json
+++ b/web/review-plans/manual-script-sweep.json
@@ -1,0 +1,200 @@
+{
+  "id": "manual-script-sweep",
+  "title": "Manual script sweep",
+  "version": "1.0.0",
+  "description": "Per-script regression: walk every Ask script through its golden path and edge cases on the iPhone webview, then on the AskMac native app. Each case isolates one script (disables others, enables only declared deps). Issues are pinned with kind + (x, y) location and the captured HTML for hand-off to a coding agent.",
+  "cases": [
+    {
+      "id": "hello-world-web",
+      "scriptId": "hello-world",
+      "surface": "web",
+      "title": "Hello World · Web",
+      "spec": "specs/scripts/hello-world.web.spec.ts",
+      "deps": [],
+      "status": "implemented"
+    },
+    {
+      "id": "hello-world-mac",
+      "scriptId": "hello-world",
+      "surface": "askmac",
+      "title": "Hello World · AskMac",
+      "driver": "computer-use",
+      "deps": [],
+      "status": "pending"
+    },
+    {
+      "id": "brew-monitor-web",
+      "scriptId": "brew-monitor",
+      "surface": "web",
+      "title": "Homebrew · Web",
+      "spec": "specs/scripts/brew-monitor.web.spec.ts",
+      "deps": [],
+      "status": "pending"
+    },
+    {
+      "id": "brew-monitor-mac",
+      "scriptId": "brew-monitor",
+      "surface": "askmac",
+      "title": "Homebrew · AskMac",
+      "driver": "computer-use",
+      "deps": [],
+      "status": "pending"
+    },
+    {
+      "id": "github-web",
+      "scriptId": "github",
+      "surface": "web",
+      "title": "Git Repos · Web",
+      "spec": "specs/scripts/github.web.spec.ts",
+      "deps": [],
+      "status": "pending"
+    },
+    {
+      "id": "github-mac",
+      "scriptId": "github",
+      "surface": "askmac",
+      "title": "Git Repos · AskMac",
+      "driver": "computer-use",
+      "deps": [],
+      "status": "pending"
+    },
+    {
+      "id": "ollama-web",
+      "scriptId": "ollama",
+      "surface": "web",
+      "title": "Ollama · Web",
+      "spec": "specs/scripts/ollama.web.spec.ts",
+      "deps": [],
+      "status": "pending"
+    },
+    {
+      "id": "ollama-mac",
+      "scriptId": "ollama",
+      "surface": "askmac",
+      "title": "Ollama · AskMac",
+      "driver": "computer-use",
+      "deps": [],
+      "status": "pending"
+    },
+    {
+      "id": "gdocs-history-web",
+      "scriptId": "gdocs-history",
+      "surface": "web",
+      "title": "Google Docs History · Web",
+      "spec": "specs/scripts/gdocs-history.web.spec.ts",
+      "deps": [],
+      "status": "pending"
+    },
+    {
+      "id": "gdocs-history-mac",
+      "scriptId": "gdocs-history",
+      "surface": "askmac",
+      "title": "Google Docs History · AskMac",
+      "driver": "computer-use",
+      "deps": [],
+      "status": "pending"
+    },
+    {
+      "id": "web-traffic-web",
+      "scriptId": "web-traffic",
+      "surface": "web",
+      "title": "Web Traffic · Web",
+      "spec": "specs/scripts/web-traffic.web.spec.ts",
+      "deps": [],
+      "status": "pending"
+    },
+    {
+      "id": "web-traffic-mac",
+      "scriptId": "web-traffic",
+      "surface": "askmac",
+      "title": "Web Traffic · AskMac",
+      "driver": "computer-use",
+      "deps": [],
+      "status": "pending"
+    },
+    {
+      "id": "task-demo-web",
+      "scriptId": "task-demo",
+      "surface": "web",
+      "title": "Task Demo · Web",
+      "spec": "specs/scripts/task-demo.web.spec.ts",
+      "deps": [],
+      "status": "pending"
+    },
+    {
+      "id": "task-demo-mac",
+      "scriptId": "task-demo",
+      "surface": "askmac",
+      "title": "Task Demo · AskMac",
+      "driver": "computer-use",
+      "deps": [],
+      "status": "pending"
+    },
+    {
+      "id": "terminal-snapshot-web",
+      "scriptId": "terminal-snapshot",
+      "surface": "web",
+      "title": "Terminal Snapshot · Web",
+      "spec": "specs/scripts/terminal-snapshot.web.spec.ts",
+      "deps": [
+        "terminal-manager"
+      ],
+      "status": "pending"
+    },
+    {
+      "id": "terminal-snapshot-mac",
+      "scriptId": "terminal-snapshot",
+      "surface": "askmac",
+      "title": "Terminal Snapshot · AskMac",
+      "driver": "computer-use",
+      "deps": [
+        "terminal-manager"
+      ],
+      "status": "pending"
+    },
+    {
+      "id": "claude-3-web",
+      "scriptId": "claude-3",
+      "surface": "web",
+      "title": "Claude 3 · Web",
+      "spec": "specs/scripts/claude-3.web.spec.ts",
+      "deps": [
+        "terminal-manager"
+      ],
+      "status": "pending"
+    },
+    {
+      "id": "claude-3-mac",
+      "scriptId": "claude-3",
+      "surface": "askmac",
+      "title": "Claude 3 · AskMac",
+      "driver": "computer-use",
+      "deps": [
+        "terminal-manager"
+      ],
+      "status": "pending"
+    },
+    {
+      "id": "codex-3-web",
+      "scriptId": "codex-3",
+      "surface": "web",
+      "title": "Codex 3 · Web",
+      "spec": "specs/scripts/codex-3.web.spec.ts",
+      "deps": [
+        "terminal-manager"
+      ],
+      "status": "pending"
+    },
+    {
+      "id": "codex-3-mac",
+      "scriptId": "codex-3",
+      "surface": "askmac",
+      "title": "Codex 3 · AskMac",
+      "driver": "computer-use",
+      "deps": [
+        "terminal-manager"
+      ],
+      "status": "pending"
+    }
+  ]
+}

--- a/web/scripts/review-server.ts
+++ b/web/scripts/review-server.ts
@@ -426,14 +426,20 @@ const HTML = `<!doctype html>
   .mini-map .node.current .cap { font-weight: 600; }
   .mini-map .node .fb-count { position: absolute; top: -2px; left: 22px; min-width: 14px; height: 14px; padding: 0 3px; border-radius: 7px; background: var(--success); color: #fff; font-size: 9px; font-weight: 700; display: flex; align-items: center; justify-content: center; border: 2px solid var(--bg); }
   .mini-map .arrow { flex: 0 0 14px; height: 2px; background: var(--rail); }
-  /* ----- Slide (one step at a time) ----- */
-  .slide { padding: 12px 16px 14px; }
-  .slide .step-head { display: flex; align-items: baseline; gap: 10px; flex-wrap: wrap; margin: 0 0 6px; }
+  /* ----- Slide: image left, sidebar right (title/description/feedback)
+     The image always sits at the top of the panel; text on the right grows
+     downward without ever pushing the image. ----- */
+  .slide { display: grid; grid-template-columns: minmax(0, 1fr) 300px; grid-template-rows: auto auto; gap: 14px; padding: 12px 14px 14px; }
+  @media (max-width: 900px) { .slide { grid-template-columns: 1fr; } }
+  .slide .step-image { grid-column: 1; grid-row: 1; }
+  .slide .step-side  { grid-column: 2; grid-row: 1; display: flex; flex-direction: column; gap: 10px; min-width: 0; }
+  .slide .slide-nav  { grid-column: 1 / -1; grid-row: 2; }
+  .slide .step-head { display: flex; align-items: baseline; gap: 8px; flex-wrap: wrap; }
   .slide .step-meta { color: var(--muted); font-size: 11px; margin: 0; }
-  .slide .step-title { font-size: 16px; font-weight: 600; margin: 0; }
-  .slide .step-desc { color: var(--muted); font-size: 12px; line-height: 1.5; margin: 0 0 8px; max-width: 920px; }
-  .slide .step-shot-wrap { display: flex; justify-content: center; align-items: center; background: var(--code-bg); border: 1px solid var(--border); border-radius: 8px; padding: 8px; margin-bottom: 8px; min-height: 200px; }
-  .slide .step-shot { max-width: 100%; max-height: calc(100vh - 320px); object-fit: contain; cursor: zoom-in; border-radius: 4px; }
+  .slide .step-title { font-size: 16px; font-weight: 600; margin: 0; line-height: 1.3; }
+  .slide .step-desc { color: var(--text); font-size: 13px; line-height: 1.55; margin: 0; }
+  .slide .step-shot-wrap { display: flex; justify-content: center; align-items: center; background: var(--code-bg); border: 1px solid var(--border); border-radius: 8px; padding: 8px; min-height: 200px; }
+  .slide .step-shot { max-width: 100%; max-height: calc(100vh - 240px); object-fit: contain; cursor: zoom-in; border-radius: 4px; }
   .slide .quick { margin-top: 0; display: flex; gap: 6px; flex-wrap: wrap; }
   .slide .quick button { font-size: 13px; padding: 6px 12px 6px 10px; display: inline-flex; align-items: center; gap: 6px; }
   .slide .quick button svg { width: 18px; height: 18px; flex-shrink: 0; }
@@ -523,9 +529,9 @@ const HTML = `<!doctype html>
 // No network dependency, scales cleanly, inherits the button text color.
 const SVG = {
   ok:        '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M9 12.75 11.25 15 15 9.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"/></svg>',
-  bug:       '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M12 12.75c1.148 0 2.278.08 3.383.237 1.037.146 1.866.966 1.866 2.013 0 3.728-2.35 6.75-5.25 6.75S6.75 18.728 6.75 15c0-1.046.83-1.867 1.866-2.013A24.16 24.16 0 0 1 12 12.75ZM12 9.75v.008M12 6.75v6M9 6.75 7.5 5.25M15 6.75l1.5-1.5M9 12.75H6M15 12.75h3M5.25 18.75H4.5M19.5 18.75H18.75"/></svg>',
-  style:     '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M9.53 16.122a3 3 0 0 0-3.412 1.034c-.473.658-.892 1.4-1.218 2.193a39.4 39.4 0 0 0 3.279-.764 3 3 0 0 0 1.351-2.463zM3.75 12.75A8.967 8.967 0 0 1 12 4.5c5 0 8.25 3.75 8.25 8.25 0 4-2 6-3 7l-3-3c1-1 3-3 3-7"/><path d="M14.25 9.75 10 14"/></svg>',
-  copy:      '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M16.862 4.487 18.549 2.799a2.121 2.121 0 1 1 3 3L19.862 7.487m-3-3L6.832 14.518a4.5 4.5 0 0 0-1.13 1.897l-1.034 3.45 3.45-1.034a4.5 4.5 0 0 0 1.897-1.13L19.862 7.487m-3-3 3 3"/></svg>',
+  bug:       '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="7" y="8" width="10" height="12" rx="5"/><path d="M12 8V5M9 5l-1-2M15 5l1-2M7 12H4M20 12h-3M7 16H4M20 16h-3M7 20l-2 1M17 20l2 1"/></svg>',
+  style:     '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3a9 9 0 1 0 0 18 1.5 1.5 0 0 0 0-3 1.5 1.5 0 0 1 0-3h2.5a4.5 4.5 0 0 0 4.5-4.5C19 6.4 15.86 3 12 3z"/><circle cx="7.5" cy="11" r=".75" fill="currentColor"/><circle cx="11" cy="7.5" r=".75" fill="currentColor"/><circle cx="15.5" cy="9.5" r=".75" fill="currentColor"/></svg>',
+  copy:      '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M8 4h8a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2z"/><path d="M9 9h6M9 13h6M9 17h4"/></svg>',
   confusing: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 5.25h.008v.008H12v-.008Z"/></svg>',
   slow:      '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M12 6v6h4.5m4.5 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"/></svg>',
   other:     '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M2.25 12.76c0 1.6 1.123 2.994 2.707 3.227 1.068.157 2.148.279 3.238.364.466.037.893.281 1.153.671L12 21l2.652-3.978c.26-.39.687-.634 1.153-.67 1.09-.086 2.17-.208 3.238-.365 1.584-.233 2.707-1.626 2.707-3.228V6.741c0-1.602-1.123-2.995-2.707-3.228A48.394 48.394 0 0 0 12 3c-2.392 0-4.744.175-7.043.513C3.373 3.746 2.25 5.14 2.25 6.741v6.018Z"/></svg>',
@@ -759,12 +765,23 @@ async function renderDetail(id) {
     const stepFb = fb.filter(x => x.storyPath === s.path && x.stepIdx === st.idx);
     slideHtml =
       '<div class="panel slide" data-story-path="' + escape(s.path) + '" data-step="' + st.idx + '">' +
-        '<div class="step-head">' +
-          '<h2 class="step-title">' + escape(st.title) + '</h2>' +
-          '<span class="step-meta">Step ' + (slideIdx+1) + ' / ' + allSteps.length + ' · ' + st.durationMs + 'ms</span>' +
+        (st.file
+          ? '<div class="step-image"><div class="step-shot-wrap"><img class="step-shot" src="/runs/' + r.id + '/story/' + encodeURI(s.path) + '/' + encodeURI(st.file) + '" alt="' + escape(st.title) + '"></div></div>'
+          : '<div class="step-image"></div>') +
+        '<div class="step-side">' +
+          '<div class="step-head">' +
+            '<h2 class="step-title">' + escape(st.title) + '</h2>' +
+            '<span class="step-meta">Step ' + (slideIdx+1) + ' / ' + allSteps.length + ' · ' + st.durationMs + 'ms</span>' +
+          '</div>' +
+          (st.description ? '<p class="step-desc">' + escape(st.description) + '</p>' : '') +
+          (stepFb.length ? '<div class="fb-list">' +
+            stepFb.map(f => '<div class="fb-row">' +
+              '<span class="kind">' + (KINDS.find(k=>k.id===f.kind)?.icon ?? SVG.other) + escape(f.kind) + '</span>' +
+              '<span class="text">' + escape(f.text || '') + '</span>' +
+              '<span class="x" data-at="' + f.at + '" title="remove">' + SVG.remove + '</span>' +
+            '</div>').join('') +
+          '</div>' : '') +
         '</div>' +
-        (st.description ? '<p class="step-desc">' + escape(st.description) + '</p>' : '') +
-        (st.file ? '<div class="step-shot-wrap"><img class="step-shot" src="/runs/' + r.id + '/story/' + encodeURI(s.path) + '/' + encodeURI(st.file) + '" alt="' + escape(st.title) + '"></div>' : '') +
         '<div class="slide-nav">' +
           '<button id="prev"' + (slideIdx === 0 ? ' disabled' : '') + '>' + SVG.arrowLeft + '<span>Previous</span></button>' +
           '<div class="quick">' +
@@ -773,13 +790,6 @@ async function renderDetail(id) {
           '</div>' +
           '<button id="next"' + (slideIdx === allSteps.length-1 ? ' disabled' : '') + '><span>Next</span>' + SVG.arrowRight + '</button>' +
         '</div>' +
-        (stepFb.length ? '<div class="fb-list">' +
-          stepFb.map(f => '<div class="fb-row">' +
-            '<span class="kind">' + (KINDS.find(k=>k.id===f.kind)?.icon ?? SVG.other) + escape(f.kind) + '</span>' +
-            '<span class="text">' + escape(f.text || '') + '</span>' +
-            '<span class="x" data-at="' + f.at + '" title="remove">' + SVG.remove + '</span>' +
-          '</div>').join('') +
-        '</div>' : '') +
       '</div>';
   }
 

--- a/web/scripts/review-server.ts
+++ b/web/scripts/review-server.ts
@@ -317,14 +317,17 @@ const HTML = `<!doctype html>
   .step .duration { color: #666; font-size: 11px; }
   .step .shot { display: block; margin-top: 8px; max-width: 720px; width: 100%; border: 1px solid #262629; border-radius: 6px; cursor: zoom-in; }
   .step .quick { margin-top: 6px; display: flex; gap: 4px; flex-wrap: wrap; }
-  .step .quick button { font-size: 12px; padding: 3px 8px; }
+  .step .quick button { font-size: 12px; padding: 3px 8px 3px 6px; display: inline-flex; align-items: center; gap: 5px; }
+  .step .quick button svg { width: 14px; height: 14px; flex-shrink: 0; opacity: 0.85; }
   .step .quick button.active { background: #4aa3ff; border-color: #4aa3ff; color: #fff; }
   .step .fb { margin-top: 6px; }
   .step .fb-list { margin-top: 6px; display: flex; flex-direction: column; gap: 4px; }
   .step .fb-row { background: #1a1a1c; border: 1px solid #262629; border-radius: 4px; padding: 6px 8px; font-size: 12px; display: flex; gap: 8px; align-items: flex-start; }
-  .step .fb-row .kind { font-weight: 600; min-width: 80px; }
+  .step .fb-row .kind { font-weight: 600; min-width: 80px; display: inline-flex; align-items: center; gap: 4px; }
+  .step .fb-row .kind svg { width: 13px; height: 13px; flex-shrink: 0; opacity: 0.85; }
   .step .fb-row .text { color: #ddd; flex: 1; }
-  .step .fb-row .x { color: #666; cursor: pointer; }
+  .step .fb-row .x { color: #666; cursor: pointer; display: inline-flex; align-items: center; }
+  .step .fb-row .x svg { width: 13px; height: 13px; }
   .step .fb-row .x:hover { color: #ee9c9c; }
   /* Lightbox */
   dialog { background: rgba(0,0,0,0.95); border: none; max-width: 100vw; max-height: 100vh; padding: 0; }
@@ -352,13 +355,26 @@ const HTML = `<!doctype html>
 <main id="view"></main>
 <dialog id="lightbox"><img alt=""></dialog>
 <script>
+// Inline SVGs (Heroicons outline, 24x24 viewBox, stroke=currentColor).
+// No network dependency, scales cleanly, inherits the button text color.
+const SVG = {
+  ok:        '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M9 12.75 11.25 15 15 9.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"/></svg>',
+  bug:       '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M12 12.75c1.148 0 2.278.08 3.383.237 1.037.146 1.866.966 1.866 2.013 0 3.728-2.35 6.75-5.25 6.75S6.75 18.728 6.75 15c0-1.046.83-1.867 1.866-2.013A24.16 24.16 0 0 1 12 12.75ZM12 9.75v.008M12 6.75v6M9 6.75 7.5 5.25M15 6.75l1.5-1.5M9 12.75H6M15 12.75h3M5.25 18.75H4.5M19.5 18.75H18.75"/></svg>',
+  style:     '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M9.53 16.122a3 3 0 0 0-3.412 1.034c-.473.658-.892 1.4-1.218 2.193a39.4 39.4 0 0 0 3.279-.764 3 3 0 0 0 1.351-2.463zM3.75 12.75A8.967 8.967 0 0 1 12 4.5c5 0 8.25 3.75 8.25 8.25 0 4-2 6-3 7l-3-3c1-1 3-3 3-7"/><path d="M14.25 9.75 10 14"/></svg>',
+  copy:      '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M16.862 4.487 18.549 2.799a2.121 2.121 0 1 1 3 3L19.862 7.487m-3-3L6.832 14.518a4.5 4.5 0 0 0-1.13 1.897l-1.034 3.45 3.45-1.034a4.5 4.5 0 0 0 1.897-1.13L19.862 7.487m-3-3 3 3"/></svg>',
+  confusing: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 5.25h.008v.008H12v-.008Z"/></svg>',
+  slow:      '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M12 6v6h4.5m4.5 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"/></svg>',
+  other:     '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M2.25 12.76c0 1.6 1.123 2.994 2.707 3.227 1.068.157 2.148.279 3.238.364.466.037.893.281 1.153.671L12 21l2.652-3.978c.26-.39.687-.634 1.153-.67 1.09-.086 2.17-.208 3.238-.365 1.584-.233 2.707-1.626 2.707-3.228V6.741c0-1.602-1.123-2.995-2.707-3.228A48.394 48.394 0 0 0 12 3c-2.392 0-4.744.175-7.043.513C3.373 3.746 2.25 5.14 2.25 6.741v6.018Z"/></svg>',
+  remove:    '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M6 18 18 6M6 6l12 12"/></svg>',
+};
+
 const KINDS = [
-  { id: 'ok',         label: 'OK',         emoji: '👍' },
-  { id: 'bug',        label: 'Bug',        emoji: '🐛' },
-  { id: 'style',      label: 'Style',      emoji: '🎨' },
-  { id: 'copy',       label: 'Copy',       emoji: '📝' },
-  { id: 'confusing',  label: 'Confusing',  emoji: '🤔' },
-  { id: 'slow',       label: 'Slow',       emoji: '⚠️' },
+  { id: 'ok',         label: 'OK',         icon: SVG.ok },
+  { id: 'bug',        label: 'Bug',        icon: SVG.bug },
+  { id: 'style',      label: 'Style',      icon: SVG.style },
+  { id: 'copy',       label: 'Copy',       icon: SVG.copy },
+  { id: 'confusing',  label: 'Confusing',  icon: SVG.confusing },
+  { id: 'slow',       label: 'Slow',       icon: SVG.slow },
 ];
 
 const view = document.getElementById('view');
@@ -484,14 +500,14 @@ async function renderDetail(id) {
             '</div>' +
             (st.file ? '<img class="shot" loading="lazy" src="/runs/' + r.id + '/story/' + encodeURI(s.path) + '/' + encodeURI(st.file) + '" alt="' + escape(st.name) + '">' : '') +
             '<div class="quick">' +
-              KINDS.map(k => '<button data-kind="' + k.id + '">' + k.emoji + ' ' + k.label + '</button>').join('') +
-              '<button data-kind="other">＋ Comment</button>' +
+              KINDS.map(k => '<button data-kind="' + k.id + '">' + k.icon + '<span>' + k.label + '</span></button>').join('') +
+              '<button data-kind="other">' + SVG.other + '<span>Comment</span></button>' +
             '</div>' +
             '<div class="fb-list">' +
               stepFb.map(f => '<div class="fb-row">' +
-                '<span class="kind">' + (KINDS.find(k=>k.id===f.kind)?.emoji ?? '·') + ' ' + escape(f.kind) + '</span>' +
+                '<span class="kind">' + (KINDS.find(k=>k.id===f.kind)?.icon ?? SVG.other) + escape(f.kind) + '</span>' +
                 '<span class="text">' + escape(f.text || '') + '</span>' +
-                '<span class="x" data-at="' + f.at + '" title="remove">✕</span>' +
+                '<span class="x" data-at="' + f.at + '" title="remove">' + SVG.remove + '</span>' +
               '</div>').join('') +
             '</div>' +
           '</div>';

--- a/web/scripts/review-server.ts
+++ b/web/scripts/review-server.ts
@@ -1695,7 +1695,17 @@ themeBtn.addEventListener('click', () => {
 
 loadSpecs();
 route();
-setInterval(() => { if (!location.hash.startsWith('#/run/')) renderList(); }, 5000);
+// Refresh the current view periodically so a running test updates the
+// status. Use route() so plan-aware paths render the right view (the prior
+// version called renderList() unconditionally, which clobbered any plan
+// or plan-run page back to the legacy runs table).
+setInterval(() => {
+  const h = location.hash;
+  // Don't disrupt the slideshow — pin/popover state is local to the DOM.
+  if (h.startsWith('#/run/')) return;
+  if (h.match(/^#\\/plan\\/[^/]+\\/run\\/[^/]+\\/[^/]+$/)) return;
+  route();
+}, 5000);
 </script>
 </body></html>`
 

--- a/web/scripts/review-server.ts
+++ b/web/scripts/review-server.ts
@@ -229,6 +229,9 @@ interface StartRunOpts {
   specs?: string[]          // many specs (plan-aware multi-case runs)
   planId?: string
   scope?: 'all' | { caseIds: string[] }
+  manual?: boolean          // true → don't spawn Playwright; leave run open
+                            // for screenshot ingest. Used for computer-use
+                            // (AskMac) walkthroughs driven by Claude.
 }
 
 function startRun(opts: StartRunOpts | string): Run | null {
@@ -273,6 +276,13 @@ function startRun(opts: StartRunOpts | string): Run | null {
   currentRunId = run.id
   currentOutput = ''
   broadcast('started', { id: run.id })
+
+  // Manual runs (computer-use / hand-driven) leave the run open. Steps
+  // are POSTed to /api/runs/:id/cases/:caseId/step and the run is closed
+  // via /api/runs/:id/finish.
+  if (o.manual) {
+    return run
+  }
 
   const args = ['playwright', 'test', ...allSpecs]
   const child = spawn('npx', args, { cwd: WEB, env: { ...process.env, FORCE_COLOR: '0' } })
@@ -1629,7 +1639,10 @@ async function renderPlanDetail(planId) {
     const actions = c.status === 'implemented'
       ? '<button class="primary" data-act="run" data-caseid="' + escape(c.id) + '">Run only this case</button>' +
         '<button data-act="open" data-caseid="' + escape(c.id) + '">Open case</button>'
-      : '<button data-act="open" data-caseid="' + escape(c.id) + '">Open case</button>';
+      : c.driver === 'computer-use'
+        ? '<button class="primary" data-act="run-manual" data-caseid="' + escape(c.id) + '">Start AskMac walkthrough</button>' +
+          '<button data-act="open" data-caseid="' + escape(c.id) + '">Open case</button>'
+        : '<button data-act="open" data-caseid="' + escape(c.id) + '">Open case</button>';
 
     return '<div class="card" data-caseid="' + escape(c.id) + '" data-runid="' + escape(lastRun?.id || '') + '" data-storypath="' + escape(story?.path || '') + '">' +
       '<div class="head"><h2>' + escape(c.title) + '</h2>' + surfaceTag + statusBadge + '</div>' +
@@ -1709,13 +1722,21 @@ async function renderPlanDetail(planId) {
         location.hash = '#/plan/' + planId + '/case/' + cid;
         return;
       }
-      if (b.dataset.act === 'run') {
+      if (b.dataset.act === 'run' || b.dataset.act === 'run-manual') {
         const r = await fetch('/api/plans/' + planId + '/runs', {
           method: 'POST', headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ scope: { caseIds: [cid] } }),
         }).then(r => r.json());
         if (r.error) { alert(r.error); return; }
-        if (r.id) location.hash = '#/plan/' + planId + '/run/' + r.id;
+        if (r.id) {
+          if (r.manual) {
+            const tip = 'Manual run created — id: ' + r.id + '\\n\\n' +
+              'In chat, tell Claude:\\n  Drive the AskMac walkthrough for run ' + r.id + ' (case ' + cid + ').\\n\\n' +
+              'Claude will capture each step via computer-use and post it to /api/runs/' + r.id + '/cases/' + cid + '/step.';
+            alert(tip);
+          }
+          location.hash = '#/plan/' + planId + '/run/' + r.id;
+        }
       }
     });
   });
@@ -1900,9 +1921,13 @@ async function renderCaseDetail(planId, caseId) {
     : '<tr><td colspan="6" class="muted" style="padding:18px;text-align:center">No runs of this case yet.</td></tr>';
 
   const isPending = c.status === 'pending';
+  const isComputerUse = c.driver === 'computer-use';
   const runScopedBtn = !isPending
     ? '<button class="primary" id="run-this-case">Run only this case</button>'
-    : '<span class="muted" style="font-size:12px">This case is pending — driver is <code>' + escape(c.driver || 'not set') + '</code> (Phase 3).</span>';
+    : isComputerUse
+      ? '<button class="primary" id="run-this-case">Start AskMac walkthrough</button>' +
+        ' <span class="muted" style="font-size:12px;margin-left:8px">Creates a manual run; ask Claude in chat to capture steps via computer-use.</span>'
+      : '<span class="muted" style="font-size:12px">This case is pending — no driver configured.</span>';
 
   view.innerHTML =
     '<div class="run-hero">' +
@@ -1928,8 +1953,13 @@ async function renderCaseDetail(planId, caseId) {
         method: 'POST', headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ scope: { caseIds: [c.id] } }),
       }).then(r => r.json());
-      if (r.id) location.hash = '#/plan/' + planId + '/run/' + r.id;
-      else if (r.error) alert(r.error);
+      if (r.error) { alert(r.error); return; }
+      if (r.id) {
+        if (r.manual) {
+          alert('Manual run created — id: ' + r.id + '\\n\\nIn chat, tell Claude:\\n  Drive the AskMac walkthrough for run ' + r.id + ' (case ' + c.id + ').\\n\\nClaude will capture each step via computer-use and post it to /api/runs/' + r.id + '/cases/' + c.id + '/step.');
+        }
+        location.hash = '#/plan/' + planId + '/run/' + r.id;
+      }
     });
   }
   view.querySelectorAll('tr.clickable').forEach(tr => {
@@ -2215,15 +2245,27 @@ const server = http.createServer(async (req, res) => {
       try { const parsed = JSON.parse(body || '{}'); if (parsed.scope) scope = parsed.scope } catch { /* */ }
       // Resolve which spec(s) to run for the chosen cases.
       const wantedIds = scope === 'all' ? null : new Set(scope.caseIds)
-      const specs = plan.cases
-        .filter(c => c.status === 'implemented' && c.spec)
-        .filter(c => !wantedIds || wantedIds.has(c.id))
-        .map(c => `e2e/${c.spec}`)
-      if (!specs.length) { res.writeHead(400); res.end(JSON.stringify({ error: 'no implemented cases match the scope' })); return }
-      const run = startRun({ specs, planId: plan.id, scope })
+      // Resolve selected cases — could be Playwright (web) or computer-use
+      // (AskMac/manual). For mixed scopes, we currently require single-driver.
+      const selected = plan.cases.filter(c => !wantedIds || wantedIds.has(c.id))
+      const playwrightCases = selected.filter(c => c.spec && c.status === 'implemented')
+      const manualCases = selected.filter(c => c.driver === 'computer-use' && !c.spec)
+      if (!playwrightCases.length && !manualCases.length) {
+        res.writeHead(400); res.end(JSON.stringify({ error: 'no runnable cases match the scope' })); return
+      }
+      if (playwrightCases.length && manualCases.length) {
+        res.writeHead(400); res.end(JSON.stringify({ error: 'mixed-driver scopes not yet supported — pick web or AskMac cases, not both' })); return
+      }
+      let run
+      if (playwrightCases.length) {
+        const specs = playwrightCases.map(c => `e2e/${c.spec}`)
+        run = startRun({ specs, planId: plan.id, scope })
+      } else {
+        run = startRun({ planId: plan.id, scope, manual: true })
+      }
       if (!run) { res.writeHead(409); res.end(JSON.stringify({ error: 'a run is already in progress' })); return }
       res.writeHead(202, { 'Content-Type': 'application/json' })
-      res.end(JSON.stringify({ id: run.id }))
+      res.end(JSON.stringify({ id: run.id, manual: !playwrightCases.length }))
     })
     return
   }
@@ -2252,6 +2294,78 @@ const server = http.createServer(async (req, res) => {
     res.end(JSON.stringify({ plan: { id: plan.id, title: plan.title, version: plan.version }, case: c, history }))
     return
   }
+  // Manual-run step ingest: append a captured step to a manual (driver=
+  // computer-use) run. Body: { idx, title, description, image_b64 }.
+  // Writes a PNG into runs/<id>/story/<caseId>/NN-<slug>.png and updates
+  // story.json so the dashboard renders it like any other captured step.
+  const caseStepIngest = p.match(/^\/api\/runs\/([^/]+)\/cases\/([^/]+)\/step$/)
+  if (caseStepIngest && req.method === 'POST') {
+    let body = ''
+    req.on('data', d => body += d)
+    req.on('end', () => {
+      try {
+        const { idx, title, description, image_b64 } = JSON.parse(body) as {
+          idx: number; title: string; description?: string; image_b64: string
+        }
+        const runId = caseStepIngest[1]
+        const caseId = caseStepIngest[2]
+        const r = getRun(runId)
+        if (!r) { res.writeHead(404); res.end(JSON.stringify({ error: 'run not found' })); return }
+        const storyDir = path.join(RUNS_DIR, runId, 'story', caseId)
+        fs.mkdirSync(storyDir, { recursive: true })
+        const slug = (title || `step-${idx}`).toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '').slice(0, 60)
+        const file = `${String(idx).padStart(2, '0')}-${slug}.png`
+        const buf = Buffer.from(image_b64, 'base64')
+        fs.writeFileSync(path.join(storyDir, file), buf)
+        // Maintain story.json
+        const storyJsonPath = path.join(storyDir, 'story.json')
+        let story: Record<string, unknown> = {}
+        try { story = JSON.parse(fs.readFileSync(storyJsonPath, 'utf-8')) as Record<string, unknown> } catch { /* */ }
+        const meta = loadRunMeta(runId)
+        const planCase = meta ? getPlan(meta.planId)?.cases.find(c => c.id === caseId) : undefined
+        if (!story.title) story.title = planCase?.title ?? caseId
+        if (!story.description) story.description = planCase?.description ?? ''
+        if (!story.testTitle) story.testTitle = caseId
+        if (!story.caseId) story.caseId = caseId
+        if (!story.startedAt) story.startedAt = r.startedAt
+        const steps = (Array.isArray(story.steps) ? story.steps : []) as Array<Record<string, unknown>>
+        // Replace any existing step with the same idx, else append.
+        const existing = steps.findIndex(s => s.idx === idx)
+        const stepRecord = { idx, title, description: description ?? '', file, at: Date.now(), durationMs: 0 }
+        if (existing >= 0) steps[existing] = stepRecord
+        else steps.push(stepRecord)
+        steps.sort((a, b) => (a.idx as number) - (b.idx as number))
+        story.steps = steps
+        fs.writeFileSync(storyJsonPath, JSON.stringify(story, null, 2))
+        res.writeHead(200, { 'Content-Type': 'application/json' })
+        res.end(JSON.stringify({ ok: true, file, total: steps.length }))
+      } catch (e) { res.writeHead(400); res.end(JSON.stringify({ error: String(e) })) }
+    })
+    return
+  }
+  // Close a manual run: sets exitCode + endedAt + status, broadcasts done.
+  const finishRun = p.match(/^\/api\/runs\/([^/]+)\/finish$/)
+  if (finishRun && req.method === 'POST') {
+    let body = ''
+    req.on('data', d => body += d)
+    req.on('end', () => {
+      let exitCode = 0
+      try { const j = JSON.parse(body || '{}'); if (typeof j.exitCode === 'number') exitCode = j.exitCode } catch { /* */ }
+      const runId = finishRun[1]
+      const updated = updateRun(runId, {
+        endedAt: Date.now(),
+        exitCode,
+        status: 'awaiting-review',
+      })
+      if (!updated) { res.writeHead(404); res.end(JSON.stringify({ error: 'run not found' })); return }
+      if (currentRunId === runId) currentRunId = null
+      broadcast('done', { id: runId, exitCode, screenshotCount: 0 })
+      res.writeHead(200, { 'Content-Type': 'application/json' })
+      res.end(JSON.stringify(updated))
+    })
+    return
+  }
+
   const caseDetail = p.match(/^\/api\/runs\/([^/]+)\/cases\/([^/]+)$/)
   if (caseDetail && req.method === 'GET') {
     const r = getRun(caseDetail[1])

--- a/web/scripts/review-server.ts
+++ b/web/scripts/review-server.ts
@@ -344,10 +344,28 @@ const HTML = `<!doctype html>
   }
   * { box-sizing: border-box; }
   body { margin: 0; font: 14px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; background: var(--bg); color: var(--text); }
-  header { position: sticky; top: 0; z-index: 20; padding: 12px 16px; background: var(--header); border-bottom: 1px solid var(--header-bd); display: flex; gap: 12px; align-items: center; flex-wrap: wrap; }
-  header h1 { font-size: 14px; margin: 0; font-weight: 600; }
-  header h1 a { color: inherit; text-decoration: none; }
-  header .right { margin-left: auto; display: flex; gap: 8px; align-items: center; }
+  /* ----- Floating menu trigger + slide-out side panel
+     Replaces the old sticky top toolbar. The trigger sits in the corner so
+     screenshots get the full vertical space; the panel slides in from the
+     left when opened. ----- */
+  #menu-trigger { position: fixed; top: 10px; left: 12px; z-index: 30; width: 38px; height: 38px; display: flex; align-items: center; justify-content: center; background: var(--panel); border: 1px solid var(--border); border-radius: 8px; box-shadow: var(--shadow); cursor: pointer; padding: 0; }
+  #menu-trigger svg { width: 20px; height: 20px; }
+  #menu-trigger:hover { background: var(--row-hover); }
+  #status-pill { position: fixed; top: 18px; right: 14px; z-index: 30; }
+  #side-panel { position: fixed; top: 0; left: 0; bottom: 0; width: 280px; background: var(--panel); border-right: 1px solid var(--border); box-shadow: 4px 0 18px rgba(0,0,0,0.12); z-index: 40; transform: translateX(-110%); transition: transform .22s ease; padding: 16px; display: flex; flex-direction: column; gap: 12px; overflow-y: auto; }
+  #side-panel.open { transform: translateX(0); }
+  #side-panel h1 { font-size: 14px; margin: 0; font-weight: 600; padding-right: 30px; }
+  #side-panel h1 a { color: inherit; text-decoration: none; }
+  #side-panel .group { display: flex; flex-direction: column; gap: 6px; }
+  #side-panel .group label { font-size: 11px; color: var(--muted); text-transform: uppercase; letter-spacing: 0.06em; }
+  #side-panel .group select, #side-panel .group button, #side-panel .group a button { width: 100%; text-align: left; }
+  #side-panel #theme-toggle { display: inline-flex; align-items: center; gap: 8px; }
+  #side-panel #theme-toggle svg { width: 18px; height: 18px; flex-shrink: 0; }
+  #side-panel #close-panel { position: absolute; top: 10px; right: 10px; width: 28px; height: 28px; display: flex; align-items: center; justify-content: center; padding: 0; background: transparent; border: none; cursor: pointer; }
+  #side-panel #close-panel svg { width: 16px; height: 16px; }
+  #side-panel #close-panel:hover { background: var(--row-hover); border-radius: 4px; }
+  #panel-backdrop { position: fixed; inset: 0; background: rgba(0,0,0,0.35); opacity: 0; pointer-events: none; transition: opacity .2s ease; z-index: 35; }
+  #panel-backdrop.open { opacity: 1; pointer-events: auto; }
   select, button, input, textarea { background: var(--panel); color: var(--text); border: 1px solid var(--border); border-radius: 6px; padding: 6px 10px; font: inherit; }
   button { cursor: pointer; }
   select:hover, button:hover:not(:disabled) { background: var(--row-hover); }
@@ -358,7 +376,7 @@ const HTML = `<!doctype html>
   button.icon-only { padding: 5px 7px; line-height: 1; }
   button.icon-only svg { width: 18px; height: 18px; display: block; }
   button:disabled { opacity: 0.5; cursor: not-allowed; }
-  main { padding: 16px; max-width: 1400px; margin: 0 auto; }
+  main { padding: 16px 16px 16px 60px; max-width: 1400px; margin: 0 auto; }
   table { width: 100%; border-collapse: collapse; background: var(--panel); border-radius: 8px; overflow: hidden; box-shadow: var(--shadow); }
   table th, table td { padding: 10px 14px; text-align: left; border-bottom: 1px solid var(--border); vertical-align: top; }
   table tr:last-child td { border-bottom: 0; }
@@ -395,7 +413,7 @@ const HTML = `<!doctype html>
        - dark           = step you already passed
      A separate small badge by the number indicates feedback count, so
      "I left a note here" is no longer confused with "I'm here". */
-  .mini-map { position: sticky; top: 53px; z-index: 15; background: var(--bg); padding: 10px 0 12px; border-bottom: 1px solid var(--border); margin: 8px 0 16px; }
+  .mini-map { position: sticky; top: 0; z-index: 15; background: var(--bg); padding: 10px 0 12px; border-bottom: 1px solid var(--border); margin: 0 0 12px; }
   .mini-map .label { font-size: 11px; color: var(--muted); text-transform: uppercase; letter-spacing: 0.06em; margin-bottom: 8px; }
   .mini-map .nodes { display: flex; gap: 0; align-items: stretch; overflow-x: auto; padding-bottom: 2px; }
   .mini-map .node { flex: 1 1 0; min-width: 80px; display: flex; flex-direction: column; align-items: center; cursor: pointer; padding: 4px; border-radius: 6px; position: relative; }
@@ -415,8 +433,8 @@ const HTML = `<!doctype html>
   .slide .step-meta { color: var(--muted); font-size: 12px; margin: 0 0 4px; }
   .slide .step-title { font-size: 18px; font-weight: 600; margin: 0 0 6px; }
   .slide .step-desc { color: var(--muted); font-size: 14px; line-height: 1.6; margin: 0 0 16px; max-width: 760px; }
-  .slide .step-shot-wrap { display: flex; justify-content: center; background: var(--code-bg); border: 1px solid var(--border); border-radius: 8px; padding: 18px; margin-bottom: 16px; }
-  .slide .step-shot { max-width: 100%; max-height: 720px; cursor: zoom-in; border-radius: 4px; }
+  .slide .step-shot-wrap { display: flex; justify-content: center; align-items: center; background: var(--code-bg); border: 1px solid var(--border); border-radius: 8px; padding: 12px; margin-bottom: 12px; min-height: 200px; }
+  .slide .step-shot { max-width: 100%; max-height: calc(100vh - 360px); object-fit: contain; cursor: zoom-in; border-radius: 4px; }
   .slide .quick { margin-top: 0; display: flex; gap: 6px; flex-wrap: wrap; }
   .slide .quick button { font-size: 13px; padding: 6px 12px 6px 10px; display: inline-flex; align-items: center; gap: 6px; }
   .slide .quick button svg { width: 18px; height: 18px; flex-shrink: 0; }
@@ -443,10 +461,16 @@ const HTML = `<!doctype html>
   .review-sticky textarea { min-height: 50px; }
   .review-sticky .row { margin-top: 8px; }
   .review-sticky .help { color: var(--muted); font-size: 11px; margin-top: 6px; line-height: 1.5; }
-  /* Lightbox */
-  dialog { background: rgba(0,0,0,0.92); border: none; max-width: 100vw; max-height: 100vh; padding: 0; }
-  dialog img { max-width: 100vw; max-height: 100vh; display: block; cursor: zoom-out; }
-  dialog::backdrop { background: rgba(0,0,0,0.85); }
+  /* Lightbox with zoom/pan */
+  dialog#lightbox { background: rgba(0,0,0,0.95); border: none; width: 100vw; height: 100vh; max-width: 100vw; max-height: 100vh; padding: 0; margin: 0; overflow: hidden; }
+  dialog#lightbox::backdrop { background: rgba(0,0,0,0.9); }
+  #lb-stage { width: 100vw; height: 100vh; overflow: hidden; cursor: grab; user-select: none; touch-action: none; }
+  #lb-stage.dragging { cursor: grabbing; }
+  #lb-stage img { display: block; transform-origin: 0 0; user-select: none; -webkit-user-drag: none; pointer-events: none; }
+  #lb-controls { position: fixed; top: 14px; right: 14px; z-index: 50; display: flex; gap: 6px; }
+  #lb-controls button { background: rgba(255,255,255,0.92); color: #111; border: none; border-radius: 6px; width: 36px; height: 36px; font-size: 18px; cursor: pointer; display: flex; align-items: center; justify-content: center; }
+  #lb-controls button:hover { background: #fff; }
+  #lb-hint { position: fixed; bottom: 14px; left: 50%; transform: translateX(-50%); background: rgba(0,0,0,0.7); color: #fff; padding: 6px 12px; border-radius: 4px; font-size: 12px; pointer-events: none; }
   /* Misc */
   .muted { color: var(--muted); font-size: 12px; }
   .grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(360px, 1fr)); gap: 12px; }
@@ -456,19 +480,40 @@ const HTML = `<!doctype html>
 </style>
 </head>
 <body data-theme="light">
-<header>
+<button id="menu-trigger" aria-label="Open menu" title="Menu">
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 6h16M4 12h16M4 18h16"/></svg>
+</button>
+<span id="status-pill" class="badge">idle</span>
+<div id="panel-backdrop"></div>
+<aside id="side-panel" aria-hidden="true">
+  <button id="close-panel" aria-label="Close menu" title="Close"></button>
   <h1><a href="#/">Ask · review</a></h1>
-  <span id="status" class="badge">idle</span>
-  <div class="right">
+  <div class="group">
+    <label for="spec">Spec</label>
     <select id="spec"><option value="">All specs</option></select>
+  </div>
+  <div class="group">
     <button id="run" class="primary">New run</button>
-    <button id="theme-toggle" class="icon-only" title="Toggle light/dark"></button>
+  </div>
+  <div class="group">
+    <button id="theme-toggle"></button>
+  </div>
+  <div class="group">
     <a href="http://localhost:5173/dev/markdown" target="_blank"><button>/dev/markdown ↗</button></a>
     <a href="http://localhost:5173/" target="_blank"><button>app ↗</button></a>
   </div>
-</header>
+</aside>
 <main id="view"></main>
-<dialog id="lightbox"><img alt=""></dialog>
+<dialog id="lightbox">
+  <div id="lb-controls">
+    <button id="lb-zoom-out" title="Zoom out (-)"></button>
+    <button id="lb-zoom-reset" title="Reset (0)">⤢</button>
+    <button id="lb-zoom-in" title="Zoom in (+)">+</button>
+    <button id="lb-close" title="Close (Esc)">×</button>
+  </div>
+  <div id="lb-stage"><img alt=""></div>
+  <div id="lb-hint">scroll = zoom · drag = pan · double-click = reset</div>
+</dialog>
 <script>
 // Inline SVGs (Heroicons outline, 24x24 viewBox, stroke=currentColor).
 // No network dependency, scales cleanly, inherits the button text color.
@@ -499,11 +544,83 @@ const KINDS = [
 const view = document.getElementById('view');
 const specEl = document.getElementById('spec');
 const runEl = document.getElementById('run');
-const statusEl = document.getElementById('status');
+const statusEl = document.getElementById('status-pill');
+
+// ---------- side panel toggle -----------------------------------------------
+const sidePanel = document.getElementById('side-panel');
+const panelBackdrop = document.getElementById('panel-backdrop');
+const menuTrigger = document.getElementById('menu-trigger');
+const closePanelBtn = document.getElementById('close-panel');
+function setPanel(open) {
+  sidePanel.classList.toggle('open', open);
+  panelBackdrop.classList.toggle('open', open);
+  sidePanel.setAttribute('aria-hidden', open ? 'false' : 'true');
+}
+menuTrigger.addEventListener('click', () => setPanel(!sidePanel.classList.contains('open')));
+panelBackdrop.addEventListener('click', () => setPanel(false));
+closePanelBtn.innerHTML = SVG.remove;
+
+// ---------- lightbox with zoom + pan ----------------------------------------
 const lightbox = document.getElementById('lightbox');
-const lightboxImg = lightbox.querySelector('img');
-lightboxImg.addEventListener('click', () => lightbox.close());
+const lbStage = document.getElementById('lb-stage');
+const lightboxImg = lbStage.querySelector('img');
+let lbScale = 1, lbTx = 0, lbTy = 0;
+function lbApply() { lightboxImg.style.transform = 'translate(' + lbTx + 'px,' + lbTy + 'px) scale(' + lbScale + ')'; }
+function lbFit() {
+  // Fit to viewport at scale=1, centered.
+  const vw = window.innerWidth, vh = window.innerHeight;
+  const nw = lightboxImg.naturalWidth || 1, nh = lightboxImg.naturalHeight || 1;
+  const fit = Math.min(vw / nw, vh / nh, 1);
+  lbScale = fit;
+  lbTx = (vw - nw * fit) / 2;
+  lbTy = (vh - nh * fit) / 2;
+  lbApply();
+}
+function lbZoomAt(factor, cx, cy) {
+  const next = Math.max(0.1, Math.min(8, lbScale * factor));
+  // keep the point under (cx, cy) stationary
+  lbTx = cx - (cx - lbTx) * (next / lbScale);
+  lbTy = cy - (cy - lbTy) * (next / lbScale);
+  lbScale = next;
+  lbApply();
+}
+function openLightbox(src) {
+  lightboxImg.src = src;
+  lightbox.showModal();
+  if (lightboxImg.complete) lbFit();
+  else lightboxImg.onload = () => lbFit();
+}
+lbStage.addEventListener('wheel', (e) => {
+  e.preventDefault();
+  const r = lbStage.getBoundingClientRect();
+  lbZoomAt(e.deltaY < 0 ? 1.15 : 1/1.15, e.clientX - r.left, e.clientY - r.top);
+}, { passive: false });
+let dragging = false, dragX = 0, dragY = 0, dragTx = 0, dragTy = 0;
+lbStage.addEventListener('pointerdown', (e) => {
+  dragging = true; lbStage.classList.add('dragging');
+  lbStage.setPointerCapture(e.pointerId);
+  dragX = e.clientX; dragY = e.clientY; dragTx = lbTx; dragTy = lbTy;
+});
+lbStage.addEventListener('pointermove', (e) => {
+  if (!dragging) return;
+  lbTx = dragTx + (e.clientX - dragX);
+  lbTy = dragTy + (e.clientY - dragY);
+  lbApply();
+});
+lbStage.addEventListener('pointerup', (e) => { dragging = false; lbStage.classList.remove('dragging'); try { lbStage.releasePointerCapture(e.pointerId); } catch {} });
+lbStage.addEventListener('dblclick', () => lbFit());
+document.getElementById('lb-zoom-in').addEventListener('click', () => lbZoomAt(1.25, window.innerWidth/2, window.innerHeight/2));
+document.getElementById('lb-zoom-out').addEventListener('click', () => lbZoomAt(1/1.25, window.innerWidth/2, window.innerHeight/2));
+document.getElementById('lb-zoom-reset').addEventListener('click', () => lbFit());
+document.getElementById('lb-close').addEventListener('click', () => lightbox.close());
+document.getElementById('lb-zoom-out').textContent = '−';
 lightbox.addEventListener('click', (e) => { if (e.target === lightbox) lightbox.close(); });
+window.addEventListener('keydown', (e) => {
+  if (!lightbox.open) return;
+  if (e.key === '+' || e.key === '=') { e.preventDefault(); lbZoomAt(1.25, window.innerWidth/2, window.innerHeight/2); }
+  if (e.key === '-') { e.preventDefault(); lbZoomAt(1/1.25, window.innerWidth/2, window.innerHeight/2); }
+  if (e.key === '0') { e.preventDefault(); lbFit(); }
+});
 
 function ago(ms) {
   const s = (Date.now() - ms) / 1000;
@@ -707,7 +824,7 @@ async function renderDetail(id) {
 
   // image lightbox
   view.querySelectorAll('img.step-shot, figure img').forEach(img => {
-    img.addEventListener('click', () => { lightboxImg.src = img.src; lightbox.showModal(); });
+    img.addEventListener('click', () => openLightbox(img.src));
   });
 
   // ----- slideshow navigation -----
@@ -793,6 +910,7 @@ runEl.addEventListener('click', async () => {
     method: 'POST', headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ spec: specEl.value }),
   }).then(r => r.json());
+  setPanel(false);
   if (r.id) location.hash = '#/run/' + r.id;
 });
 
@@ -812,8 +930,10 @@ es.addEventListener('done', () => {
 const themeBtn = document.getElementById('theme-toggle');
 function applyTheme(t) {
   document.body.dataset.theme = t;
-  themeBtn.innerHTML = t === 'dark' ? SVG.sun : SVG.moon;
-  themeBtn.title = t === 'dark' ? 'Switch to light' : 'Switch to dark';
+  const icon = t === 'dark' ? SVG.sun : SVG.moon;
+  const label = t === 'dark' ? 'Light theme' : 'Dark theme';
+  themeBtn.innerHTML = icon + '<span>' + label + '</span>';
+  themeBtn.title = label;
 }
 applyTheme(localStorage.getItem('ask-review-theme') || 'light');
 themeBtn.addEventListener('click', () => {

--- a/web/scripts/review-server.ts
+++ b/web/scripts/review-server.ts
@@ -57,6 +57,11 @@ interface Feedback {
   kind: string        // ok | bug | style | copy | confusing | slow | other
   text: string
   at: number
+  // Optional pin location, as fractions (0..1) of the screenshot's natural
+  // dimensions. Pins survive image rescaling; absent => unpinned (sidebar
+  // comment as before).
+  x?: number | null
+  y?: number | null
 }
 interface Run {
   id: string
@@ -233,7 +238,7 @@ function listFrozenShots(runId: string): { rel: string; size: number }[] {
   return out.sort((a, b) => a.rel.localeCompare(b.rel))
 }
 
-interface FrozenStep { idx: number; title: string; description?: string; name?: string; file: string; durationMs: number }
+interface FrozenStep { idx: number; title: string; description?: string; name?: string; file: string; htmlFile?: string; durationMs: number }
 interface FrozenStory {
   path: string
   testTitle: string
@@ -438,8 +443,45 @@ const HTML = `<!doctype html>
   .slide .step-meta { color: var(--muted); font-size: 12px; margin: 0; }
   .slide .step-title { font-size: 22px; font-weight: 600; margin: 0; line-height: 1.25; }
   .slide .step-desc { color: var(--text); font-size: 15px; line-height: 1.6; margin: 0; }
-  .slide .step-shot-wrap { display: flex; justify-content: center; align-items: center; background: var(--code-bg); border: 1px solid var(--border); border-radius: 8px; padding: 8px; min-height: 200px; }
-  .slide .step-shot { max-width: 100%; max-height: calc(100vh - 240px); object-fit: contain; cursor: zoom-in; border-radius: 4px; }
+  /* ----- Image / HTML view shell + pin overlay ----- */
+  .slide .view-toolbar { display: flex; align-items: center; gap: 8px; margin-bottom: 6px; flex-wrap: wrap; }
+  .slide .view-toolbar .seg { display: inline-flex; border: 1px solid var(--border); border-radius: 6px; overflow: hidden; }
+  .slide .view-toolbar .seg button { border: none; border-right: 1px solid var(--border); border-radius: 0; padding: 4px 10px; font-size: 12px; background: var(--panel); }
+  .slide .view-toolbar .seg button:last-child { border-right: none; }
+  .slide .view-toolbar .seg button.active { background: var(--primary); color: #fff; }
+  .slide .view-toolbar .toolbar-spacer { flex: 1; }
+  .slide .view-toolbar button.tool { font-size: 12px; padding: 4px 10px; display: inline-flex; align-items: center; gap: 4px; }
+  .slide .view-toolbar button.tool svg { width: 14px; height: 14px; }
+  .slide .step-shot-wrap { position: relative; display: flex; justify-content: center; align-items: center; background: var(--code-bg); border: 1px solid var(--border); border-radius: 8px; padding: 8px; min-height: 200px; }
+  .slide .step-shot-wrap.pinning { cursor: crosshair; }
+  .slide .step-shot { max-width: 100%; max-height: calc(100vh - 280px); object-fit: contain; border-radius: 4px; user-select: none; -webkit-user-drag: none; }
+  .slide .step-shot.idle { cursor: zoom-in; }
+  .slide .html-frame { width: 100%; height: calc(100vh - 280px); border: 1px solid var(--border); border-radius: 4px; background: #fff; }
+  /* pin layer sits exactly over the rendered image */
+  .slide .pin-layer { position: absolute; pointer-events: none; }
+  .slide .pin-layer .pin { position: absolute; transform: translate(-50%, -100%); pointer-events: auto; cursor: grab; user-select: none; }
+  .slide .pin-layer .pin.dragging { cursor: grabbing; }
+  .slide .pin-layer .pin .marker { width: 26px; height: 32px; display: flex; align-items: center; justify-content: center; padding-bottom: 6px; font-size: 11px; font-weight: 700; filter: drop-shadow(0 2px 3px rgba(0,0,0,.35)); position: relative; }
+  .slide .pin-layer .pin .marker svg { position: absolute; inset: 0; width: 100%; height: 100%; }
+  .slide .pin-layer .pin .marker .num { position: relative; z-index: 1; color: #fff; }
+  /* pin colors per kind */
+  .pin-kind-ok        { color: #1d6f1d; }
+  .pin-kind-bug       { color: #b91c1c; }
+  .pin-kind-style     { color: #7c3aed; }
+  .pin-kind-copy      { color: #0891b2; }
+  .pin-kind-confusing { color: #ca8a04; }
+  .pin-kind-slow      { color: #c2410c; }
+  .pin-kind-other     { color: #475569; }
+  /* inline comment popover */
+  .cmt-popover { position: absolute; z-index: 30; background: var(--panel); border: 1px solid var(--border); border-radius: 8px; box-shadow: 0 8px 24px rgba(0,0,0,.18); padding: 10px; width: 320px; max-width: calc(100vw - 40px); transform: translate(-50%, 8px); }
+  [data-theme="dark"] .cmt-popover { box-shadow: 0 8px 24px rgba(0,0,0,.5); }
+  .cmt-popover .kind-row { display: flex; gap: 4px; flex-wrap: wrap; margin-bottom: 8px; }
+  .cmt-popover .kind-row button { padding: 4px 8px; font-size: 12px; display: inline-flex; align-items: center; gap: 4px; }
+  .cmt-popover .kind-row button svg { width: 14px; height: 14px; }
+  .cmt-popover .kind-row button.selected { background: var(--primary); color: #fff; border-color: var(--primary); }
+  .cmt-popover textarea { min-height: 60px; font-size: 13px; }
+  .cmt-popover .actions { display: flex; gap: 6px; margin-top: 8px; justify-content: flex-end; }
+  .cmt-popover .actions button { font-size: 12px; padding: 5px 10px; }
   .slide .quick { margin-top: 0; display: flex; gap: 6px; flex-wrap: wrap; }
   .slide .quick button { font-size: 13px; padding: 6px 12px 6px 10px; display: inline-flex; align-items: center; gap: 6px; }
   .slide .quick button svg { width: 18px; height: 18px; flex-shrink: 0; }
@@ -540,6 +582,10 @@ const SVG = {
   moon:      '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>',
   arrowLeft: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M19 12H5M12 19l-7-7 7-7"/></svg>',
   arrowRight:'<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M12 5l7 7-7 7"/></svg>',
+  pin:       '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2C8 2 5 5 5 9c0 5 7 13 7 13s7-8 7-13c0-4-3-7-7-7z"/><circle cx="12" cy="9" r="2.5"/></svg>',
+  clipboard: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="8" y="3" width="8" height="4" rx="1"/><path d="M16 5h2a2 2 0 0 1 2 2v13a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V7a2 2 0 0 1 2-2h2"/></svg>',
+  // Shape used by the pin marker (filled teardrop)
+  pinShape:  '<svg viewBox="0 0 26 32" fill="currentColor"><path d="M13 1C6.4 1 1 6.4 1 13c0 8 12 18 12 18s12-10 12-18c0-6.6-5.4-12-12-12z"/></svg>',
 };
 
 const KINDS = [
@@ -763,11 +809,26 @@ async function renderDetail(id) {
   if (allSteps.length) {
     const { s, st } = allSteps[slideIdx];
     const stepFb = fb.filter(x => x.storyPath === s.path && x.stepIdx === st.idx);
+    const shotURL = st.file ? '/runs/' + r.id + '/story/' + encodeURI(s.path) + '/' + encodeURI(st.file) : '';
+    const htmlURL = st.htmlFile ? '/runs/' + r.id + '/story/' + encodeURI(s.path) + '/' + encodeURI(st.htmlFile) : '';
     slideHtml =
-      '<div class="panel slide" data-story-path="' + escape(s.path) + '" data-step="' + st.idx + '">' +
-        (st.file
-          ? '<div class="step-image"><div class="step-shot-wrap"><img class="step-shot" src="/runs/' + r.id + '/story/' + encodeURI(s.path) + '/' + encodeURI(st.file) + '" alt="' + escape(st.title) + '"></div></div>'
-          : '<div class="step-image"></div>') +
+      '<div class="panel slide" data-story-path="' + escape(s.path) + '" data-step="' + st.idx + '" data-shot-url="' + shotURL + '" data-html-url="' + htmlURL + '">' +
+        '<div class="step-image">' +
+          '<div class="view-toolbar">' +
+            '<div class="seg" id="view-seg">' +
+              '<button data-view="image" class="active">Image</button>' +
+              (htmlURL ? '<button data-view="html">HTML</button>' : '') +
+            '</div>' +
+            '<button class="tool" id="add-pin-btn" title="Click then click on the image to drop a pin">' + SVG.pin + '<span>Add pin</span></button>' +
+            '<div class="toolbar-spacer"></div>' +
+            (htmlURL ? '<button class="tool" id="copy-html-btn">' + SVG.clipboard + '<span>Copy HTML</span></button>' : '') +
+            '<button class="tool" id="copy-context-btn">' + SVG.clipboard + '<span>Copy step context</span></button>' +
+          '</div>' +
+          '<div class="step-shot-wrap" id="shot-wrap">' +
+            (shotURL ? '<img class="step-shot idle" id="step-shot" src="' + shotURL + '" alt="' + escape(st.title) + '">' : '') +
+            '<div class="pin-layer" id="pin-layer"></div>' +
+          '</div>' +
+        '</div>' +
         '<div class="step-side">' +
           '<div class="step-head">' +
             '<h2 class="step-title">' + escape(st.title) + '</h2>' +
@@ -850,10 +911,21 @@ async function renderDetail(id) {
   const heroInfoBtn = document.getElementById('hero-info');
   if (heroInfoBtn) heroInfoBtn.addEventListener('click', () => setPanel(true));
 
-  // image lightbox
-  view.querySelectorAll('img.step-shot, figure img').forEach(img => {
+  // image lightbox (only when not in pin-add mode and not clicking on a pin)
+  view.querySelectorAll('figure img').forEach(img => {
     img.addEventListener('click', () => openLightbox(img.src));
   });
+  const stepShot = document.getElementById('step-shot');
+  if (stepShot) {
+    stepShot.addEventListener('click', (ev) => {
+      if (document.getElementById('shot-wrap')?.classList.contains('pinning')) return;
+      if (ev.target.closest('.pin')) return;
+      openLightbox(stepShot.src);
+    });
+  }
+
+  // ---------- pinned comments + inline popover ----------
+  setupSlideInteractions(r.id, allSteps[slideIdx], fb, () => renderDetail(r.id));
 
   // ----- slideshow navigation -----
   function goTo(i) {
@@ -895,32 +967,262 @@ async function renderDetail(id) {
     await fetch('/api/runs/' + r.id + '/review', { method: 'DELETE' });
     renderDetail(r.id);
   });
-  // per-step quick-tag handlers (slide is the active step container)
-  const slideEl = view.querySelector('.slide');
-  if (slideEl) {
-    const storyPath = slideEl.dataset.storyPath;
-    const stepIdx = parseInt(slideEl.dataset.step, 10);
-    slideEl.querySelectorAll('button[data-kind]').forEach(btn => {
-      btn.addEventListener('click', async () => {
-        const kind = btn.dataset.kind;
-        let text = '';
-        if (kind === 'other' || kind === 'bug' || kind === 'confusing') {
-          text = prompt('Add a note (optional):') ?? '';
-          if (kind === 'other' && !text) return;
+  // sidebar "remove" buttons on existing comments
+  view.querySelectorAll('.slide .fb-row .x').forEach(x => {
+    x.addEventListener('click', async () => {
+      const at = parseInt(x.dataset.at, 10);
+      await fetch('/api/runs/' + r.id + '/feedback?at=' + at, { method: 'DELETE' });
+      renderDetail(r.id);
+    });
+  });
+}
+
+// =============================================================================
+// Slide interactions: quick-tag toolbar, image/HTML toggle, pinned comments,
+// inline popover, copy buttons. All routed through one function so re-renders
+// don't double-bind handlers.
+// =============================================================================
+function setupSlideInteractions(runId, current, fb, refresh) {
+  if (!current) return;
+  const { s, st } = current;
+  const storyPath = s.path, stepIdx = st.idx;
+  const slideEl = document.querySelector('.slide');
+  if (!slideEl) return;
+  const shotWrap = slideEl.querySelector('#shot-wrap');
+  const shotImg = slideEl.querySelector('#step-shot');
+  const pinLayer = slideEl.querySelector('#pin-layer');
+  const stepFb = fb.filter(x => x.storyPath === storyPath && x.stepIdx === stepIdx);
+
+  // ----- view toggle: Image vs HTML -----
+  const viewSeg = slideEl.querySelector('#view-seg');
+  if (viewSeg) {
+    viewSeg.querySelectorAll('button').forEach(btn => {
+      btn.addEventListener('click', () => {
+        viewSeg.querySelectorAll('button').forEach(b => b.classList.toggle('active', b === btn));
+        const mode = btn.dataset.view;
+        const htmlURL = slideEl.dataset.htmlUrl;
+        if (mode === 'html' && htmlURL) {
+          // Replace the contents of shot-wrap with a sandboxed iframe.
+          // Pin layer kept hidden in HTML view (anchored to image pixels, not DOM).
+          shotWrap.innerHTML = '<iframe class="html-frame" sandbox="allow-same-origin" src="' + htmlURL + '"></iframe>';
+        } else {
+          shotWrap.innerHTML = '<img class="step-shot idle" id="step-shot" src="' + slideEl.dataset.shotUrl + '"><div class="pin-layer" id="pin-layer"></div>';
+          // Re-bind interactions for the regenerated DOM
+          setupSlideInteractions(runId, current, fb, refresh);
         }
-        await fetch('/api/runs/' + r.id + '/feedback', {
-          method: 'POST', headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ storyPath, stepIdx, kind, text }),
-        });
-        renderDetail(r.id);
       });
     });
-    slideEl.querySelectorAll('.fb-row .x').forEach(x => {
-      x.addEventListener('click', async () => {
-        const at = parseInt(x.dataset.at, 10);
-        await fetch('/api/runs/' + r.id + '/feedback?at=' + at, { method: 'DELETE' });
-        renderDetail(r.id);
+  }
+
+  // ----- pin layer: render existing pinned comments -----
+  function renderPins() {
+    if (!pinLayer || !shotImg) return;
+    pinLayer.innerHTML = '';
+    // Position the pin layer to overlap the rendered image rect exactly.
+    const rect = shotImg.getBoundingClientRect();
+    const wrapRect = shotWrap.getBoundingClientRect();
+    pinLayer.style.left = (rect.left - wrapRect.left) + 'px';
+    pinLayer.style.top  = (rect.top  - wrapRect.top)  + 'px';
+    pinLayer.style.width  = rect.width + 'px';
+    pinLayer.style.height = rect.height + 'px';
+    let pinNum = 0;
+    stepFb.forEach((f) => {
+      if (typeof f.x !== 'number' || typeof f.y !== 'number') return;
+      pinNum++;
+      const pin = document.createElement('div');
+      pin.className = 'pin pin-kind-' + f.kind;
+      pin.style.left = (f.x * 100) + '%';
+      pin.style.top  = (f.y * 100) + '%';
+      pin.dataset.at = String(f.at);
+      pin.innerHTML = '<div class="marker">' + SVG.pinShape + '<span class="num">' + pinNum + '</span></div>';
+      pin.title = f.kind + (f.text ? ': ' + f.text : '');
+      attachPinDrag(pin, f);
+      pinLayer.appendChild(pin);
+    });
+  }
+  if (shotImg) {
+    if (shotImg.complete) renderPins();
+    else shotImg.addEventListener('load', renderPins);
+    window.addEventListener('resize', renderPins);
+  }
+
+  // ----- pin drag-to-move -----
+  function attachPinDrag(pin, f) {
+    let dragging = false, startX = 0, startY = 0;
+    pin.addEventListener('pointerdown', (e) => {
+      e.stopPropagation();
+      dragging = false;
+      startX = e.clientX; startY = e.clientY;
+      pin.setPointerCapture(e.pointerId);
+    });
+    pin.addEventListener('pointermove', (e) => {
+      if (Math.abs(e.clientX - startX) + Math.abs(e.clientY - startY) > 4) {
+        dragging = true;
+        pin.classList.add('dragging');
+        const rect = shotImg.getBoundingClientRect();
+        const nx = Math.max(0, Math.min(1, (e.clientX - rect.left) / rect.width));
+        const ny = Math.max(0, Math.min(1, (e.clientY - rect.top) / rect.height));
+        pin.style.left = (nx * 100) + '%';
+        pin.style.top  = (ny * 100) + '%';
+        pin.dataset.nx = String(nx);
+        pin.dataset.ny = String(ny);
+      }
+    });
+    pin.addEventListener('pointerup', async (e) => {
+      try { pin.releasePointerCapture(e.pointerId); } catch {}
+      pin.classList.remove('dragging');
+      if (dragging) {
+        const nx = parseFloat(pin.dataset.nx), ny = parseFloat(pin.dataset.ny);
+        await fetch('/api/runs/' + runId + '/feedback?at=' + f.at, {
+          method: 'PATCH', headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ x: nx, y: ny }),
+        });
+        refresh();
+      } else {
+        // Click (no drag) → open editor for this pin
+        openPopover({ x: f.x, y: f.y, existing: f });
+      }
+    });
+  }
+
+  // ----- "Add pin" mode: next click on the image drops a new pin -----
+  const addPinBtn = slideEl.querySelector('#add-pin-btn');
+  if (addPinBtn && shotWrap && shotImg) {
+    addPinBtn.addEventListener('click', () => {
+      shotWrap.classList.add('pinning');
+      addPinBtn.classList.add('active');
+    });
+    shotImg.addEventListener('click', (e) => {
+      if (!shotWrap.classList.contains('pinning')) return;
+      e.stopPropagation();
+      const rect = shotImg.getBoundingClientRect();
+      const nx = (e.clientX - rect.left) / rect.width;
+      const ny = (e.clientY - rect.top) / rect.height;
+      shotWrap.classList.remove('pinning');
+      addPinBtn.classList.remove('active');
+      openPopover({ x: nx, y: ny, existing: null });
+    });
+  }
+
+  // ----- quick-tag toolbar (unpinned comments) -----
+  slideEl.querySelectorAll('.slide-nav .quick button[data-kind]').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const kind = btn.dataset.kind;
+      // OK and Slow are zero-text shortcuts — save immediately, no popover.
+      if (kind === 'ok' || kind === 'slow') {
+        fetch('/api/runs/' + runId + '/feedback', {
+          method: 'POST', headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ storyPath, stepIdx, kind, text: '', x: null, y: null }),
+        }).then(refresh);
+        return;
+      }
+      openPopover({ x: null, y: null, existing: null, presetKind: kind });
+    });
+  });
+
+  // ----- inline popover (replaces window.prompt) -----
+  function closePopover() {
+    document.querySelectorAll('.cmt-popover').forEach(p => p.remove());
+  }
+  function openPopover({ x, y, existing, presetKind }) {
+    closePopover();
+    const pop = document.createElement('div');
+    pop.className = 'cmt-popover';
+    let chosenKind = existing?.kind || presetKind || 'comment';
+    const kindButtons = KINDS.concat([{ id: 'other', label: 'Comment', icon: SVG.other }])
+      .map(k => '<button data-k="' + k.id + '"' + (k.id === chosenKind ? ' class="selected"' : '') + '>' + k.icon + '<span>' + k.label + '</span></button>')
+      .join('');
+    pop.innerHTML =
+      '<div class="kind-row">' + kindButtons + '</div>' +
+      '<textarea placeholder="Note (optional)">' + (existing?.text ? escape(existing.text) : '') + '</textarea>' +
+      '<div class="actions">' +
+        (existing ? '<button class="danger" data-act="delete">Delete</button>' : '') +
+        '<button data-act="cancel">Cancel</button>' +
+        '<button class="primary" data-act="save">Save</button>' +
+      '</div>';
+    // Position: anchored to pin coords if given, else top-center of image
+    const wrapRect = shotWrap.getBoundingClientRect();
+    if (typeof x === 'number' && typeof y === 'number' && shotImg) {
+      const rect = shotImg.getBoundingClientRect();
+      pop.style.left = (rect.left - wrapRect.left + x * rect.width) + 'px';
+      pop.style.top  = (rect.top  - wrapRect.top  + y * rect.height + 4) + 'px';
+    } else {
+      pop.style.left = '50%';
+      pop.style.top  = '12px';
+    }
+    shotWrap.appendChild(pop);
+    pop.querySelector('textarea').focus();
+    pop.querySelectorAll('.kind-row button').forEach(b => {
+      b.addEventListener('click', () => {
+        chosenKind = b.dataset.k;
+        pop.querySelectorAll('.kind-row button').forEach(x => x.classList.toggle('selected', x === b));
       });
+    });
+    pop.querySelector('[data-act="cancel"]').addEventListener('click', closePopover);
+    if (existing) {
+      pop.querySelector('[data-act="delete"]').addEventListener('click', async () => {
+        await fetch('/api/runs/' + runId + '/feedback?at=' + existing.at, { method: 'DELETE' });
+        closePopover(); refresh();
+      });
+    }
+    pop.querySelector('[data-act="save"]').addEventListener('click', async () => {
+      const text = pop.querySelector('textarea').value.trim();
+      if (existing) {
+        await fetch('/api/runs/' + runId + '/feedback?at=' + existing.at, {
+          method: 'PATCH', headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ kind: chosenKind, text }),
+        });
+      } else {
+        await fetch('/api/runs/' + runId + '/feedback', {
+          method: 'POST', headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ storyPath, stepIdx, kind: chosenKind, text, x, y }),
+        });
+      }
+      closePopover(); refresh();
+    });
+    // Esc to dismiss
+    pop.querySelector('textarea').addEventListener('keydown', (ev) => {
+      if (ev.key === 'Escape') { ev.preventDefault(); closePopover(); }
+      if (ev.key === 'Enter' && (ev.metaKey || ev.ctrlKey)) {
+        ev.preventDefault();
+        pop.querySelector('[data-act="save"]').click();
+      }
+    });
+  }
+
+  // ----- copy HTML / copy step context -----
+  const copyHtmlBtn = slideEl.querySelector('#copy-html-btn');
+  if (copyHtmlBtn) {
+    copyHtmlBtn.addEventListener('click', async () => {
+      const url = slideEl.dataset.htmlUrl;
+      if (!url) return;
+      const html = await fetch(url).then(r => r.text());
+      await navigator.clipboard.writeText(html);
+      copyHtmlBtn.querySelector('span').textContent = 'Copied!';
+      setTimeout(() => { copyHtmlBtn.querySelector('span').textContent = 'Copy HTML'; }, 1500);
+    });
+  }
+  const copyCtxBtn = slideEl.querySelector('#copy-context-btn');
+  if (copyCtxBtn) {
+    copyCtxBtn.addEventListener('click', async () => {
+      const url = slideEl.dataset.htmlUrl;
+      const html = url ? await fetch(url).then(r => r.text()) : '';
+      const lines = [];
+      lines.push('## ' + st.title);
+      if (st.description) lines.push('', st.description);
+      if (stepFb.length) {
+        lines.push('', '### Comments');
+        stepFb.forEach((f, i) => {
+          const loc = (typeof f.x === 'number') ? ' @ pin ' + (i+1) : '';
+          lines.push('- (' + f.kind + loc + ') ' + (f.text || '(no note)'));
+        });
+      }
+      if (html) {
+        lines.push('', '### Captured HTML', '\\u0060\\u0060\\u0060html', html, '\\u0060\\u0060\\u0060');
+      }
+      await navigator.clipboard.writeText(lines.join('\\n'));
+      copyCtxBtn.querySelector('span').textContent = 'Copied!';
+      setTimeout(() => { copyCtxBtn.querySelector('span').textContent = 'Copy step context'; }, 1500);
     });
   }
 }
@@ -1061,9 +1363,29 @@ const server = http.createServer(async (req, res) => {
     req.on('data', d => body += d)
     req.on('end', () => {
       try {
-        const { storyPath, stepIdx, kind, text } = JSON.parse(body) as Omit<Feedback, 'at'>
+        const { storyPath, stepIdx, kind, text, x, y } = JSON.parse(body) as Omit<Feedback, 'at'>
         const fb = loadFeedback(feedback[1])
-        fb.push({ storyPath, stepIdx, kind, text: text || '', at: Date.now() })
+        fb.push({
+          storyPath, stepIdx, kind, text: text || '', at: Date.now(),
+          x: typeof x === 'number' ? x : null,
+          y: typeof y === 'number' ? y : null,
+        })
+        saveFeedback(feedback[1], fb)
+        res.writeHead(200, { 'Content-Type': 'application/json' })
+        res.end(JSON.stringify({ ok: true }))
+      } catch (e) { res.writeHead(400); res.end(JSON.stringify({ error: String(e) })) }
+    })
+    return
+  }
+  // PATCH: edit text or move pin on an existing comment (matched by `at`)
+  if (feedback && req.method === 'PATCH') {
+    let body = ''
+    req.on('data', d => body += d)
+    req.on('end', () => {
+      try {
+        const at = parseInt(url.searchParams.get('at') ?? '', 10)
+        const patch = JSON.parse(body) as Partial<Pick<Feedback, 'text' | 'kind' | 'x' | 'y'>>
+        const fb = loadFeedback(feedback[1]).map(f => f.at === at ? { ...f, ...patch } : f)
         saveFeedback(feedback[1], fb)
         res.writeHead(200, { 'Content-Type': 'application/json' })
         res.end(JSON.stringify({ ok: true }))
@@ -1103,14 +1425,17 @@ const server = http.createServer(async (req, res) => {
     res.writeHead(200, { 'Content-Type': 'image/png', 'Cache-Control': 'public, max-age=300' })
     fs.createReadStream(full).pipe(res); return
   }
-  // Frozen story step image
+  // Frozen story step asset (image OR captured HTML)
   const storyShot = p.match(/^\/runs\/([^/]+)\/story\/([^/]+)\/(.+)$/)
   if (storyShot && req.method === 'GET') {
     const [, id, storyPath, rel] = storyShot
     const root = path.join(RUNS_DIR, id, 'story', decodeURIComponent(storyPath))
     const full = path.join(root, decodeURIComponent(rel))
     if (!full.startsWith(root) || !fs.existsSync(full)) { res.writeHead(404); res.end('not found'); return }
-    res.writeHead(200, { 'Content-Type': 'image/png', 'Cache-Control': 'public, max-age=300' })
+    const ct = full.endsWith('.html') ? 'text/html; charset=utf-8'
+             : full.endsWith('.json') ? 'application/json'
+             : 'image/png'
+    res.writeHead(200, { 'Content-Type': ct, 'Cache-Control': 'public, max-age=300' })
     fs.createReadStream(full).pipe(res); return
   }
 

--- a/web/scripts/review-server.ts
+++ b/web/scripts/review-server.ts
@@ -1,0 +1,301 @@
+/**
+ * Tiny review dashboard for the e2e screenshots + test runs.
+ *
+ * Start with: cd web && npm run review
+ *
+ * Serves:
+ *   GET  /                       → HTML dashboard (auto-refreshes when shots change)
+ *   GET  /api/screenshots        → JSON listing of e2e/screenshots/**
+ *   GET  /api/specs              → JSON listing of e2e/*.spec.ts
+ *   POST /api/run                → body: { spec: string | "" }   →  runs playwright test
+ *   GET  /api/output             → SSE stream of the most recent run's stdout
+ *   GET  /shots/<relpath>        → serves a PNG out of e2e/screenshots/
+ *
+ * Fully dependency-light — uses Node's built-in http + fs and `npx playwright`.
+ */
+import http from 'http'
+import fs from 'fs'
+import path from 'path'
+import { spawn } from 'child_process'
+import { fileURLToPath } from 'url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const WEB = path.resolve(__dirname, '..')
+const SHOTS = path.join(WEB, 'e2e', 'screenshots')
+const E2E = path.join(WEB, 'e2e')
+
+const PORT = parseInt(process.env.REVIEW_PORT ?? '4244', 10)
+
+// --- in-memory state for the latest run -----------------------------------
+let runOutput = ''
+let runRunning = false
+const sseClients: http.ServerResponse[] = []
+
+function broadcast(line: string) {
+  runOutput += line
+  const payload = `data: ${JSON.stringify({ line })}\n\n`
+  for (const c of sseClients) { try { c.write(payload) } catch { /* drop */ } }
+}
+
+function runPlaywright(specRel: string | '') {
+  if (runRunning) return false
+  runRunning = true
+  runOutput = ''
+  broadcast(`$ npx playwright test ${specRel || '(all)'}\n`)
+  const args = ['playwright', 'test']
+  if (specRel) args.push(specRel)
+  const child = spawn('npx', args, { cwd: WEB, env: { ...process.env, FORCE_COLOR: '0' } })
+  child.stdout.on('data', (d: Buffer) => broadcast(d.toString()))
+  child.stderr.on('data', (d: Buffer) => broadcast(d.toString()))
+  child.on('close', (code) => {
+    broadcast(`\n[exit ${code}]\n`)
+    runRunning = false
+  })
+  return true
+}
+
+// --- file scanning --------------------------------------------------------
+function listScreenshots(): { rel: string; size: number; mtime: number }[] {
+  if (!fs.existsSync(SHOTS)) return []
+  const out: { rel: string; size: number; mtime: number }[] = []
+  function walk(dir: string) {
+    for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+      const p = path.join(dir, e.name)
+      if (e.isDirectory()) walk(p)
+      else if (/\.(png|jpe?g)$/i.test(e.name)) {
+        const st = fs.statSync(p)
+        out.push({ rel: path.relative(SHOTS, p), size: st.size, mtime: st.mtimeMs })
+      }
+    }
+  }
+  walk(SHOTS)
+  return out.sort((a, b) => b.mtime - a.mtime)
+}
+
+function listSpecs(): string[] {
+  if (!fs.existsSync(E2E)) return []
+  return fs.readdirSync(E2E)
+    .filter(n => n.endsWith('.spec.ts'))
+    .map(n => path.join('e2e', n))
+}
+
+// --- HTML page ------------------------------------------------------------
+const HTML = `<!doctype html>
+<html lang="en"><head>
+<meta charset="utf-8">
+<title>Ask · review</title>
+<style>
+  :root { color-scheme: dark; }
+  * { box-sizing: border-box; }
+  body { margin: 0; font: 14px/1.4 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; background: #0b0b0c; color: #eee; }
+  header { position: sticky; top: 0; z-index: 10; padding: 12px 16px; background: #111; border-bottom: 1px solid #2a2a2a; display: flex; gap: 12px; align-items: center; flex-wrap: wrap; }
+  header h1 { font-size: 14px; margin: 0; font-weight: 600; }
+  header .right { margin-left: auto; display: flex; gap: 8px; align-items: center; }
+  select, button { background: #1a1a1c; color: #eee; border: 1px solid #333; border-radius: 6px; padding: 6px 10px; font: inherit; cursor: pointer; }
+  select:hover, button:hover { background: #222226; }
+  button.primary { background: #0066cc; border-color: #0066cc; }
+  button.primary:hover { background: #0077ee; }
+  button:disabled { opacity: 0.5; cursor: not-allowed; }
+  main { padding: 16px; }
+  .group { margin-bottom: 24px; }
+  .group h2 { font-size: 12px; color: #888; text-transform: uppercase; letter-spacing: 0.06em; margin: 0 0 8px; font-weight: 600; }
+  .grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(360px, 1fr)); gap: 12px; }
+  figure { margin: 0; background: #131316; border: 1px solid #262629; border-radius: 8px; overflow: hidden; }
+  figure img { display: block; width: 100%; cursor: zoom-in; background: #000; }
+  figcaption { padding: 6px 10px; font-size: 11px; color: #999; display: flex; justify-content: space-between; }
+  pre.output { background: #0a0a0c; border: 1px solid #2a2a2a; border-radius: 6px; padding: 10px; max-height: 300px; overflow: auto; font: 11px/1.4 ui-monospace,monospace; white-space: pre-wrap; }
+  .empty { color: #666; padding: 20px; text-align: center; }
+  .badge { padding: 2px 6px; background: #2a2a2c; border-radius: 4px; font-size: 11px; }
+  .badge.running { background: #0a4d0a; }
+  a { color: #4aa3ff; }
+  /* Lightbox */
+  dialog { background: rgba(0,0,0,0.95); border: none; max-width: 100vw; max-height: 100vh; padding: 0; }
+  dialog img { max-width: 100vw; max-height: 100vh; display: block; cursor: zoom-out; }
+  dialog::backdrop { background: rgba(0,0,0,0.9); }
+</style>
+</head>
+<body>
+<header>
+  <h1>Ask · review</h1>
+  <span id="status" class="badge">idle</span>
+  <div class="right">
+    <select id="spec">
+      <option value="">All specs</option>
+    </select>
+    <button id="run" class="primary">Run</button>
+    <a href="http://localhost:5173/dev/markdown" target="_blank"><button>/dev/markdown ↗</button></a>
+    <a href="http://localhost:5173/" target="_blank"><button>app ↗</button></a>
+  </div>
+</header>
+<main>
+  <pre id="output" class="output" hidden></pre>
+  <div id="shots"></div>
+</main>
+<dialog id="lightbox"><img alt=""></dialog>
+<script>
+const specEl = document.getElementById('spec');
+const runEl = document.getElementById('run');
+const statusEl = document.getElementById('status');
+const outputEl = document.getElementById('output');
+const shotsEl = document.getElementById('shots');
+const lightbox = document.getElementById('lightbox');
+const lightboxImg = lightbox.querySelector('img');
+
+lightboxImg.addEventListener('click', () => lightbox.close());
+lightbox.addEventListener('click', (e) => { if (e.target === lightbox) lightbox.close(); });
+
+async function loadSpecs() {
+  const r = await fetch('/api/specs').then(r => r.json());
+  for (const s of r) {
+    const o = document.createElement('option');
+    o.value = s; o.textContent = s.replace(/^e2e\\//, '');
+    specEl.appendChild(o);
+  }
+}
+
+function fmt(bytes) {
+  if (bytes < 1024) return bytes + ' B';
+  if (bytes < 1024*1024) return (bytes / 1024).toFixed(1) + ' KB';
+  return (bytes / 1024 / 1024).toFixed(1) + ' MB';
+}
+
+function ago(ms) {
+  const s = (Date.now() - ms) / 1000;
+  if (s < 60) return Math.round(s) + 's ago';
+  if (s < 3600) return Math.round(s/60) + 'm ago';
+  return Math.round(s/3600) + 'h ago';
+}
+
+async function loadShots() {
+  const r = await fetch('/api/screenshots').then(r => r.json());
+  shotsEl.innerHTML = '';
+  if (!r.length) { shotsEl.innerHTML = '<p class="empty">No screenshots yet — pick a spec and hit Run.</p>'; return; }
+  // group by top directory
+  const groups = new Map();
+  for (const s of r) {
+    const parts = s.rel.split('/');
+    const g = parts.length > 1 ? parts[0] : '(root)';
+    if (!groups.has(g)) groups.set(g, []);
+    groups.get(g).push(s);
+  }
+  for (const [g, items] of groups) {
+    const groupDiv = document.createElement('div');
+    groupDiv.className = 'group';
+    const h = document.createElement('h2'); h.textContent = g + ' — ' + items.length; groupDiv.appendChild(h);
+    const grid = document.createElement('div'); grid.className = 'grid';
+    for (const s of items) {
+      const fig = document.createElement('figure');
+      const img = document.createElement('img');
+      img.src = '/shots/' + encodeURI(s.rel) + '?t=' + s.mtime;
+      img.loading = 'lazy';
+      img.alt = s.rel;
+      img.addEventListener('click', () => { lightboxImg.src = img.src; lightbox.showModal(); });
+      const cap = document.createElement('figcaption');
+      cap.innerHTML = '<span>' + s.rel.split('/').pop() + '</span><span>' + fmt(s.size) + ' · ' + ago(s.mtime) + '</span>';
+      fig.appendChild(img); fig.appendChild(cap);
+      grid.appendChild(fig);
+    }
+    groupDiv.appendChild(grid);
+    shotsEl.appendChild(groupDiv);
+  }
+}
+
+runEl.addEventListener('click', async () => {
+  outputEl.hidden = false;
+  outputEl.textContent = '';
+  statusEl.textContent = 'running…'; statusEl.className = 'badge running';
+  runEl.disabled = true;
+  await fetch('/api/run', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ spec: specEl.value }) });
+});
+
+const es = new EventSource('/api/output');
+es.addEventListener('line', (e) => {
+  const { line } = JSON.parse(e.data);
+  outputEl.hidden = false;
+  outputEl.textContent += line;
+  outputEl.scrollTop = outputEl.scrollHeight;
+});
+es.addEventListener('done', () => {
+  statusEl.textContent = 'idle'; statusEl.className = 'badge';
+  runEl.disabled = false;
+  loadShots();
+});
+
+loadSpecs();
+loadShots();
+setInterval(loadShots, 5000);
+</script>
+</body></html>`
+
+// --- HTTP server ----------------------------------------------------------
+const server = http.createServer(async (req, res) => {
+  const url = new URL(req.url ?? '/', `http://localhost:${PORT}`)
+  const p = url.pathname
+
+  if (p === '/' && req.method === 'GET') {
+    res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' })
+    res.end(HTML)
+    return
+  }
+
+  if (p === '/api/specs' && req.method === 'GET') {
+    res.writeHead(200, { 'Content-Type': 'application/json' })
+    res.end(JSON.stringify(listSpecs()))
+    return
+  }
+
+  if (p === '/api/screenshots' && req.method === 'GET') {
+    res.writeHead(200, { 'Content-Type': 'application/json' })
+    res.end(JSON.stringify(listScreenshots()))
+    return
+  }
+
+  if (p === '/api/run' && req.method === 'POST') {
+    let body = ''
+    req.on('data', d => body += d)
+    req.on('end', () => {
+      let spec = ''
+      try { spec = (JSON.parse(body) as { spec?: string }).spec ?? '' } catch { /* */ }
+      const ok = runPlaywright(spec)
+      res.writeHead(ok ? 202 : 409, { 'Content-Type': 'application/json' })
+      res.end(JSON.stringify({ ok }))
+    })
+    return
+  }
+
+  if (p === '/api/output' && req.method === 'GET') {
+    res.writeHead(200, {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      'Connection': 'keep-alive',
+    })
+    res.write(': connected\n\n')
+    if (runOutput) res.write(`event: line\ndata: ${JSON.stringify({ line: runOutput })}\n\n`)
+    sseClients.push(res)
+    const interval = setInterval(() => {
+      if (!runRunning) {
+        res.write('event: done\ndata: {}\n\n')
+      }
+    }, 1000)
+    req.on('close', () => {
+      clearInterval(interval)
+      const i = sseClients.indexOf(res); if (i >= 0) sseClients.splice(i, 1)
+    })
+    return
+  }
+
+  if (p.startsWith('/shots/') && req.method === 'GET') {
+    const rel = decodeURIComponent(p.replace('/shots/', ''))
+    const full = path.join(SHOTS, rel)
+    if (!full.startsWith(SHOTS) || !fs.existsSync(full)) { res.writeHead(404); res.end('not found'); return }
+    res.writeHead(200, { 'Content-Type': 'image/png', 'Cache-Control': 'public, max-age=60' })
+    fs.createReadStream(full).pipe(res)
+    return
+  }
+
+  res.writeHead(404); res.end('not found')
+})
+
+server.listen(PORT, () => {
+  console.log(`Ask · review dashboard → http://localhost:${PORT}`)
+})

--- a/web/scripts/review-server.ts
+++ b/web/scripts/review-server.ts
@@ -233,7 +233,14 @@ function listFrozenShots(runId: string): { rel: string; size: number }[] {
   return out.sort((a, b) => a.rel.localeCompare(b.rel))
 }
 
-interface FrozenStory { path: string; testTitle: string; steps: { idx: number; name: string; file: string; durationMs: number }[] }
+interface FrozenStep { idx: number; title: string; description?: string; name?: string; file: string; durationMs: number }
+interface FrozenStory {
+  path: string
+  testTitle: string
+  title: string
+  description: string
+  steps: FrozenStep[]
+}
 function listFrozenStories(runId: string): FrozenStory[] {
   const root = path.join(RUNS_DIR, runId, 'story')
   if (!fs.existsSync(root)) return []
@@ -243,8 +250,15 @@ function listFrozenStories(runId: string): FrozenStory[] {
     const j = path.join(root, e.name, 'story.json')
     if (!fs.existsSync(j)) continue
     try {
-      const data = JSON.parse(fs.readFileSync(j, 'utf-8')) as { testTitle?: string; steps: FrozenStory['steps'] }
-      out.push({ path: e.name, testTitle: data.testTitle ?? e.name, steps: data.steps ?? [] })
+      const data = JSON.parse(fs.readFileSync(j, 'utf-8')) as Partial<FrozenStory> & { steps?: FrozenStep[] }
+      const steps = (data.steps ?? []).map(s => ({ ...s, title: s.title ?? s.name ?? '(unnamed step)' }))
+      out.push({
+        path: e.name,
+        testTitle: data.testTitle ?? e.name,
+        title: data.title ?? data.testTitle ?? e.name,
+        description: data.description ?? '',
+        steps,
+      })
     } catch { /* skip */ }
   }
   return out
@@ -264,90 +278,173 @@ const HTML = `<!doctype html>
 <meta charset="utf-8">
 <title>Ask · review</title>
 <style>
-  :root { color-scheme: dark; }
+  /* ---------- theme tokens (light default, dark via [data-theme=dark]) ---------- */
+  :root {
+    color-scheme: light;
+    --bg:        #f6f7fa;
+    --panel:     #ffffff;
+    --text:      #1a1a1c;
+    --muted:     #6b7280;
+    --border:    #e5e7eb;
+    --header:    #ffffff;
+    --header-bd: #e5e7eb;
+    --row-hover: #f3f4f6;
+    --code-bg:   #f9fafb;
+    --link:      #0066cc;
+    --pill-bg:   #eef0f3;
+    --primary:   #0066cc;
+    --primary-h: #0077ee;
+    --success:   #1d6f1d;
+    --danger:    #b91c1c;
+    --rail:      #e5e7eb;
+    --dot:       #cbd5e1;
+    --dot-fb:    #0066cc;
+    --shadow:    0 1px 2px rgba(0,0,0,0.04), 0 1px 3px rgba(0,0,0,0.06);
+    /* badge palettes */
+    --b-running-bg:  #e3f7e3; --b-running-fg:  #1d6f1d;
+    --b-awaiting-bg: #fef3c7; --b-awaiting-fg: #92400e;
+    --b-reviewed-bg: #dbeafe; --b-reviewed-fg: #1e40af;
+    --b-passed-bg:   #e3f7e3; --b-passed-fg:   #1d6f1d;
+    --b-failed-bg:   #fee2e2; --b-failed-fg:   #b91c1c;
+    --b-stale-bg:    #fff7ed; --b-stale-fg:    #c2410c;
+    --d-approved:           #1d6f1d;
+    --d-changes-requested:  #92400e;
+    --d-rejected:           #b91c1c;
+  }
+  [data-theme="dark"] {
+    color-scheme: dark;
+    --bg:        #0b0b0c;
+    --panel:     #131316;
+    --text:      #eee;
+    --muted:     #9ca3af;
+    --border:    #262629;
+    --header:    #111;
+    --header-bd: #2a2a2a;
+    --row-hover: #14141a;
+    --code-bg:   #0a0a0c;
+    --link:      #4aa3ff;
+    --pill-bg:   #1a1a1c;
+    --primary:   #0066cc;
+    --primary-h: #0077ee;
+    --success:   #1d6f1d;
+    --danger:    #6b1a1a;
+    --rail:      #262629;
+    --dot:       #444;
+    --dot-fb:    #4aa3ff;
+    --shadow:    none;
+    --b-running-bg:  #0a4d0a; --b-running-fg:  #afe9af;
+    --b-awaiting-bg: #4d3d0a; --b-awaiting-fg: #f5d77a;
+    --b-reviewed-bg: #0a3a4d; --b-reviewed-fg: #a4d8ee;
+    --b-passed-bg:   #0a4d0a; --b-passed-fg:   #afe9af;
+    --b-failed-bg:   #4d0a0a; --b-failed-fg:   #ee9c9c;
+    --b-stale-bg:    #6b1a1a; --b-stale-fg:    #ffc9c9;
+    --d-approved:          #afe9af;
+    --d-changes-requested: #f5d77a;
+    --d-rejected:          #ee9c9c;
+  }
   * { box-sizing: border-box; }
-  body { margin: 0; font: 14px/1.4 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; background: #0b0b0c; color: #eee; }
-  header { position: sticky; top: 0; z-index: 10; padding: 12px 16px; background: #111; border-bottom: 1px solid #2a2a2a; display: flex; gap: 12px; align-items: center; flex-wrap: wrap; }
+  body { margin: 0; font: 14px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; background: var(--bg); color: var(--text); }
+  header { position: sticky; top: 0; z-index: 20; padding: 12px 16px; background: var(--header); border-bottom: 1px solid var(--header-bd); display: flex; gap: 12px; align-items: center; flex-wrap: wrap; }
   header h1 { font-size: 14px; margin: 0; font-weight: 600; }
   header h1 a { color: inherit; text-decoration: none; }
   header .right { margin-left: auto; display: flex; gap: 8px; align-items: center; }
-  select, button, input, textarea { background: #1a1a1c; color: #eee; border: 1px solid #333; border-radius: 6px; padding: 6px 10px; font: inherit; }
+  select, button, input, textarea { background: var(--panel); color: var(--text); border: 1px solid var(--border); border-radius: 6px; padding: 6px 10px; font: inherit; }
   button { cursor: pointer; }
-  select:hover, button:hover:not(:disabled) { background: #222226; }
-  button.primary { background: #0066cc; border-color: #0066cc; color: #fff; }
-  button.primary:hover { background: #0077ee; }
-  button.danger { background: #6b1a1a; border-color: #6b1a1a; color: #fff; }
-  button.success { background: #1d6f1d; border-color: #1d6f1d; color: #fff; }
+  select:hover, button:hover:not(:disabled) { background: var(--row-hover); }
+  button.primary { background: var(--primary); border-color: var(--primary); color: #fff; }
+  button.primary:hover { background: var(--primary-h); }
+  button.danger { background: var(--danger); border-color: var(--danger); color: #fff; }
+  button.success { background: var(--success); border-color: var(--success); color: #fff; }
+  button.icon-only { padding: 5px 7px; line-height: 1; }
+  button.icon-only svg { width: 18px; height: 18px; display: block; }
   button:disabled { opacity: 0.5; cursor: not-allowed; }
   main { padding: 16px; max-width: 1400px; margin: 0 auto; }
-  table { width: 100%; border-collapse: collapse; }
-  table th, table td { padding: 10px 12px; text-align: left; border-bottom: 1px solid #1f1f22; vertical-align: top; }
-  table th { font-size: 11px; color: #888; text-transform: uppercase; letter-spacing: 0.06em; font-weight: 600; }
-  table tr:hover td { background: #14141a; }
+  table { width: 100%; border-collapse: collapse; background: var(--panel); border-radius: 8px; overflow: hidden; box-shadow: var(--shadow); }
+  table th, table td { padding: 10px 14px; text-align: left; border-bottom: 1px solid var(--border); vertical-align: top; }
+  table tr:last-child td { border-bottom: 0; }
+  table th { font-size: 11px; color: var(--muted); text-transform: uppercase; letter-spacing: 0.06em; font-weight: 600; }
+  table tr:hover td { background: var(--row-hover); }
   table tr.clickable { cursor: pointer; }
-  .empty { color: #666; padding: 28px; text-align: center; }
+  .empty { color: var(--muted); padding: 28px; text-align: center; background: var(--panel); border-radius: 8px; }
   .badge { padding: 2px 8px; border-radius: 4px; font-size: 11px; font-weight: 600; display: inline-block; }
-  .badge.running { background: #0a4d0a; color: #afe9af; }
-  .badge.awaiting { background: #4d3d0a; color: #f5d77a; }
-  .badge.reviewed { background: #0a3a4d; color: #a4d8ee; }
-  .badge.passed { background: #0a4d0a; color: #afe9af; }
-  .badge.failed { background: #4d0a0a; color: #ee9c9c; }
-  .badge.stale { background: #6b1a1a; color: #ffc9c9; }
-  .decision-approved { color: #afe9af; }
-  .decision-changes-requested { color: #f5d77a; }
-  .decision-rejected { color: #ee9c9c; }
-  a { color: #4aa3ff; text-decoration: none; }
+  .badge.running  { background: var(--b-running-bg);  color: var(--b-running-fg); }
+  .badge.awaiting { background: var(--b-awaiting-bg); color: var(--b-awaiting-fg); }
+  .badge.reviewed { background: var(--b-reviewed-bg); color: var(--b-reviewed-fg); }
+  .badge.passed   { background: var(--b-passed-bg);   color: var(--b-passed-fg); }
+  .badge.failed   { background: var(--b-failed-bg);   color: var(--b-failed-fg); }
+  .badge.stale    { background: var(--b-stale-bg);    color: var(--b-stale-fg); }
+  .decision-approved { color: var(--d-approved); font-weight: 600; }
+  .decision-changes-requested { color: var(--d-changes-requested); font-weight: 600; }
+  .decision-rejected { color: var(--d-rejected); font-weight: 600; }
+  a { color: var(--link); text-decoration: none; }
   a:hover { text-decoration: underline; }
   textarea { width: 100%; min-height: 60px; resize: vertical; font-family: inherit; }
-  pre.output { background: #0a0a0c; border: 1px solid #2a2a2a; border-radius: 6px; padding: 10px; max-height: 280px; overflow: auto; font: 11px/1.4 ui-monospace,monospace; white-space: pre-wrap; }
-  .panel { background: #131316; border: 1px solid #262629; border-radius: 8px; padding: 14px; margin: 16px 0; }
-  .panel h3 { margin: 0 0 8px; font-size: 13px; color: #aaa; }
+  pre.output { background: var(--code-bg); border: 1px solid var(--border); border-radius: 6px; padding: 10px; max-height: 280px; overflow: auto; font: 11px/1.5 ui-monospace,monospace; white-space: pre-wrap; }
+  .panel { background: var(--panel); border: 1px solid var(--border); border-radius: 8px; padding: 16px; margin: 16px 0; box-shadow: var(--shadow); }
+  .panel h3 { margin: 0 0 8px; font-size: 13px; color: var(--muted); }
   .panel .row { display: flex; gap: 10px; align-items: center; flex-wrap: wrap; }
-  .panel .help { color: #777; font-size: 12px; margin-top: 8px; line-height: 1.5; }
+  .panel .help { color: var(--muted); font-size: 12px; margin-top: 10px; line-height: 1.6; }
+  /* Run summary header */
+  .run-hero h1 { margin: 0 0 4px; font-size: 22px; line-height: 1.25; }
+  .run-hero p.lead { margin: 0 0 8px; color: var(--muted); font-size: 14px; line-height: 1.55; }
+  .run-hero .meta { color: var(--muted); font-size: 12px; }
+  /* Sticky mini-map flowchart */
+  .mini-map { position: sticky; top: 53px; z-index: 15; background: var(--bg); padding: 10px 0 12px; border-bottom: 1px solid var(--border); margin: 8px 0 16px; }
+  .mini-map .label { font-size: 11px; color: var(--muted); text-transform: uppercase; letter-spacing: 0.06em; margin-bottom: 8px; }
+  .mini-map .nodes { display: flex; gap: 0; align-items: stretch; overflow-x: auto; padding-bottom: 2px; }
+  .mini-map .node { flex: 1 1 0; min-width: 80px; display: flex; flex-direction: column; align-items: center; cursor: pointer; padding: 4px; border-radius: 6px; }
+  .mini-map .node:hover { background: var(--row-hover); }
+  .mini-map .node .dot { width: 22px; height: 22px; border-radius: 50%; background: var(--dot); color: #fff; display: flex; align-items: center; justify-content: center; font-size: 10px; font-weight: 700; }
+  .mini-map .node.has-fb .dot { background: var(--dot-fb); }
+  .mini-map .node.current .dot { box-shadow: 0 0 0 3px rgba(0,102,204,0.25); transform: scale(1.05); }
+  .mini-map .node .cap { font-size: 11px; color: var(--text); margin-top: 5px; max-width: 110px; text-align: center; line-height: 1.25; }
+  .mini-map .arrow { flex: 0 0 18px; align-self: center; height: 2px; background: var(--rail); margin-top: 11px; }
   /* Story timeline */
-  .story h2 { font-size: 12px; color: #888; text-transform: uppercase; margin: 0 0 8px; }
-  .timeline { position: relative; padding-left: 32px; }
-  .timeline::before { content: ""; position: absolute; left: 12px; top: 6px; bottom: 6px; width: 2px; background: #262629; }
-  .step { position: relative; margin-bottom: 18px; }
-  .step::before { content: ""; position: absolute; left: -26px; top: 6px; width: 12px; height: 12px; border-radius: 50%; background: #444; border: 2px solid #131316; }
-  .step.has-fb::before { background: #4aa3ff; }
+  .story h2 { font-size: 14px; margin: 0 0 4px; }
+  .story .desc { color: var(--muted); font-size: 13px; margin: 0 0 14px; line-height: 1.55; }
+  .timeline { position: relative; padding-left: 36px; }
+  .timeline::before { content: ""; position: absolute; left: 13px; top: 8px; bottom: 8px; width: 2px; background: var(--rail); }
+  .step { position: relative; margin-bottom: 22px; scroll-margin-top: 140px; }
+  .step::before { content: ""; position: absolute; left: -29px; top: 4px; width: 14px; height: 14px; border-radius: 50%; background: var(--dot); border: 2px solid var(--panel); }
+  .step.has-fb::before { background: var(--dot-fb); }
   .step .head { display: flex; gap: 8px; align-items: baseline; flex-wrap: wrap; }
-  .step .num { color: #666; font-size: 12px; font-family: ui-monospace, monospace; }
-  .step .name { font-weight: 500; }
-  .step .duration { color: #666; font-size: 11px; }
-  .step .shot { display: block; margin-top: 8px; max-width: 720px; width: 100%; border: 1px solid #262629; border-radius: 6px; cursor: zoom-in; }
-  .step .quick { margin-top: 6px; display: flex; gap: 4px; flex-wrap: wrap; }
-  .step .quick button { font-size: 12px; padding: 3px 8px 3px 6px; display: inline-flex; align-items: center; gap: 5px; }
-  .step .quick button svg { width: 14px; height: 14px; flex-shrink: 0; opacity: 0.85; }
-  .step .quick button.active { background: #4aa3ff; border-color: #4aa3ff; color: #fff; }
-  .step .fb { margin-top: 6px; }
-  .step .fb-list { margin-top: 6px; display: flex; flex-direction: column; gap: 4px; }
-  .step .fb-row { background: #1a1a1c; border: 1px solid #262629; border-radius: 4px; padding: 6px 8px; font-size: 12px; display: flex; gap: 8px; align-items: flex-start; }
-  .step .fb-row .kind { font-weight: 600; min-width: 80px; display: inline-flex; align-items: center; gap: 4px; }
-  .step .fb-row .kind svg { width: 13px; height: 13px; flex-shrink: 0; opacity: 0.85; }
-  .step .fb-row .text { color: #ddd; flex: 1; }
-  .step .fb-row .x { color: #666; cursor: pointer; display: inline-flex; align-items: center; }
-  .step .fb-row .x svg { width: 13px; height: 13px; }
-  .step .fb-row .x:hover { color: #ee9c9c; }
+  .step .num { color: var(--muted); font-size: 12px; font-family: ui-monospace, monospace; }
+  .step .title { font-weight: 600; font-size: 15px; }
+  .step .duration { color: var(--muted); font-size: 11px; }
+  .step .desc { color: var(--muted); font-size: 13px; line-height: 1.55; margin: 4px 0 8px; max-width: 720px; }
+  .step .shot { display: block; max-width: 720px; width: 100%; border: 1px solid var(--border); border-radius: 6px; cursor: zoom-in; box-shadow: var(--shadow); background: var(--code-bg); }
+  .step .quick { margin-top: 8px; display: flex; gap: 4px; flex-wrap: wrap; }
+  .step .quick button { font-size: 12px; padding: 4px 10px 4px 8px; display: inline-flex; align-items: center; gap: 6px; }
+  .step .quick button svg { width: 18px; height: 18px; flex-shrink: 0; }
+  .step .quick button:hover { border-color: var(--primary); color: var(--primary); }
+  .step .fb-list { margin-top: 8px; display: flex; flex-direction: column; gap: 5px; }
+  .step .fb-row { background: var(--pill-bg); border: 1px solid var(--border); border-radius: 6px; padding: 7px 10px; font-size: 13px; display: flex; gap: 10px; align-items: flex-start; }
+  .step .fb-row .kind { font-weight: 600; min-width: 90px; display: inline-flex; align-items: center; gap: 6px; text-transform: capitalize; }
+  .step .fb-row .kind svg { width: 16px; height: 16px; flex-shrink: 0; }
+  .step .fb-row .text { color: var(--text); flex: 1; }
+  .step .fb-row .x { color: var(--muted); cursor: pointer; display: inline-flex; align-items: center; padding: 0 2px; }
+  .step .fb-row .x svg { width: 14px; height: 14px; }
+  .step .fb-row .x:hover { color: var(--danger); }
   /* Lightbox */
-  dialog { background: rgba(0,0,0,0.95); border: none; max-width: 100vw; max-height: 100vh; padding: 0; }
+  dialog { background: rgba(0,0,0,0.92); border: none; max-width: 100vw; max-height: 100vh; padding: 0; }
   dialog img { max-width: 100vw; max-height: 100vh; display: block; cursor: zoom-out; }
-  dialog::backdrop { background: rgba(0,0,0,0.9); }
+  dialog::backdrop { background: rgba(0,0,0,0.85); }
   /* Misc */
-  .muted { color: #888; font-size: 12px; }
+  .muted { color: var(--muted); font-size: 12px; }
   .grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(360px, 1fr)); gap: 12px; }
-  figure { margin: 0; background: #131316; border: 1px solid #262629; border-radius: 8px; overflow: hidden; }
-  figure img { display: block; width: 100%; cursor: zoom-in; background: #000; }
-  figcaption { padding: 6px 10px; font-size: 11px; color: #999; display: flex; justify-content: space-between; }
+  figure { margin: 0; background: var(--panel); border: 1px solid var(--border); border-radius: 8px; overflow: hidden; box-shadow: var(--shadow); }
+  figure img { display: block; width: 100%; cursor: zoom-in; background: var(--code-bg); }
+  figcaption { padding: 7px 10px; font-size: 11px; color: var(--muted); display: flex; justify-content: space-between; border-top: 1px solid var(--border); }
 </style>
 </head>
-<body>
+<body data-theme="light">
 <header>
   <h1><a href="#/">Ask · review</a></h1>
   <span id="status" class="badge">idle</span>
   <div class="right">
     <select id="spec"><option value="">All specs</option></select>
     <button id="run" class="primary">New run</button>
+    <button id="theme-toggle" class="icon-only" title="Toggle light/dark"></button>
     <a href="http://localhost:5173/dev/markdown" target="_blank"><button>/dev/markdown ↗</button></a>
     <a href="http://localhost:5173/" target="_blank"><button>app ↗</button></a>
   </div>
@@ -366,6 +463,8 @@ const SVG = {
   slow:      '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M12 6v6h4.5m4.5 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"/></svg>',
   other:     '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M2.25 12.76c0 1.6 1.123 2.994 2.707 3.227 1.068.157 2.148.279 3.238.364.466.037.893.281 1.153.671L12 21l2.652-3.978c.26-.39.687-.634 1.153-.67 1.09-.086 2.17-.208 3.238-.365 1.584-.233 2.707-1.626 2.707-3.228V6.741c0-1.602-1.123-2.995-2.707-3.228A48.394 48.394 0 0 0 12 3c-2.392 0-4.744.175-7.043.513C3.373 3.746 2.25 5.14 2.25 6.741v6.018Z"/></svg>',
   remove:    '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M6 18 18 6M6 6l12 12"/></svg>',
+  sun:       '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="4"/><path d="M12 3v2M12 19v2M5.05 5.05l1.41 1.41M17.54 17.54l1.41 1.41M3 12h2M19 12h2M5.05 18.95l1.41-1.41M17.54 6.46l1.41-1.41"/></svg>',
+  moon:      '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>',
 };
 
 const KINDS = [
@@ -484,21 +583,43 @@ async function renderDetail(id) {
     '</div>';
   }
 
+  // ----- mini-map flowchart (sticky) -----
+  let miniMap = '';
+  const stories = r.stories || [];
+  if (stories.length) {
+    const allSteps = stories.flatMap(s => s.steps.map(st => ({ s, st })));
+    miniMap = '<div class="mini-map" id="mini-map">' +
+      '<div class="label">Where you are</div>' +
+      '<div class="nodes">' +
+        allSteps.map(({ s, st }, i) => {
+          const has = fb.some(x => x.storyPath === s.path && x.stepIdx === st.idx);
+          const arrow = i < allSteps.length - 1 ? '<div class="arrow"></div>' : '';
+          return '<div class="node' + (has ? ' has-fb' : '') + '" data-target="step-' + escape(s.path) + '-' + st.idx + '">' +
+              '<div class="dot">' + (st.idx+1) + '</div>' +
+              '<div class="cap">' + escape(st.title) + '</div>' +
+            '</div>' + arrow;
+        }).join('') +
+      '</div></div>';
+  }
+
   // ----- story timelines -----
   let storyHtml = '';
-  for (const s of (r.stories || [])) {
+  for (const s of stories) {
     storyHtml += '<div class="story panel" data-story-path="' + escape(s.path) + '">' +
-      '<h2>' + escape(s.testTitle) + ' — ' + s.steps.length + ' step' + (s.steps.length===1?'':'s') + '</h2>' +
+      '<h2>' + escape(s.title || s.testTitle) + '</h2>' +
+      (s.description ? '<p class="desc">' + escape(s.description) + '</p>' : '') +
+      '<div class="muted" style="margin-bottom:14px">' + s.steps.length + ' step' + (s.steps.length===1?'':'s') + '</div>' +
       '<div class="timeline">' +
         s.steps.map(st => {
           const stepFb = fb.filter(x => x.storyPath === s.path && x.stepIdx === st.idx);
-          return '<div class="step' + (stepFb.length ? ' has-fb' : '') + '" data-step="' + st.idx + '">' +
+          return '<div id="step-' + escape(s.path) + '-' + st.idx + '" class="step' + (stepFb.length ? ' has-fb' : '') + '" data-step="' + st.idx + '">' +
             '<div class="head">' +
               '<span class="num">' + String(st.idx+1).padStart(2,'0') + '</span>' +
-              '<span class="name">' + escape(st.name) + '</span>' +
-              '<span class="duration">· ' + st.durationMs + 'ms</span>' +
+              '<span class="title">' + escape(st.title) + '</span>' +
+              '<span class="duration">' + st.durationMs + 'ms</span>' +
             '</div>' +
-            (st.file ? '<img class="shot" loading="lazy" src="/runs/' + r.id + '/story/' + encodeURI(s.path) + '/' + encodeURI(st.file) + '" alt="' + escape(st.name) + '">' : '') +
+            (st.description ? '<p class="desc">' + escape(st.description) + '</p>' : '') +
+            (st.file ? '<img class="shot" loading="lazy" src="/runs/' + r.id + '/story/' + encodeURI(s.path) + '/' + encodeURI(st.file) + '" alt="' + escape(st.title) + '">' : '') +
             '<div class="quick">' +
               KINDS.map(k => '<button data-kind="' + k.id + '">' + k.icon + '<span>' + k.label + '</span></button>').join('') +
               '<button data-kind="other">' + SVG.other + '<span>Comment</span></button>' +
@@ -535,10 +656,19 @@ async function renderDetail(id) {
     }
   }
 
+  // ----- friendly hero -----
+  const primaryStory = stories[0];
+  const heroTitle = primaryStory?.title || (r.spec || '(all specs)').replace(/^e2e\\//, '').replace(/\\.spec\\.ts$/, '');
+  const heroDesc = primaryStory?.description || '';
+
   view.innerHTML =
     '<p style="margin:0 0 12px"><a href="#/">← all runs</a></p>' +
-    '<h2 style="margin:0 0 4px;font-size:16px">' + escape(r.spec || '(all specs)').replace(/^e2e\\//,'') + '</h2>' +
-    '<p style="margin:0 0 14px" class="muted">' + r.id + ' · started ' + ago(r.startedAt) + ' · ' + passedBadge + staleBadge + '</p>' +
+    '<div class="run-hero">' +
+      '<h1>' + escape(heroTitle) + '</h1>' +
+      (heroDesc ? '<p class="lead">' + escape(heroDesc) + '</p>' : '') +
+      '<p class="meta">' + escape(r.spec || '(all specs)').replace(/^e2e\\//,'') + ' · ' + r.id + ' · started ' + ago(r.startedAt) + ' · ' + passedBadge + staleBadge + '</p>' +
+    '</div>' +
+    miniMap +
     reviewSection +
     storyHtml +
     shotsHtml +
@@ -549,6 +679,24 @@ async function renderDetail(id) {
   view.querySelectorAll('img.shot, figure img').forEach(img => {
     img.addEventListener('click', () => { lightboxImg.src = img.src; lightbox.showModal(); });
   });
+  // mini-map: click → scroll, scroll → highlight current
+  const miniNodes = view.querySelectorAll('.mini-map .node');
+  miniNodes.forEach(n => {
+    n.addEventListener('click', () => {
+      const tgt = document.getElementById(n.dataset.target);
+      if (tgt) tgt.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    });
+  });
+  if (miniNodes.length) {
+    const observer = new IntersectionObserver((entries) => {
+      entries.forEach(e => {
+        if (!e.isIntersecting) return;
+        const id = e.target.id;
+        miniNodes.forEach(n => n.classList.toggle('current', n.dataset.target === id));
+      });
+    }, { rootMargin: '-150px 0px -60% 0px', threshold: 0 });
+    view.querySelectorAll('.step[id]').forEach(s => observer.observe(s));
+  }
   // review submit / reopen
   view.querySelectorAll('button[data-decision]').forEach(b => {
     b.addEventListener('click', async () => {
@@ -622,6 +770,20 @@ es.addEventListener('done', () => {
   statusEl.textContent = 'idle'; statusEl.className = 'badge';
   runEl.disabled = false;
   route();
+});
+
+// ---------- theme toggle (light by default, persisted) -------------------
+const themeBtn = document.getElementById('theme-toggle');
+function applyTheme(t) {
+  document.body.dataset.theme = t;
+  themeBtn.innerHTML = t === 'dark' ? SVG.sun : SVG.moon;
+  themeBtn.title = t === 'dark' ? 'Switch to light' : 'Switch to dark';
+}
+applyTheme(localStorage.getItem('ask-review-theme') || 'light');
+themeBtn.addEventListener('click', () => {
+  const next = document.body.dataset.theme === 'dark' ? 'light' : 'dark';
+  localStorage.setItem('ask-review-theme', next);
+  applyTheme(next);
 });
 
 loadSpecs();

--- a/web/scripts/review-server.ts
+++ b/web/scripts/review-server.ts
@@ -1,28 +1,42 @@
 /**
  * Ask · review dashboard
  *
- * Landing page: every test run as a row (status, spec, time, shots, review note).
- * Click a run → frozen screenshots, run output, and a review form to mark it
- * reviewed with a summary + decision.
+ * Landing page: every test run, with status, decision, and a "may be stale"
+ * badge when commits land between approval and now.
  *
- * Data lives under web/.review/:
- *   runs.json                    – array of run metadata (newest first)
- *   runs/<id>/output.txt         – captured stdout/stderr
- *   runs/<id>/screenshots/...    – frozen copy of the screenshots that PR
- *                                  produced (so historical runs survive
- *                                  re-runs that overwrite e2e/screenshots/)
+ * Run detail:
+ *   - Vertical step-by-step "story" timeline (from helpers/story.ts in the
+ *     spec) with per-step quick-tag feedback (👍🐛🎨📝🤔⚠️) + optional text
+ *   - Captured Playwright stdout
+ *   - Review form to mark the run reviewed; submitting NEVER kicks off
+ *     another run — re-runs are explicit via the New run button
+ *
+ * Approve / Changes-requested / Reject semantics
+ *   approved          → don't re-prompt unless code changes (stale = code
+ *                       under web/src or ask/scripts/ changed since this run)
+ *   changes-requested → known-not-ready, dashboard ignores it for stale alerts
+ *   rejected          → same as changes-requested — won't nag
+ *
+ * Storage (gitignored, web/.review/):
+ *   runs.json                          – metadata for every run
+ *   runs/<id>/output.txt               – captured stdout/stderr
+ *   runs/<id>/screenshots/...          – frozen ad-hoc screenshots
+ *   runs/<id>/story/<spec>/...         – frozen story dirs (from helpers/story.ts)
+ *   runs/<id>/feedback.json            – per-step feedback {step,kind,text}
  *
  * Run with: cd web && npm run review   →   http://localhost:4244
  */
 import http from 'http'
 import fs from 'fs'
 import path from 'path'
-import { spawn } from 'child_process'
+import { spawn, execSync } from 'child_process'
 import { fileURLToPath } from 'url'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const WEB = path.resolve(__dirname, '..')
+const REPO = path.resolve(WEB, '..')
 const SHOTS = path.join(WEB, 'e2e', 'screenshots')
+const STORY_ROOT = path.join(SHOTS, '__story')
 const E2E = path.join(WEB, 'e2e')
 const REVIEW = path.join(WEB, '.review')
 const RUNS_DIR = path.join(REVIEW, 'runs')
@@ -37,27 +51,31 @@ interface Review {
   decision: 'approved' | 'changes-requested' | 'rejected'
   reviewedAt: number
 }
+interface Feedback {
+  storyPath: string   // relative path under runs/<id>/story/  e.g. "<test-slug>"
+  stepIdx: number
+  kind: string        // ok | bug | style | copy | confusing | slow | other
+  text: string
+  at: number
+}
 interface Run {
   id: string
-  spec: string                  // '' = all specs
+  spec: string
   startedAt: number
   endedAt: number | null
   exitCode: number | null
   screenshotCount: number
   status: 'running' | 'awaiting-review' | 'reviewed'
   review: Review | null
+  gitHead: string | null    // sha at run start (for staleness detection)
 }
 
 function loadRuns(): Run[] {
   try { return JSON.parse(fs.readFileSync(RUNS_JSON, 'utf-8')) as Run[] }
   catch { return [] }
 }
-function saveRuns(runs: Run[]) {
-  fs.writeFileSync(RUNS_JSON, JSON.stringify(runs, null, 2))
-}
-function getRun(id: string): Run | undefined {
-  return loadRuns().find(r => r.id === id)
-}
+function saveRuns(runs: Run[]) { fs.writeFileSync(RUNS_JSON, JSON.stringify(runs, null, 2)) }
+function getRun(id: string): Run | undefined { return loadRuns().find(r => r.id === id) }
 function updateRun(id: string, patch: Partial<Run>): Run | undefined {
   const runs = loadRuns()
   const i = runs.findIndex(r => r.id === id)
@@ -70,6 +88,24 @@ function newRunId(): string {
   const d = new Date()
   const pad = (n: number) => String(n).padStart(2, '0')
   return `${d.getFullYear()}${pad(d.getMonth()+1)}${pad(d.getDate())}-${pad(d.getHours())}${pad(d.getMinutes())}${pad(d.getSeconds())}`
+}
+
+function git(args: string[]): string {
+  try { return execSync(`git ${args.map(a => `'${a.replace(/'/g, "'\\''")}'`).join(' ')}`, { cwd: REPO, encoding: 'utf-8' }).trim() }
+  catch { return '' }
+}
+function currentGitHead(): string | null { return git(['rev-parse', 'HEAD']) || null }
+
+/** True if any file under web/src or ask/scripts has changed since the run's gitHead. */
+function isPotentiallyStale(run: Run): boolean {
+  if (!run.gitHead) return false
+  if (!run.review || run.review.decision !== 'approved') return false
+  const out = git(['diff', '--name-only', `${run.gitHead}..HEAD`])
+  if (!out) return false
+  for (const line of out.split('\n')) {
+    if (line.startsWith('web/src/') || line.startsWith('ask/scripts/')) return true
+  }
+  return false
 }
 
 // ---------- run state -----------------------------------------------------
@@ -95,10 +131,12 @@ function listShots(dir: string): string[] {
 }
 
 function freezeScreenshots(runId: string, since: number): number {
+  // Freeze ad-hoc screenshots (anything in e2e/screenshots/ except __story)
   const dest = path.join(RUNS_DIR, runId, 'screenshots')
   fs.mkdirSync(dest, { recursive: true })
   let n = 0
   for (const src of listShots(SHOTS)) {
+    if (src.startsWith(STORY_ROOT)) continue
     const st = fs.statSync(src)
     if (st.mtimeMs < since) continue
     const rel = path.relative(SHOTS, src)
@@ -106,6 +144,24 @@ function freezeScreenshots(runId: string, since: number): number {
     fs.mkdirSync(path.dirname(dst), { recursive: true })
     fs.copyFileSync(src, dst)
     n++
+  }
+  // Freeze every story directory whole (story.json + step PNGs)
+  if (fs.existsSync(STORY_ROOT)) {
+    for (const e of fs.readdirSync(STORY_ROOT, { withFileTypes: true })) {
+      if (!e.isDirectory()) continue
+      const srcDir = path.join(STORY_ROOT, e.name)
+      const storyJson = path.join(srcDir, 'story.json')
+      if (!fs.existsSync(storyJson)) continue
+      const startedAt = (() => {
+        try { return JSON.parse(fs.readFileSync(storyJson, 'utf-8')).startedAt as number ?? 0 } catch { return 0 }
+      })()
+      if (startedAt < since) continue
+      const dstDir = path.join(RUNS_DIR, runId, 'story', e.name)
+      fs.mkdirSync(dstDir, { recursive: true })
+      for (const f of fs.readdirSync(srcDir)) {
+        fs.copyFileSync(path.join(srcDir, f), path.join(dstDir, f))
+      }
+    }
   }
   return n
 }
@@ -121,6 +177,7 @@ function startRun(spec: string): Run | null {
     screenshotCount: 0,
     status: 'running',
     review: null,
+    gitHead: currentGitHead(),
   }
   fs.mkdirSync(path.join(RUNS_DIR, run.id), { recursive: true })
   saveRuns([run, ...loadRuns()])
@@ -176,6 +233,31 @@ function listFrozenShots(runId: string): { rel: string; size: number }[] {
   return out.sort((a, b) => a.rel.localeCompare(b.rel))
 }
 
+interface FrozenStory { path: string; testTitle: string; steps: { idx: number; name: string; file: string; durationMs: number }[] }
+function listFrozenStories(runId: string): FrozenStory[] {
+  const root = path.join(RUNS_DIR, runId, 'story')
+  if (!fs.existsSync(root)) return []
+  const out: FrozenStory[] = []
+  for (const e of fs.readdirSync(root, { withFileTypes: true })) {
+    if (!e.isDirectory()) continue
+    const j = path.join(root, e.name, 'story.json')
+    if (!fs.existsSync(j)) continue
+    try {
+      const data = JSON.parse(fs.readFileSync(j, 'utf-8')) as { testTitle?: string; steps: FrozenStory['steps'] }
+      out.push({ path: e.name, testTitle: data.testTitle ?? e.name, steps: data.steps ?? [] })
+    } catch { /* skip */ }
+  }
+  return out
+}
+
+function loadFeedback(runId: string): Feedback[] {
+  const p = path.join(RUNS_DIR, runId, 'feedback.json')
+  try { return JSON.parse(fs.readFileSync(p, 'utf-8')) as Feedback[] } catch { return [] }
+}
+function saveFeedback(runId: string, fb: Feedback[]) {
+  fs.writeFileSync(path.join(RUNS_DIR, runId, 'feedback.json'), JSON.stringify(fb, null, 2))
+}
+
 // ---------- HTML page (SPA with hash routing) -----------------------------
 const HTML = `<!doctype html>
 <html lang="en"><head>
@@ -191,25 +273,18 @@ const HTML = `<!doctype html>
   header .right { margin-left: auto; display: flex; gap: 8px; align-items: center; }
   select, button, input, textarea { background: #1a1a1c; color: #eee; border: 1px solid #333; border-radius: 6px; padding: 6px 10px; font: inherit; }
   button { cursor: pointer; }
-  select:hover, button:hover { background: #222226; }
+  select:hover, button:hover:not(:disabled) { background: #222226; }
   button.primary { background: #0066cc; border-color: #0066cc; color: #fff; }
   button.primary:hover { background: #0077ee; }
   button.danger { background: #6b1a1a; border-color: #6b1a1a; color: #fff; }
   button.success { background: #1d6f1d; border-color: #1d6f1d; color: #fff; }
   button:disabled { opacity: 0.5; cursor: not-allowed; }
-  main { padding: 16px; }
-  .group { margin-bottom: 24px; }
-  .group h2 { font-size: 12px; color: #888; text-transform: uppercase; letter-spacing: 0.06em; margin: 0 0 8px; font-weight: 600; }
+  main { padding: 16px; max-width: 1400px; margin: 0 auto; }
   table { width: 100%; border-collapse: collapse; }
   table th, table td { padding: 10px 12px; text-align: left; border-bottom: 1px solid #1f1f22; vertical-align: top; }
   table th { font-size: 11px; color: #888; text-transform: uppercase; letter-spacing: 0.06em; font-weight: 600; }
   table tr:hover td { background: #14141a; }
   table tr.clickable { cursor: pointer; }
-  .grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(360px, 1fr)); gap: 12px; }
-  figure { margin: 0; background: #131316; border: 1px solid #262629; border-radius: 8px; overflow: hidden; }
-  figure img { display: block; width: 100%; cursor: zoom-in; background: #000; }
-  figcaption { padding: 6px 10px; font-size: 11px; color: #999; display: flex; justify-content: space-between; }
-  pre.output { background: #0a0a0c; border: 1px solid #2a2a2a; border-radius: 6px; padding: 10px; max-height: 280px; overflow: auto; font: 11px/1.4 ui-monospace,monospace; white-space: pre-wrap; }
   .empty { color: #666; padding: 28px; text-align: center; }
   .badge { padding: 2px 8px; border-radius: 4px; font-size: 11px; font-weight: 600; display: inline-block; }
   .badge.running { background: #0a4d0a; color: #afe9af; }
@@ -217,21 +292,50 @@ const HTML = `<!doctype html>
   .badge.reviewed { background: #0a3a4d; color: #a4d8ee; }
   .badge.passed { background: #0a4d0a; color: #afe9af; }
   .badge.failed { background: #4d0a0a; color: #ee9c9c; }
+  .badge.stale { background: #6b1a1a; color: #ffc9c9; }
   .decision-approved { color: #afe9af; }
   .decision-changes-requested { color: #f5d77a; }
   .decision-rejected { color: #ee9c9c; }
   a { color: #4aa3ff; text-decoration: none; }
   a:hover { text-decoration: underline; }
-  textarea { width: 100%; min-height: 80px; resize: vertical; font-family: inherit; }
-  .review-form { background: #131316; border: 1px solid #262629; border-radius: 8px; padding: 14px; margin: 16px 0; }
-  .review-form .row { display: flex; gap: 10px; align-items: center; margin-top: 10px; }
-  .review-existing { background: #131316; border: 1px solid #262629; border-radius: 8px; padding: 14px; margin: 16px 0; }
-  .review-existing h3 { margin: 0 0 6px; font-size: 13px; color: #aaa; }
-  .review-existing p { margin: 0; white-space: pre-wrap; }
+  textarea { width: 100%; min-height: 60px; resize: vertical; font-family: inherit; }
+  pre.output { background: #0a0a0c; border: 1px solid #2a2a2a; border-radius: 6px; padding: 10px; max-height: 280px; overflow: auto; font: 11px/1.4 ui-monospace,monospace; white-space: pre-wrap; }
+  .panel { background: #131316; border: 1px solid #262629; border-radius: 8px; padding: 14px; margin: 16px 0; }
+  .panel h3 { margin: 0 0 8px; font-size: 13px; color: #aaa; }
+  .panel .row { display: flex; gap: 10px; align-items: center; flex-wrap: wrap; }
+  .panel .help { color: #777; font-size: 12px; margin-top: 8px; line-height: 1.5; }
+  /* Story timeline */
+  .story h2 { font-size: 12px; color: #888; text-transform: uppercase; margin: 0 0 8px; }
+  .timeline { position: relative; padding-left: 32px; }
+  .timeline::before { content: ""; position: absolute; left: 12px; top: 6px; bottom: 6px; width: 2px; background: #262629; }
+  .step { position: relative; margin-bottom: 18px; }
+  .step::before { content: ""; position: absolute; left: -26px; top: 6px; width: 12px; height: 12px; border-radius: 50%; background: #444; border: 2px solid #131316; }
+  .step.has-fb::before { background: #4aa3ff; }
+  .step .head { display: flex; gap: 8px; align-items: baseline; flex-wrap: wrap; }
+  .step .num { color: #666; font-size: 12px; font-family: ui-monospace, monospace; }
+  .step .name { font-weight: 500; }
+  .step .duration { color: #666; font-size: 11px; }
+  .step .shot { display: block; margin-top: 8px; max-width: 720px; width: 100%; border: 1px solid #262629; border-radius: 6px; cursor: zoom-in; }
+  .step .quick { margin-top: 6px; display: flex; gap: 4px; flex-wrap: wrap; }
+  .step .quick button { font-size: 12px; padding: 3px 8px; }
+  .step .quick button.active { background: #4aa3ff; border-color: #4aa3ff; color: #fff; }
+  .step .fb { margin-top: 6px; }
+  .step .fb-list { margin-top: 6px; display: flex; flex-direction: column; gap: 4px; }
+  .step .fb-row { background: #1a1a1c; border: 1px solid #262629; border-radius: 4px; padding: 6px 8px; font-size: 12px; display: flex; gap: 8px; align-items: flex-start; }
+  .step .fb-row .kind { font-weight: 600; min-width: 80px; }
+  .step .fb-row .text { color: #ddd; flex: 1; }
+  .step .fb-row .x { color: #666; cursor: pointer; }
+  .step .fb-row .x:hover { color: #ee9c9c; }
   /* Lightbox */
   dialog { background: rgba(0,0,0,0.95); border: none; max-width: 100vw; max-height: 100vh; padding: 0; }
   dialog img { max-width: 100vw; max-height: 100vh; display: block; cursor: zoom-out; }
   dialog::backdrop { background: rgba(0,0,0,0.9); }
+  /* Misc */
+  .muted { color: #888; font-size: 12px; }
+  .grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(360px, 1fr)); gap: 12px; }
+  figure { margin: 0; background: #131316; border: 1px solid #262629; border-radius: 8px; overflow: hidden; }
+  figure img { display: block; width: 100%; cursor: zoom-in; background: #000; }
+  figcaption { padding: 6px 10px; font-size: 11px; color: #999; display: flex; justify-content: space-between; }
 </style>
 </head>
 <body>
@@ -248,6 +352,15 @@ const HTML = `<!doctype html>
 <main id="view"></main>
 <dialog id="lightbox"><img alt=""></dialog>
 <script>
+const KINDS = [
+  { id: 'ok',         label: 'OK',         emoji: '👍' },
+  { id: 'bug',        label: 'Bug',        emoji: '🐛' },
+  { id: 'style',      label: 'Style',      emoji: '🎨' },
+  { id: 'copy',       label: 'Copy',       emoji: '📝' },
+  { id: 'confusing',  label: 'Confusing',  emoji: '🤔' },
+  { id: 'slow',       label: 'Slow',       emoji: '⚠️' },
+];
+
 const view = document.getElementById('view');
 const specEl = document.getElementById('spec');
 const runEl = document.getElementById('run');
@@ -288,33 +401,32 @@ async function renderList() {
     return;
   }
   const rows = runs.map(r => {
-    const passed = r.exitCode === 0;
     const exitBadge = r.exitCode === null
       ? '<span class="badge running">running</span>'
-      : passed ? '<span class="badge passed">passed</span>'
-               : '<span class="badge failed">failed</span>';
+      : r.exitCode === 0 ? '<span class="badge passed">passed</span>'
+                         : '<span class="badge failed">failed</span>';
     const statusBadge = '<span class="badge ' + (
       r.status === 'running' ? 'running' :
-      r.status === 'reviewed' ? 'reviewed' :
-      'awaiting'
+      r.status === 'reviewed' ? 'reviewed' : 'awaiting'
     ) + '">' + r.status + '</span>';
+    const staleBadge = r.stale ? ' <span class="badge stale" title="Code under web/src or ask/scripts has changed since this run was approved.">may be stale</span>' : '';
     const decision = r.review
-      ? '<span class="decision-' + r.review.decision + '">' + r.review.decision + '</span> · ' + escape(r.review.summary).slice(0, 80)
-      : '—';
+      ? '<span class="decision-' + r.review.decision + '">' + r.review.decision + '</span>' +
+        (r.review.summary ? ' · ' + escape(r.review.summary).slice(0, 80) : '')
+      : '<span class="muted">—</span>';
     return '<tr class="clickable" data-id="' + r.id + '">' +
-      '<td>' + ago(r.startedAt) + '<br><span style="color:#666;font-size:11px">' + r.id + '</span></td>' +
+      '<td>' + ago(r.startedAt) + '<br><span class="muted">' + r.id + '</span></td>' +
       '<td>' + escape(r.spec || '(all specs)').replace(/^e2e\\//,'') + '</td>' +
       '<td>' + exitBadge + '</td>' +
-      '<td>' + statusBadge + '</td>' +
+      '<td>' + statusBadge + staleBadge + '</td>' +
       '<td>' + r.screenshotCount + '</td>' +
       '<td>' + decision + '</td>' +
     '</tr>';
   }).join('');
   view.innerHTML =
-    '<table>' +
-      '<thead><tr><th>When</th><th>Spec</th><th>Result</th><th>Review</th><th>Shots</th><th>Decision · Summary</th></tr></thead>' +
-      '<tbody>' + rows + '</tbody>' +
-    '</table>';
+    '<table><thead><tr>' +
+      '<th>When</th><th>Spec</th><th>Result</th><th>Review</th><th>Shots</th><th>Decision · Summary</th>' +
+    '</tr></thead><tbody>' + rows + '</tbody></table>';
   view.querySelectorAll('tr.clickable').forEach(tr => {
     tr.addEventListener('click', () => location.hash = '#/run/' + tr.dataset.id);
   });
@@ -324,44 +436,84 @@ async function renderList() {
 async function renderDetail(id) {
   const r = await fetch('/api/runs/' + id).then(r => r.json());
   if (r.error) { view.innerHTML = '<div class="empty">Run not found.</div>'; return; }
+  const fb = r.feedback || [];
   const passedBadge = r.exitCode === null
     ? '<span class="badge running">running</span>'
-    : r.exitCode === 0 ? '<span class="badge passed">passed</span>' : '<span class="badge failed">failed</span>';
+    : r.exitCode === 0 ? '<span class="badge passed">passed</span>'
+                       : '<span class="badge failed">failed</span>';
+  const staleBadge = r.stale ? ' <span class="badge stale">may be stale (code changed since approval)</span>' : '';
 
+  // ----- review section -----
   let reviewSection = '';
   if (r.review) {
-    reviewSection = '<div class="review-existing">' +
+    reviewSection = '<div class="panel">' +
       '<h3>Review · <span class="decision-' + r.review.decision + '">' + r.review.decision + '</span> · ' + ago(r.review.reviewedAt) + '</h3>' +
-      '<p>' + escape(r.review.summary) + '</p>' +
-      '<div class="row"><button id="reopen">Reopen</button></div>' +
+      '<p style="margin:0;white-space:pre-wrap">' + escape(r.review.summary || '(no summary)') + '</p>' +
+      '<div class="row" style="margin-top:8px"><button id="reopen">Reopen</button></div>' +
     '</div>';
   } else if (r.status !== 'running') {
-    reviewSection = '<div class="review-form">' +
-      '<h3 style="margin:0 0 8px;font-size:13px;color:#aaa">Mark this run reviewed</h3>' +
-      '<textarea id="summary" placeholder="What did you decide? What needs follow-up?"></textarea>' +
-      '<div class="row">' +
+    reviewSection = '<div class="panel">' +
+      '<h3>Mark this run reviewed</h3>' +
+      '<textarea id="summary" placeholder="Optional — what stood out? (Per-step quick-tags below replace most typing.)"></textarea>' +
+      '<div class="row" style="margin-top:8px">' +
         '<button class="success" data-decision="approved">Approve</button>' +
         '<button data-decision="changes-requested">Changes requested</button>' +
         '<button class="danger" data-decision="rejected">Reject</button>' +
       '</div>' +
+      '<p class="help">' +
+        '<strong>Approve</strong> → don\\'t re-prompt unless web/src or ask/scripts changes (then a "may be stale" badge appears).<br>' +
+        '<strong>Changes requested / Reject</strong> → suppresses stale alerts; this run is logged as known-not-ready.<br>' +
+        'Submitting never re-runs the test. Use the <em>New run</em> button when you want to retest.' +
+      '</p>' +
     '</div>';
   }
 
-  const shotGroups = new Map();
-  for (const s of r.screenshots) {
-    const parts = s.rel.split('/');
-    const g = parts.length > 1 ? parts[0] : '(root)';
-    if (!shotGroups.has(g)) shotGroups.set(g, []);
-    shotGroups.get(g).push(s);
+  // ----- story timelines -----
+  let storyHtml = '';
+  for (const s of (r.stories || [])) {
+    storyHtml += '<div class="story panel" data-story-path="' + escape(s.path) + '">' +
+      '<h2>' + escape(s.testTitle) + ' — ' + s.steps.length + ' step' + (s.steps.length===1?'':'s') + '</h2>' +
+      '<div class="timeline">' +
+        s.steps.map(st => {
+          const stepFb = fb.filter(x => x.storyPath === s.path && x.stepIdx === st.idx);
+          return '<div class="step' + (stepFb.length ? ' has-fb' : '') + '" data-step="' + st.idx + '">' +
+            '<div class="head">' +
+              '<span class="num">' + String(st.idx+1).padStart(2,'0') + '</span>' +
+              '<span class="name">' + escape(st.name) + '</span>' +
+              '<span class="duration">· ' + st.durationMs + 'ms</span>' +
+            '</div>' +
+            (st.file ? '<img class="shot" loading="lazy" src="/runs/' + r.id + '/story/' + encodeURI(s.path) + '/' + encodeURI(st.file) + '" alt="' + escape(st.name) + '">' : '') +
+            '<div class="quick">' +
+              KINDS.map(k => '<button data-kind="' + k.id + '">' + k.emoji + ' ' + k.label + '</button>').join('') +
+              '<button data-kind="other">＋ Comment</button>' +
+            '</div>' +
+            '<div class="fb-list">' +
+              stepFb.map(f => '<div class="fb-row">' +
+                '<span class="kind">' + (KINDS.find(k=>k.id===f.kind)?.emoji ?? '·') + ' ' + escape(f.kind) + '</span>' +
+                '<span class="text">' + escape(f.text || '') + '</span>' +
+                '<span class="x" data-at="' + f.at + '" title="remove">✕</span>' +
+              '</div>').join('') +
+            '</div>' +
+          '</div>';
+        }).join('') +
+      '</div>' +
+    '</div>';
   }
+
+  // ----- ad-hoc shots (fallback for specs that don't use story()) -----
   let shotsHtml = '';
-  if (!r.screenshots.length) {
-    shotsHtml = '<div class="empty">This run captured no screenshots.</div>';
-  } else {
-    for (const [g, items] of shotGroups) {
-      shotsHtml += '<div class="group"><h2>' + escape(g) + ' — ' + items.length + '</h2><div class="grid">' +
+  if (r.screenshots?.length) {
+    const groups = new Map();
+    for (const s of r.screenshots) {
+      const top = s.rel.split('/')[0] || '(root)';
+      if (!groups.has(top)) groups.set(top, []);
+      groups.get(top).push(s);
+    }
+    for (const [g, items] of groups) {
+      shotsHtml += '<div class="panel"><h2 style="margin:0 0 8px;font-size:12px;color:#888;text-transform:uppercase">' + escape(g) + ' — ' + items.length + '</h2>' +
+        '<div class="grid">' +
         items.map(s =>
-          '<figure><img loading="lazy" src="/runs/' + r.id + '/shots/' + encodeURI(s.rel) + '" alt="' + escape(s.rel) + '" />' +
+          '<figure><img loading="lazy" src="/runs/' + r.id + '/shots/' + encodeURI(s.rel) + '" alt="' + escape(s.rel) + '">' +
           '<figcaption><span>' + escape(s.rel.split("/").pop()) + '</span><span>' + fmt(s.size) + '</span></figcaption></figure>'
         ).join('') + '</div></div>';
     }
@@ -370,19 +522,21 @@ async function renderDetail(id) {
   view.innerHTML =
     '<p style="margin:0 0 12px"><a href="#/">← all runs</a></p>' +
     '<h2 style="margin:0 0 4px;font-size:16px">' + escape(r.spec || '(all specs)').replace(/^e2e\\//,'') + '</h2>' +
-    '<p style="margin:0 0 14px;color:#888;font-size:12px">' + r.id + ' · started ' + ago(r.startedAt) + ' · ' + passedBadge + '</p>' +
+    '<p style="margin:0 0 14px" class="muted">' + r.id + ' · started ' + ago(r.startedAt) + ' · ' + passedBadge + staleBadge + '</p>' +
     reviewSection +
-    '<details' + (r.exitCode === 0 ? '' : ' open') + '><summary style="cursor:pointer;color:#888;margin:8px 0;font-size:12px">Output</summary>' +
-      '<pre class="output" id="run-output">' + escape(r.output ?? '') + '</pre>' +
-    '</details>' +
-    shotsHtml;
+    storyHtml +
+    shotsHtml +
+    '<details' + (r.exitCode === 0 ? '' : ' open') + '><summary style="cursor:pointer" class="muted">Output</summary>' +
+      '<pre class="output" id="run-output">' + escape(r.output ?? '') + '</pre></details>';
 
-  view.querySelectorAll('figure img').forEach(img => {
+  // image lightbox
+  view.querySelectorAll('img.shot, figure img').forEach(img => {
     img.addEventListener('click', () => { lightboxImg.src = img.src; lightbox.showModal(); });
   });
+  // review submit / reopen
   view.querySelectorAll('button[data-decision]').forEach(b => {
     b.addEventListener('click', async () => {
-      const summary = (document.getElementById('summary')).value.trim() || '(no notes)';
+      const summary = (document.getElementById('summary')).value.trim();
       await fetch('/api/runs/' + r.id + '/review', {
         method: 'POST', headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ summary, decision: b.dataset.decision }),
@@ -394,6 +548,35 @@ async function renderDetail(id) {
   if (reopen) reopen.addEventListener('click', async () => {
     await fetch('/api/runs/' + r.id + '/review', { method: 'DELETE' });
     renderDetail(r.id);
+  });
+  // per-step quick-tag handlers
+  view.querySelectorAll('.story').forEach(storyEl => {
+    const storyPath = storyEl.dataset.storyPath;
+    storyEl.querySelectorAll('.step').forEach(stepEl => {
+      const stepIdx = parseInt(stepEl.dataset.step, 10);
+      stepEl.querySelectorAll('button[data-kind]').forEach(btn => {
+        btn.addEventListener('click', async () => {
+          const kind = btn.dataset.kind;
+          let text = '';
+          if (kind === 'other' || kind === 'bug' || kind === 'confusing') {
+            text = prompt('Add a note (optional):') ?? '';
+            if (kind === 'other' && !text) return;
+          }
+          await fetch('/api/runs/' + r.id + '/feedback', {
+            method: 'POST', headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ storyPath, stepIdx, kind, text }),
+          });
+          renderDetail(r.id);
+        });
+      });
+      stepEl.querySelectorAll('.fb-row .x').forEach(x => {
+        x.addEventListener('click', async () => {
+          const at = parseInt(x.dataset.at, 10);
+          await fetch('/api/runs/' + r.id + '/feedback?at=' + at, { method: 'DELETE' });
+          renderDetail(r.id);
+        });
+      });
+    });
   });
 }
 
@@ -422,7 +605,7 @@ es.addEventListener('line', (e) => {
 es.addEventListener('done', () => {
   statusEl.textContent = 'idle'; statusEl.className = 'badge';
   runEl.disabled = false;
-  route();   // reload current view (list or detail) so new shots appear
+  route();
 });
 
 loadSpecs();
@@ -447,8 +630,9 @@ const server = http.createServer(async (req, res) => {
   }
 
   if (p === '/api/runs' && req.method === 'GET') {
+    const runs = loadRuns().map(r => ({ ...r, stale: isPotentiallyStale(r) }))
     res.writeHead(200, { 'Content-Type': 'application/json' })
-    res.end(JSON.stringify(loadRuns())); return
+    res.end(JSON.stringify(runs)); return
   }
 
   const runDetail = p.match(/^\/api\/runs\/([^/]+)$/)
@@ -459,7 +643,14 @@ const server = http.createServer(async (req, res) => {
     const output = fs.existsSync(outputPath) ? fs.readFileSync(outputPath, 'utf-8')
                   : (currentRunId === r.id ? currentOutput : '')
     res.writeHead(200, { 'Content-Type': 'application/json' })
-    res.end(JSON.stringify({ ...r, output, screenshots: listFrozenShots(r.id) })); return
+    res.end(JSON.stringify({
+      ...r,
+      output,
+      screenshots: listFrozenShots(r.id),
+      stories: listFrozenStories(r.id),
+      feedback: loadFeedback(r.id),
+      stale: isPotentiallyStale(r),
+    })); return
   }
 
   if (p === '/api/run' && req.method === 'POST') {
@@ -485,23 +676,45 @@ const server = http.createServer(async (req, res) => {
         const { summary, decision } = JSON.parse(body) as { summary: string; decision: Review['decision'] }
         const r = updateRun(review[1], {
           status: 'reviewed',
-          review: { summary, decision, reviewedAt: Date.now() },
+          review: { summary: summary || '', decision, reviewedAt: Date.now() },
         })
         if (!r) { res.writeHead(404); res.end(JSON.stringify({ error: 'not found' })); return }
         res.writeHead(200, { 'Content-Type': 'application/json' })
         res.end(JSON.stringify(r))
-      } catch (e) {
-        res.writeHead(400); res.end(JSON.stringify({ error: String(e) }))
-      }
+      } catch (e) { res.writeHead(400); res.end(JSON.stringify({ error: String(e) })) }
     })
     return
   }
-
   if (review && req.method === 'DELETE') {
     const r = updateRun(review[1], { status: 'awaiting-review', review: null })
     if (!r) { res.writeHead(404); res.end(JSON.stringify({ error: 'not found' })); return }
     res.writeHead(200, { 'Content-Type': 'application/json' })
     res.end(JSON.stringify(r)); return
+  }
+
+  // Per-step feedback endpoints
+  const feedback = p.match(/^\/api\/runs\/([^/]+)\/feedback$/)
+  if (feedback && req.method === 'POST') {
+    let body = ''
+    req.on('data', d => body += d)
+    req.on('end', () => {
+      try {
+        const { storyPath, stepIdx, kind, text } = JSON.parse(body) as Omit<Feedback, 'at'>
+        const fb = loadFeedback(feedback[1])
+        fb.push({ storyPath, stepIdx, kind, text: text || '', at: Date.now() })
+        saveFeedback(feedback[1], fb)
+        res.writeHead(200, { 'Content-Type': 'application/json' })
+        res.end(JSON.stringify({ ok: true }))
+      } catch (e) { res.writeHead(400); res.end(JSON.stringify({ error: String(e) })) }
+    })
+    return
+  }
+  if (feedback && req.method === 'DELETE') {
+    const at = parseInt(url.searchParams.get('at') ?? '', 10)
+    const fb = loadFeedback(feedback[1]).filter(f => f.at !== at)
+    saveFeedback(feedback[1], fb)
+    res.writeHead(200, { 'Content-Type': 'application/json' })
+    res.end(JSON.stringify({ ok: true })); return
   }
 
   if (p === '/api/output' && req.method === 'GET') {
@@ -518,11 +731,22 @@ const server = http.createServer(async (req, res) => {
     return
   }
 
+  // Frozen ad-hoc screenshot
   const runShot = p.match(/^\/runs\/([^/]+)\/shots\/(.+)$/)
   if (runShot && req.method === 'GET') {
     const [, id, rel] = runShot
-    const full = path.join(RUNS_DIR, id, 'screenshots', decodeURIComponent(rel))
     const root = path.join(RUNS_DIR, id, 'screenshots')
+    const full = path.join(root, decodeURIComponent(rel))
+    if (!full.startsWith(root) || !fs.existsSync(full)) { res.writeHead(404); res.end('not found'); return }
+    res.writeHead(200, { 'Content-Type': 'image/png', 'Cache-Control': 'public, max-age=300' })
+    fs.createReadStream(full).pipe(res); return
+  }
+  // Frozen story step image
+  const storyShot = p.match(/^\/runs\/([^/]+)\/story\/([^/]+)\/(.+)$/)
+  if (storyShot && req.method === 'GET') {
+    const [, id, storyPath, rel] = storyShot
+    const root = path.join(RUNS_DIR, id, 'story', decodeURIComponent(storyPath))
+    const full = path.join(root, decodeURIComponent(rel))
     if (!full.startsWith(root) || !fs.existsSync(full)) { res.writeHead(404); res.end('not found'); return }
     res.writeHead(200, { 'Content-Type': 'image/png', 'Cache-Control': 'public, max-age=300' })
     fs.createReadStream(full).pipe(res); return

--- a/web/scripts/review-server.ts
+++ b/web/scripts/review-server.ts
@@ -388,43 +388,61 @@ const HTML = `<!doctype html>
   .run-hero h1 { margin: 0 0 4px; font-size: 22px; line-height: 1.25; }
   .run-hero p.lead { margin: 0 0 8px; color: var(--muted); font-size: 14px; line-height: 1.55; }
   .run-hero .meta { color: var(--muted); font-size: 12px; }
-  /* Sticky mini-map flowchart */
+  /* ----- Sticky mini-map flowchart -----
+     Dot color now means "where you are":
+       - default grey   = step you haven't viewed
+       - blue ring      = step you're on
+       - dark           = step you already passed
+     A separate small badge by the number indicates feedback count, so
+     "I left a note here" is no longer confused with "I'm here". */
   .mini-map { position: sticky; top: 53px; z-index: 15; background: var(--bg); padding: 10px 0 12px; border-bottom: 1px solid var(--border); margin: 8px 0 16px; }
   .mini-map .label { font-size: 11px; color: var(--muted); text-transform: uppercase; letter-spacing: 0.06em; margin-bottom: 8px; }
   .mini-map .nodes { display: flex; gap: 0; align-items: stretch; overflow-x: auto; padding-bottom: 2px; }
-  .mini-map .node { flex: 1 1 0; min-width: 80px; display: flex; flex-direction: column; align-items: center; cursor: pointer; padding: 4px; border-radius: 6px; }
+  .mini-map .node { flex: 1 1 0; min-width: 80px; display: flex; flex-direction: column; align-items: center; cursor: pointer; padding: 4px; border-radius: 6px; position: relative; }
   .mini-map .node:hover { background: var(--row-hover); }
-  .mini-map .node .dot { width: 22px; height: 22px; border-radius: 50%; background: var(--dot); color: #fff; display: flex; align-items: center; justify-content: center; font-size: 10px; font-weight: 700; }
-  .mini-map .node.has-fb .dot { background: var(--dot-fb); }
-  .mini-map .node.current .dot { box-shadow: 0 0 0 3px rgba(0,102,204,0.25); transform: scale(1.05); }
+  .mini-map .node .dot { width: 26px; height: 26px; border-radius: 50%; background: var(--dot); color: #fff; display: flex; align-items: center; justify-content: center; font-size: 11px; font-weight: 700; transition: transform .12s ease, box-shadow .12s ease, background .12s ease; }
+  .mini-map .node.passed .dot { background: var(--muted); }
+  .mini-map .node.current .dot { background: var(--primary); box-shadow: 0 0 0 4px rgba(0,102,204,0.22); transform: scale(1.08); }
   .mini-map .node .cap { font-size: 11px; color: var(--text); margin-top: 5px; max-width: 110px; text-align: center; line-height: 1.25; }
-  .mini-map .arrow { flex: 0 0 18px; align-self: center; height: 2px; background: var(--rail); margin-top: 11px; }
-  /* Story timeline */
-  .story h2 { font-size: 14px; margin: 0 0 4px; }
-  .story .desc { color: var(--muted); font-size: 13px; margin: 0 0 14px; line-height: 1.55; }
-  .timeline { position: relative; padding-left: 36px; }
-  .timeline::before { content: ""; position: absolute; left: 13px; top: 8px; bottom: 8px; width: 2px; background: var(--rail); }
-  .step { position: relative; margin-bottom: 22px; scroll-margin-top: 140px; }
-  .step::before { content: ""; position: absolute; left: -29px; top: 4px; width: 14px; height: 14px; border-radius: 50%; background: var(--dot); border: 2px solid var(--panel); }
-  .step.has-fb::before { background: var(--dot-fb); }
-  .step .head { display: flex; gap: 8px; align-items: baseline; flex-wrap: wrap; }
-  .step .num { color: var(--muted); font-size: 12px; font-family: ui-monospace, monospace; }
-  .step .title { font-weight: 600; font-size: 15px; }
-  .step .duration { color: var(--muted); font-size: 11px; }
-  .step .desc { color: var(--muted); font-size: 13px; line-height: 1.55; margin: 4px 0 8px; max-width: 720px; }
-  .step .shot { display: block; max-width: 720px; width: 100%; border: 1px solid var(--border); border-radius: 6px; cursor: zoom-in; box-shadow: var(--shadow); background: var(--code-bg); }
-  .step .quick { margin-top: 8px; display: flex; gap: 4px; flex-wrap: wrap; }
-  .step .quick button { font-size: 12px; padding: 4px 10px 4px 8px; display: inline-flex; align-items: center; gap: 6px; }
-  .step .quick button svg { width: 18px; height: 18px; flex-shrink: 0; }
-  .step .quick button:hover { border-color: var(--primary); color: var(--primary); }
-  .step .fb-list { margin-top: 8px; display: flex; flex-direction: column; gap: 5px; }
-  .step .fb-row { background: var(--pill-bg); border: 1px solid var(--border); border-radius: 6px; padding: 7px 10px; font-size: 13px; display: flex; gap: 10px; align-items: flex-start; }
-  .step .fb-row .kind { font-weight: 600; min-width: 90px; display: inline-flex; align-items: center; gap: 6px; text-transform: capitalize; }
-  .step .fb-row .kind svg { width: 16px; height: 16px; flex-shrink: 0; }
-  .step .fb-row .text { color: var(--text); flex: 1; }
-  .step .fb-row .x { color: var(--muted); cursor: pointer; display: inline-flex; align-items: center; padding: 0 2px; }
-  .step .fb-row .x svg { width: 14px; height: 14px; }
-  .step .fb-row .x:hover { color: var(--danger); }
+  .mini-map .node.current .cap { font-weight: 600; }
+  .mini-map .node .fb-count { position: absolute; top: 0; right: 18%; min-width: 16px; height: 16px; padding: 0 4px; border-radius: 8px; background: var(--success); color: #fff; font-size: 10px; font-weight: 700; display: flex; align-items: center; justify-content: center; border: 2px solid var(--bg); }
+  .mini-map .arrow { flex: 0 0 22px; align-self: center; height: 2px; background: var(--rail); margin-top: 13px; }
+  /* ----- Slide (one step at a time) ----- */
+  .story-info { padding: 14px 18px; }
+  .story-info h2 { font-size: 14px; margin: 0 0 4px; }
+  .story-info .desc { color: var(--muted); font-size: 13px; margin: 0; line-height: 1.55; }
+  .slide { padding: 22px 22px 18px; }
+  .slide .step-meta { color: var(--muted); font-size: 12px; margin: 0 0 4px; }
+  .slide .step-title { font-size: 18px; font-weight: 600; margin: 0 0 6px; }
+  .slide .step-desc { color: var(--muted); font-size: 14px; line-height: 1.6; margin: 0 0 16px; max-width: 760px; }
+  .slide .step-shot-wrap { display: flex; justify-content: center; background: var(--code-bg); border: 1px solid var(--border); border-radius: 8px; padding: 18px; margin-bottom: 16px; }
+  .slide .step-shot { max-width: 100%; max-height: 720px; cursor: zoom-in; border-radius: 4px; }
+  .slide .quick { margin-top: 0; display: flex; gap: 6px; flex-wrap: wrap; }
+  .slide .quick button { font-size: 13px; padding: 6px 12px 6px 10px; display: inline-flex; align-items: center; gap: 6px; }
+  .slide .quick button svg { width: 18px; height: 18px; flex-shrink: 0; }
+  .slide .quick button:hover { border-color: var(--primary); color: var(--primary); }
+  .slide .fb-list { margin-top: 12px; display: flex; flex-direction: column; gap: 6px; }
+  .slide .fb-row { background: var(--pill-bg); border: 1px solid var(--border); border-radius: 6px; padding: 8px 12px; font-size: 13px; display: flex; gap: 10px; align-items: flex-start; }
+  .slide .fb-row .kind { font-weight: 600; min-width: 100px; display: inline-flex; align-items: center; gap: 6px; text-transform: capitalize; }
+  .slide .fb-row .kind svg { width: 16px; height: 16px; flex-shrink: 0; }
+  .slide .fb-row .text { color: var(--text); flex: 1; }
+  .slide .fb-row .x { color: var(--muted); cursor: pointer; display: inline-flex; align-items: center; padding: 0 2px; }
+  .slide .fb-row .x svg { width: 14px; height: 14px; }
+  .slide .fb-row .x:hover { color: var(--danger); }
+  /* ----- Prev / Next nav under the slide ----- */
+  .slide-nav { display: flex; justify-content: space-between; gap: 12px; margin: 18px 0 0; }
+  .slide-nav button { padding: 9px 16px; display: inline-flex; align-items: center; gap: 6px; font-size: 14px; }
+  .slide-nav button svg { width: 16px; height: 16px; }
+  .slide-nav button:disabled { visibility: hidden; }
+  .slide-nav .step-counter { color: var(--muted); font-size: 12px; align-self: center; }
+  /* ----- Sticky review form pinned to the bottom ----- */
+  .review-sticky { position: sticky; bottom: 0; z-index: 14; background: var(--panel); border: 1px solid var(--border); border-radius: 10px; padding: 14px 16px; margin: 24px 0 0; box-shadow: 0 -4px 14px rgba(0,0,0,0.06); }
+  [data-theme="dark"] .review-sticky { box-shadow: 0 -4px 14px rgba(0,0,0,0.3); }
+  .review-sticky .head { display: flex; justify-content: space-between; align-items: baseline; gap: 8px; flex-wrap: wrap; margin-bottom: 8px; }
+  .review-sticky .head h3 { margin: 0; font-size: 13px; color: var(--muted); }
+  .review-sticky textarea { min-height: 50px; }
+  .review-sticky .row { margin-top: 8px; }
+  .review-sticky .help { color: var(--muted); font-size: 11px; margin-top: 6px; line-height: 1.5; }
   /* Lightbox */
   dialog { background: rgba(0,0,0,0.92); border: none; max-width: 100vw; max-height: 100vh; padding: 0; }
   dialog img { max-width: 100vw; max-height: 100vh; display: block; cursor: zoom-out; }
@@ -465,6 +483,8 @@ const SVG = {
   remove:    '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M6 18 18 6M6 6l12 12"/></svg>',
   sun:       '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="4"/><path d="M12 3v2M12 19v2M5.05 5.05l1.41 1.41M17.54 17.54l1.41 1.41M3 12h2M19 12h2M5.05 18.95l1.41-1.41M17.54 6.46l1.41-1.41"/></svg>',
   moon:      '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>',
+  arrowLeft: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M19 12H5M12 19l-7-7 7-7"/></svg>',
+  arrowRight:'<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M12 5l7 7-7 7"/></svg>',
 };
 
 const KINDS = [
@@ -558,83 +578,93 @@ async function renderDetail(id) {
                        : '<span class="badge failed">failed</span>';
   const staleBadge = r.stale ? ' <span class="badge stale">may be stale (code changed since approval)</span>' : '';
 
-  // ----- review section -----
-  let reviewSection = '';
+  // ----- collected steps (flatten across stories) -----
+  const stories = r.stories || [];
+  const allSteps = stories.flatMap(s => s.steps.map(st => ({ s, st })));
+  const fbCountFor = (storyPath, stepIdx) => fb.filter(x => x.storyPath === storyPath && x.stepIdx === stepIdx).length;
+
+  // Restore previously-viewed slide index from sessionStorage so refreshing
+  // the page doesn't bounce back to step 1.
+  const slideKey = 'slide:' + r.id;
+  let slideIdx = parseInt(sessionStorage.getItem(slideKey) || '0', 10);
+  if (isNaN(slideIdx) || slideIdx < 0) slideIdx = 0;
+  if (slideIdx >= allSteps.length) slideIdx = Math.max(0, allSteps.length - 1);
+
+  // ----- review form (rendered separately, pinned to bottom) -----
+  let reviewBody = '';
   if (r.review) {
-    reviewSection = '<div class="panel">' +
-      '<h3>Review · <span class="decision-' + r.review.decision + '">' + r.review.decision + '</span> · ' + ago(r.review.reviewedAt) + '</h3>' +
-      '<p style="margin:0;white-space:pre-wrap">' + escape(r.review.summary || '(no summary)') + '</p>' +
-      '<div class="row" style="margin-top:8px"><button id="reopen">Reopen</button></div>' +
-    '</div>';
+    reviewBody = '<div class="head"><h3>Reviewed · <span class="decision-' + r.review.decision + '">' + r.review.decision + '</span> · ' + ago(r.review.reviewedAt) + '</h3>' +
+      '<button id="reopen">Reopen</button></div>' +
+      '<p style="margin:0;white-space:pre-wrap;font-size:13px">' + escape(r.review.summary || '(no summary)') + '</p>';
   } else if (r.status !== 'running') {
-    reviewSection = '<div class="panel">' +
-      '<h3>Mark this run reviewed</h3>' +
-      '<textarea id="summary" placeholder="Optional — what stood out? (Per-step quick-tags below replace most typing.)"></textarea>' +
-      '<div class="row" style="margin-top:8px">' +
+    reviewBody = '<div class="head"><h3>Overall review</h3>' +
+      '<span class="muted">Use per-step tags above for specifics; only the overall decision is required to finalize.</span></div>' +
+      '<textarea id="summary" placeholder="Optional — anything global to call out? (per-step quick-tags above replace most typing)"></textarea>' +
+      '<div class="row">' +
         '<button class="success" data-decision="approved">Approve</button>' +
         '<button data-decision="changes-requested">Changes requested</button>' +
         '<button class="danger" data-decision="rejected">Reject</button>' +
       '</div>' +
-      '<p class="help">' +
-        '<strong>Approve</strong> → don\\'t re-prompt unless web/src or ask/scripts changes (then a "may be stale" badge appears).<br>' +
-        '<strong>Changes requested / Reject</strong> → suppresses stale alerts; this run is logged as known-not-ready.<br>' +
-        'Submitting never re-runs the test. Use the <em>New run</em> button when you want to retest.' +
-      '</p>' +
-    '</div>';
+      '<p class="help"><strong>Approve</strong> = stop nagging unless web/src or ask/scripts changes. ' +
+        '<strong>Changes / Reject</strong> = log as known-not-ready, suppress stale alerts. ' +
+        'Submitting never re-runs the test — that\\'s always explicit via <em>New run</em>.</p>';
   }
 
   // ----- mini-map flowchart (sticky) -----
   let miniMap = '';
-  const stories = r.stories || [];
-  if (stories.length) {
-    const allSteps = stories.flatMap(s => s.steps.map(st => ({ s, st })));
-    miniMap = '<div class="mini-map" id="mini-map">' +
-      '<div class="label">Where you are</div>' +
-      '<div class="nodes">' +
-        allSteps.map(({ s, st }, i) => {
-          const has = fb.some(x => x.storyPath === s.path && x.stepIdx === st.idx);
-          const arrow = i < allSteps.length - 1 ? '<div class="arrow"></div>' : '';
-          return '<div class="node' + (has ? ' has-fb' : '') + '" data-target="step-' + escape(s.path) + '-' + st.idx + '">' +
-              '<div class="dot">' + (st.idx+1) + '</div>' +
-              '<div class="cap">' + escape(st.title) + '</div>' +
-            '</div>' + arrow;
-        }).join('') +
-      '</div></div>';
+  if (allSteps.length) {
+    miniMap = '<div class="mini-map" id="mini-map"><div class="label">Where you are</div><div class="nodes">' +
+      allSteps.map(({ s, st }, i) => {
+        const count = fbCountFor(s.path, st.idx);
+        const isCurrent = i === slideIdx;
+        const isPassed = i < slideIdx;
+        const cls = ['node'];
+        if (isCurrent) cls.push('current');
+        if (isPassed) cls.push('passed');
+        const arrow = i < allSteps.length - 1 ? '<div class="arrow"></div>' : '';
+        return '<div class="' + cls.join(' ') + '" data-slide="' + i + '">' +
+            '<div class="dot">' + (st.idx+1) + '</div>' +
+            (count > 0 ? '<div class="fb-count" title="' + count + ' note' + (count===1?'':'s') + '">' + count + '</div>' : '') +
+            '<div class="cap">' + escape(st.title) + '</div>' +
+          '</div>' + arrow;
+      }).join('') +
+    '</div></div>';
   }
 
-  // ----- story timelines -----
-  let storyHtml = '';
-  for (const s of stories) {
-    storyHtml += '<div class="story panel" data-story-path="' + escape(s.path) + '">' +
-      '<h2>' + escape(s.title || s.testTitle) + '</h2>' +
-      (s.description ? '<p class="desc">' + escape(s.description) + '</p>' : '') +
-      '<div class="muted" style="margin-bottom:14px">' + s.steps.length + ' step' + (s.steps.length===1?'':'s') + '</div>' +
-      '<div class="timeline">' +
-        s.steps.map(st => {
-          const stepFb = fb.filter(x => x.storyPath === s.path && x.stepIdx === st.idx);
-          return '<div id="step-' + escape(s.path) + '-' + st.idx + '" class="step' + (stepFb.length ? ' has-fb' : '') + '" data-step="' + st.idx + '">' +
-            '<div class="head">' +
-              '<span class="num">' + String(st.idx+1).padStart(2,'0') + '</span>' +
-              '<span class="title">' + escape(st.title) + '</span>' +
-              '<span class="duration">' + st.durationMs + 'ms</span>' +
-            '</div>' +
-            (st.description ? '<p class="desc">' + escape(st.description) + '</p>' : '') +
-            (st.file ? '<img class="shot" loading="lazy" src="/runs/' + r.id + '/story/' + encodeURI(s.path) + '/' + encodeURI(st.file) + '" alt="' + escape(st.title) + '">' : '') +
-            '<div class="quick">' +
-              KINDS.map(k => '<button data-kind="' + k.id + '">' + k.icon + '<span>' + k.label + '</span></button>').join('') +
-              '<button data-kind="other">' + SVG.other + '<span>Comment</span></button>' +
-            '</div>' +
-            '<div class="fb-list">' +
-              stepFb.map(f => '<div class="fb-row">' +
-                '<span class="kind">' + (KINDS.find(k=>k.id===f.kind)?.icon ?? SVG.other) + escape(f.kind) + '</span>' +
-                '<span class="text">' + escape(f.text || '') + '</span>' +
-                '<span class="x" data-at="' + f.at + '" title="remove">' + SVG.remove + '</span>' +
-              '</div>').join('') +
-            '</div>' +
-          '</div>';
-        }).join('') +
-      '</div>' +
-    '</div>';
+  // ----- single-slide rendering (current step only) -----
+  let slideHtml = '';
+  if (allSteps.length) {
+    const { s, st } = allSteps[slideIdx];
+    const stepFb = fb.filter(x => x.storyPath === s.path && x.stepIdx === st.idx);
+    slideHtml =
+      (stories.length === 1
+        ? '<div class="story-info panel" style="margin-top:0;margin-bottom:0;border-bottom-left-radius:0;border-bottom-right-radius:0;border-bottom:0">' +
+            '<h2>' + escape(s.title || s.testTitle) + '</h2>' +
+            (s.description ? '<p class="desc">' + escape(s.description) + '</p>' : '') +
+          '</div>'
+        : '') +
+      '<div class="panel slide" style="margin-top:' + (stories.length === 1 ? '0' : '16px') + ';border-top-left-radius:' + (stories.length === 1 ? '0' : '8px') + ';border-top-right-radius:' + (stories.length === 1 ? '0' : '8px') + '" data-story-path="' + escape(s.path) + '" data-step="' + st.idx + '">' +
+        '<p class="step-meta">Step ' + (slideIdx+1) + ' of ' + allSteps.length + ' · ' + st.durationMs + 'ms</p>' +
+        '<h2 class="step-title">' + escape(st.title) + '</h2>' +
+        (st.description ? '<p class="step-desc">' + escape(st.description) + '</p>' : '') +
+        (st.file ? '<div class="step-shot-wrap"><img class="step-shot" src="/runs/' + r.id + '/story/' + encodeURI(s.path) + '/' + encodeURI(st.file) + '" alt="' + escape(st.title) + '"></div>' : '') +
+        '<div class="quick">' +
+          KINDS.map(k => '<button data-kind="' + k.id + '">' + k.icon + '<span>' + k.label + '</span></button>').join('') +
+          '<button data-kind="other">' + SVG.other + '<span>Comment</span></button>' +
+        '</div>' +
+        '<div class="fb-list">' +
+          stepFb.map(f => '<div class="fb-row">' +
+            '<span class="kind">' + (KINDS.find(k=>k.id===f.kind)?.icon ?? SVG.other) + escape(f.kind) + '</span>' +
+            '<span class="text">' + escape(f.text || '') + '</span>' +
+            '<span class="x" data-at="' + f.at + '" title="remove">' + SVG.remove + '</span>' +
+          '</div>').join('') +
+        '</div>' +
+        '<div class="slide-nav">' +
+          '<button id="prev"' + (slideIdx === 0 ? ' disabled' : '') + '>' + SVG.arrowLeft + '<span>Previous</span></button>' +
+          '<span class="step-counter">' + (slideIdx+1) + ' / ' + allSteps.length + '   ·   ← / → to navigate</span>' +
+          '<button id="next"' + (slideIdx === allSteps.length-1 ? ' disabled' : '') + '><span>Next</span>' + SVG.arrowRight + '</button>' +
+        '</div>' +
+      '</div>';
   }
 
   // ----- ad-hoc shots (fallback for specs that don't use story()) -----
@@ -669,34 +699,41 @@ async function renderDetail(id) {
       '<p class="meta">' + escape(r.spec || '(all specs)').replace(/^e2e\\//,'') + ' · ' + r.id + ' · started ' + ago(r.startedAt) + ' · ' + passedBadge + staleBadge + '</p>' +
     '</div>' +
     miniMap +
-    reviewSection +
-    storyHtml +
+    slideHtml +
     shotsHtml +
-    '<details' + (r.exitCode === 0 ? '' : ' open') + '><summary style="cursor:pointer" class="muted">Output</summary>' +
+    (reviewBody ? '<div class="review-sticky" id="review-sticky">' + reviewBody + '</div>' : '') +
+    '<details' + (r.exitCode === 0 ? '' : ' open') + ' style="margin-top:16px"><summary style="cursor:pointer" class="muted">Output</summary>' +
       '<pre class="output" id="run-output">' + escape(r.output ?? '') + '</pre></details>';
 
   // image lightbox
-  view.querySelectorAll('img.shot, figure img').forEach(img => {
+  view.querySelectorAll('img.step-shot, figure img').forEach(img => {
     img.addEventListener('click', () => { lightboxImg.src = img.src; lightbox.showModal(); });
   });
-  // mini-map: click → scroll, scroll → highlight current
-  const miniNodes = view.querySelectorAll('.mini-map .node');
-  miniNodes.forEach(n => {
-    n.addEventListener('click', () => {
-      const tgt = document.getElementById(n.dataset.target);
-      if (tgt) tgt.scrollIntoView({ behavior: 'smooth', block: 'start' });
-    });
-  });
-  if (miniNodes.length) {
-    const observer = new IntersectionObserver((entries) => {
-      entries.forEach(e => {
-        if (!e.isIntersecting) return;
-        const id = e.target.id;
-        miniNodes.forEach(n => n.classList.toggle('current', n.dataset.target === id));
-      });
-    }, { rootMargin: '-150px 0px -60% 0px', threshold: 0 });
-    view.querySelectorAll('.step[id]').forEach(s => observer.observe(s));
+
+  // ----- slideshow navigation -----
+  function goTo(i) {
+    if (i < 0 || i >= allSteps.length) return;
+    sessionStorage.setItem(slideKey, String(i));
+    renderDetail(r.id);
   }
+  view.querySelectorAll('.mini-map .node').forEach(n => {
+    n.addEventListener('click', () => goTo(parseInt(n.dataset.slide, 10)));
+  });
+  const prevBtn = document.getElementById('prev');
+  const nextBtn = document.getElementById('next');
+  if (prevBtn) prevBtn.addEventListener('click', () => goTo(slideIdx - 1));
+  if (nextBtn) nextBtn.addEventListener('click', () => goTo(slideIdx + 1));
+  // Keyboard: ← / → only fire when no input/textarea is focused
+  const keyHandler = (ev) => {
+    const tag = (document.activeElement?.tagName || '').toUpperCase();
+    if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return;
+    if (ev.key === 'ArrowRight') { ev.preventDefault(); goTo(slideIdx + 1); }
+    if (ev.key === 'ArrowLeft')  { ev.preventDefault(); goTo(slideIdx - 1); }
+  };
+  // Replace any prior listener so we don't stack them across renders
+  if (window.__askKeyHandler) window.removeEventListener('keydown', window.__askKeyHandler);
+  window.__askKeyHandler = keyHandler;
+  window.addEventListener('keydown', keyHandler);
   // review submit / reopen
   view.querySelectorAll('button[data-decision]').forEach(b => {
     b.addEventListener('click', async () => {
@@ -713,35 +750,34 @@ async function renderDetail(id) {
     await fetch('/api/runs/' + r.id + '/review', { method: 'DELETE' });
     renderDetail(r.id);
   });
-  // per-step quick-tag handlers
-  view.querySelectorAll('.story').forEach(storyEl => {
-    const storyPath = storyEl.dataset.storyPath;
-    storyEl.querySelectorAll('.step').forEach(stepEl => {
-      const stepIdx = parseInt(stepEl.dataset.step, 10);
-      stepEl.querySelectorAll('button[data-kind]').forEach(btn => {
-        btn.addEventListener('click', async () => {
-          const kind = btn.dataset.kind;
-          let text = '';
-          if (kind === 'other' || kind === 'bug' || kind === 'confusing') {
-            text = prompt('Add a note (optional):') ?? '';
-            if (kind === 'other' && !text) return;
-          }
-          await fetch('/api/runs/' + r.id + '/feedback', {
-            method: 'POST', headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ storyPath, stepIdx, kind, text }),
-          });
-          renderDetail(r.id);
+  // per-step quick-tag handlers (slide is the active step container)
+  const slideEl = view.querySelector('.slide');
+  if (slideEl) {
+    const storyPath = slideEl.dataset.storyPath;
+    const stepIdx = parseInt(slideEl.dataset.step, 10);
+    slideEl.querySelectorAll('button[data-kind]').forEach(btn => {
+      btn.addEventListener('click', async () => {
+        const kind = btn.dataset.kind;
+        let text = '';
+        if (kind === 'other' || kind === 'bug' || kind === 'confusing') {
+          text = prompt('Add a note (optional):') ?? '';
+          if (kind === 'other' && !text) return;
+        }
+        await fetch('/api/runs/' + r.id + '/feedback', {
+          method: 'POST', headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ storyPath, stepIdx, kind, text }),
         });
-      });
-      stepEl.querySelectorAll('.fb-row .x').forEach(x => {
-        x.addEventListener('click', async () => {
-          const at = parseInt(x.dataset.at, 10);
-          await fetch('/api/runs/' + r.id + '/feedback?at=' + at, { method: 'DELETE' });
-          renderDetail(r.id);
-        });
+        renderDetail(r.id);
       });
     });
-  });
+    slideEl.querySelectorAll('.fb-row .x').forEach(x => {
+      x.addEventListener('click', async () => {
+        const at = parseInt(x.dataset.at, 10);
+        await fetch('/api/runs/' + r.id + '/feedback?at=' + at, { method: 'DELETE' });
+        renderDetail(r.id);
+      });
+    });
+  }
 }
 
 // ---------- routing -------------------------------------------------------

--- a/web/scripts/review-server.ts
+++ b/web/scripts/review-server.ts
@@ -215,7 +215,8 @@ function freezeScreenshots(runId: string, since: number): number {
 }
 
 interface StartRunOpts {
-  spec: string
+  spec?: string             // single spec (legacy)
+  specs?: string[]          // many specs (plan-aware multi-case runs)
   planId?: string
   scope?: 'all' | { caseIds: string[] }
 }
@@ -224,9 +225,10 @@ function startRun(opts: StartRunOpts | string): Run | null {
   // Back-compat: accept legacy string spec arg
   const o: StartRunOpts = typeof opts === 'string' ? { spec: opts } : opts
   if (currentRunId) return null
+  const allSpecs = o.specs && o.specs.length ? o.specs : (o.spec ? [o.spec] : [])
   const run: Run = {
     id: newRunId(),
-    spec: o.spec,
+    spec: allSpecs.length === 1 ? allSpecs[0] : allSpecs.join(' '),
     startedAt: Date.now(),
     endedAt: null,
     exitCode: null,
@@ -262,8 +264,7 @@ function startRun(opts: StartRunOpts | string): Run | null {
   currentOutput = ''
   broadcast('started', { id: run.id })
 
-  const args = ['playwright', 'test']
-  if (o.spec) args.push(o.spec)
+  const args = ['playwright', 'test', ...allSpecs]
   const child = spawn('npx', args, { cwd: WEB, env: { ...process.env, FORCE_COLOR: '0' } })
   const onChunk = (d: Buffer) => {
     const s = d.toString()
@@ -1886,12 +1887,7 @@ const server = http.createServer(async (req, res) => {
         .filter(c => !wantedIds || wantedIds.has(c.id))
         .map(c => `e2e/${c.spec}`)
       if (!specs.length) { res.writeHead(400); res.end(JSON.stringify({ error: 'no implemented cases match the scope' })); return }
-      // Phase 1: if multiple specs, Playwright runs them all in one invocation
-      // when we omit the spec arg and let it match by directory. For now we
-      // accept the case where a single case is selected; multi-spec runs use
-      // an empty spec arg so Playwright runs the project default.
-      const spec = specs.length === 1 ? specs[0] : ''
-      const run = startRun({ spec, planId: plan.id, scope })
+      const run = startRun({ specs, planId: plan.id, scope })
       if (!run) { res.writeHead(409); res.end(JSON.stringify({ error: 'a run is already in progress' })); return }
       res.writeHead(202, { 'Content-Type': 'application/json' })
       res.end(JSON.stringify({ id: run.id }))

--- a/web/scripts/review-server.ts
+++ b/web/scripts/review-server.ts
@@ -784,6 +784,15 @@ const HTML = `<!doctype html>
   .thumb .cap { padding: 6px 7px; font-size: 11px; color: var(--text); line-height: 1.25; max-height: 30px; overflow: hidden; text-overflow: ellipsis; }
   .surface-pill { font-size: 10px; padding: 1px 6px; border-radius: 4px; background: var(--pill-bg); color: var(--muted); text-transform: uppercase; letter-spacing: 0.04em; }
   .deps-line code { background: var(--code-bg); padding: 1px 5px; border-radius: 3px; font-size: 11px; margin-right: 4px; }
+  /* manual-run capture targets — placeholder thumbs become drop/paste targets */
+  .thumb.placeholder.capture-target { border-style: dashed; border-color: var(--primary); }
+  .thumb.placeholder.capture-target .img { background: linear-gradient(135deg, rgba(0,102,204,0.06), rgba(0,102,204,0.12)); }
+  .thumb.placeholder.capture-target .img::after { content: 'drop / paste'; font-size: 9px; color: var(--primary); margin-top: 4px; }
+  .thumb.placeholder.dragover { background: var(--primary); }
+  .thumb.placeholder.dragover .img { background: rgba(0,102,204,0.25); }
+  .thumb.uploading .img::after { content: 'uploading…'; }
+  .capture-banner { background: var(--code-bg); border: 1px solid var(--border); border-radius: 8px; padding: 10px 14px; margin: 0 0 12px; font-size: 13px; display: flex; align-items: center; gap: 12px; flex-wrap: wrap; }
+  .capture-banner kbd { background: var(--panel); border: 1px solid var(--border); border-bottom-width: 2px; border-radius: 3px; padding: 1px 5px; font-family: ui-monospace, monospace; font-size: 11px; }
 </style>
 </head>
 <body data-theme="light">
@@ -1868,6 +1877,105 @@ async function renderRunRollup(planId, runId) {
       location.hash = '#/plan/' + planId + '/run/' + runId + '/' + cid;
     });
   });
+
+  // ===== Manual-capture wiring =====
+  // For runs that haven't finished and were created from cases with a
+  // computer-use driver, turn each placeholder thumb into a drop/paste
+  // target. Captured images are POSTed to the step ingest endpoint.
+  const isOpenManual = run.exitCode === null && run.status === 'running';
+  const manualCases = (run.caseResults || []).filter(c => {
+    const pc = planCases.get(c.caseId);
+    return pc && pc.driver === 'computer-use';
+  });
+  if (isOpenManual && manualCases.length) {
+    // Banner above the gallery
+    const banner = document.createElement('div');
+    banner.className = 'capture-banner';
+    banner.innerHTML =
+      '<strong>Manual capture:</strong> capture a screenshot with ' +
+      '<kbd>⌘⇧4</kbd> (selection → file) or <kbd>⌘⇧⌃4</kbd> (selection → clipboard), ' +
+      'then drop the file or paste with <kbd>⌘V</kbd> on the matching step. ' +
+      '<button id="finish-run" class="primary" style="margin-left:auto;font-size:12px">Finish run</button>';
+    view.querySelector('.gallery').before(banner);
+
+    view.querySelectorAll('.gallery .card').forEach(card => {
+      const caseId = card.dataset.caseid;
+      const planCase = manualCases.find(c => c.caseId === caseId);
+      if (!planCase) return;
+      const declared = planCases.get(caseId)?.steps || [];
+      card.querySelectorAll('.thumb.placeholder').forEach(thumb => {
+        thumb.classList.add('capture-target');
+        const stepIdx = parseInt(thumb.dataset.step, 10);
+        const stepDecl = declared[stepIdx];
+
+        const upload = async (file) => {
+          if (!file || !file.type.startsWith('image/')) return;
+          thumb.classList.add('uploading');
+          const reader = new FileReader();
+          reader.onload = async () => {
+            const dataUrl = reader.result;
+            const b64 = dataUrl.split(',')[1];
+            await fetch('/api/runs/' + runId + '/cases/' + caseId + '/step', {
+              method: 'POST', headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({
+                idx: stepIdx,
+                title: stepDecl?.title ?? ('Step ' + (stepIdx + 1)),
+                description: stepDecl?.description ?? '',
+                image_b64: b64,
+              }),
+            });
+            // Reload the run rollup so the captured thumb swaps in
+            renderRunRollup(planId, runId);
+          };
+          reader.readAsDataURL(file);
+        };
+
+        // Drag and drop
+        thumb.addEventListener('dragover', (ev) => {
+          ev.preventDefault();
+          thumb.classList.add('dragover');
+        });
+        thumb.addEventListener('dragleave', () => thumb.classList.remove('dragover'));
+        thumb.addEventListener('drop', (ev) => {
+          ev.preventDefault();
+          ev.stopPropagation();
+          thumb.classList.remove('dragover');
+          const file = ev.dataTransfer.files?.[0];
+          if (file) upload(file);
+        });
+
+        // Click to focus, then paste with Cmd+V
+        thumb.addEventListener('click', (ev) => {
+          ev.stopPropagation();
+          thumb.tabIndex = 0;
+          thumb.focus();
+          thumb.style.outline = '2px solid var(--primary)';
+        });
+        thumb.addEventListener('blur', () => { thumb.style.outline = ''; });
+        thumb.addEventListener('paste', (ev) => {
+          const items = ev.clipboardData?.items || [];
+          for (const it of items) {
+            if (it.kind === 'file' && it.type.startsWith('image/')) {
+              ev.preventDefault();
+              const file = it.getAsFile();
+              if (file) upload(file);
+              return;
+            }
+          }
+        });
+      });
+    });
+
+    document.getElementById('finish-run').addEventListener('click', async () => {
+      await fetch('/api/runs/' + runId + '/finish', {
+        method: 'POST', headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ exitCode: 0 }),
+      });
+      // SSE 'done' will fire and route() — this view stays meaningful since
+      // the slideshow now has captured images.
+      renderRunRollup(planId, runId);
+    });
+  }
 }
 
 async function renderCaseDetail(planId, caseId) {

--- a/web/scripts/review-server.ts
+++ b/web/scripts/review-server.ts
@@ -1,17 +1,18 @@
 /**
- * Tiny review dashboard for the e2e screenshots + test runs.
+ * Ask · review dashboard
  *
- * Start with: cd web && npm run review
+ * Landing page: every test run as a row (status, spec, time, shots, review note).
+ * Click a run → frozen screenshots, run output, and a review form to mark it
+ * reviewed with a summary + decision.
  *
- * Serves:
- *   GET  /                       → HTML dashboard (auto-refreshes when shots change)
- *   GET  /api/screenshots        → JSON listing of e2e/screenshots/**
- *   GET  /api/specs              → JSON listing of e2e/*.spec.ts
- *   POST /api/run                → body: { spec: string | "" }   →  runs playwright test
- *   GET  /api/output             → SSE stream of the most recent run's stdout
- *   GET  /shots/<relpath>        → serves a PNG out of e2e/screenshots/
+ * Data lives under web/.review/:
+ *   runs.json                    – array of run metadata (newest first)
+ *   runs/<id>/output.txt         – captured stdout/stderr
+ *   runs/<id>/screenshots/...    – frozen copy of the screenshots that PR
+ *                                  produced (so historical runs survive
+ *                                  re-runs that overwrite e2e/screenshots/)
  *
- * Fully dependency-light — uses Node's built-in http + fs and `npx playwright`.
+ * Run with: cd web && npm run review   →   http://localhost:4244
  */
 import http from 'http'
 import fs from 'fs'
@@ -23,53 +24,133 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const WEB = path.resolve(__dirname, '..')
 const SHOTS = path.join(WEB, 'e2e', 'screenshots')
 const E2E = path.join(WEB, 'e2e')
+const REVIEW = path.join(WEB, '.review')
+const RUNS_DIR = path.join(REVIEW, 'runs')
+const RUNS_JSON = path.join(REVIEW, 'runs.json')
+fs.mkdirSync(RUNS_DIR, { recursive: true })
 
 const PORT = parseInt(process.env.REVIEW_PORT ?? '4244', 10)
 
-// --- in-memory state for the latest run -----------------------------------
-let runOutput = ''
-let runRunning = false
-const sseClients: http.ServerResponse[] = []
+// ---------- types ---------------------------------------------------------
+interface Review {
+  summary: string
+  decision: 'approved' | 'changes-requested' | 'rejected'
+  reviewedAt: number
+}
+interface Run {
+  id: string
+  spec: string                  // '' = all specs
+  startedAt: number
+  endedAt: number | null
+  exitCode: number | null
+  screenshotCount: number
+  status: 'running' | 'awaiting-review' | 'reviewed'
+  review: Review | null
+}
 
-function broadcast(line: string) {
-  runOutput += line
-  const payload = `data: ${JSON.stringify({ line })}\n\n`
+function loadRuns(): Run[] {
+  try { return JSON.parse(fs.readFileSync(RUNS_JSON, 'utf-8')) as Run[] }
+  catch { return [] }
+}
+function saveRuns(runs: Run[]) {
+  fs.writeFileSync(RUNS_JSON, JSON.stringify(runs, null, 2))
+}
+function getRun(id: string): Run | undefined {
+  return loadRuns().find(r => r.id === id)
+}
+function updateRun(id: string, patch: Partial<Run>): Run | undefined {
+  const runs = loadRuns()
+  const i = runs.findIndex(r => r.id === id)
+  if (i < 0) return
+  runs[i] = { ...runs[i], ...patch }
+  saveRuns(runs)
+  return runs[i]
+}
+function newRunId(): string {
+  const d = new Date()
+  const pad = (n: number) => String(n).padStart(2, '0')
+  return `${d.getFullYear()}${pad(d.getMonth()+1)}${pad(d.getDate())}-${pad(d.getHours())}${pad(d.getMinutes())}${pad(d.getSeconds())}`
+}
+
+// ---------- run state -----------------------------------------------------
+let currentRunId: string | null = null
+let currentOutput = ''
+const sseClients: http.ServerResponse[] = []
+function broadcast(event: 'line' | 'done' | 'started', data: object) {
+  const payload = `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`
   for (const c of sseClients) { try { c.write(payload) } catch { /* drop */ } }
 }
 
-function runPlaywright(specRel: string | '') {
-  if (runRunning) return false
-  runRunning = true
-  runOutput = ''
-  broadcast(`$ npx playwright test ${specRel || '(all)'}\n`)
-  const args = ['playwright', 'test']
-  if (specRel) args.push(specRel)
-  const child = spawn('npx', args, { cwd: WEB, env: { ...process.env, FORCE_COLOR: '0' } })
-  child.stdout.on('data', (d: Buffer) => broadcast(d.toString()))
-  child.stderr.on('data', (d: Buffer) => broadcast(d.toString()))
-  child.on('close', (code) => {
-    broadcast(`\n[exit ${code}]\n`)
-    runRunning = false
-  })
-  return true
+function listShots(dir: string): string[] {
+  if (!fs.existsSync(dir)) return []
+  const out: string[] = []
+  ;(function walk(d: string) {
+    for (const e of fs.readdirSync(d, { withFileTypes: true })) {
+      const p = path.join(d, e.name)
+      if (e.isDirectory()) walk(p)
+      else if (/\.(png|jpe?g)$/i.test(e.name)) out.push(p)
+    }
+  })(dir)
+  return out
 }
 
-// --- file scanning --------------------------------------------------------
-function listScreenshots(): { rel: string; size: number; mtime: number }[] {
-  if (!fs.existsSync(SHOTS)) return []
-  const out: { rel: string; size: number; mtime: number }[] = []
-  function walk(dir: string) {
-    for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
-      const p = path.join(dir, e.name)
-      if (e.isDirectory()) walk(p)
-      else if (/\.(png|jpe?g)$/i.test(e.name)) {
-        const st = fs.statSync(p)
-        out.push({ rel: path.relative(SHOTS, p), size: st.size, mtime: st.mtimeMs })
-      }
-    }
+function freezeScreenshots(runId: string, since: number): number {
+  const dest = path.join(RUNS_DIR, runId, 'screenshots')
+  fs.mkdirSync(dest, { recursive: true })
+  let n = 0
+  for (const src of listShots(SHOTS)) {
+    const st = fs.statSync(src)
+    if (st.mtimeMs < since) continue
+    const rel = path.relative(SHOTS, src)
+    const dst = path.join(dest, rel)
+    fs.mkdirSync(path.dirname(dst), { recursive: true })
+    fs.copyFileSync(src, dst)
+    n++
   }
-  walk(SHOTS)
-  return out.sort((a, b) => b.mtime - a.mtime)
+  return n
+}
+
+function startRun(spec: string): Run | null {
+  if (currentRunId) return null
+  const run: Run = {
+    id: newRunId(),
+    spec,
+    startedAt: Date.now(),
+    endedAt: null,
+    exitCode: null,
+    screenshotCount: 0,
+    status: 'running',
+    review: null,
+  }
+  fs.mkdirSync(path.join(RUNS_DIR, run.id), { recursive: true })
+  saveRuns([run, ...loadRuns()])
+  currentRunId = run.id
+  currentOutput = ''
+  broadcast('started', { id: run.id })
+
+  const args = ['playwright', 'test']
+  if (spec) args.push(spec)
+  const child = spawn('npx', args, { cwd: WEB, env: { ...process.env, FORCE_COLOR: '0' } })
+  const onChunk = (d: Buffer) => {
+    const s = d.toString()
+    currentOutput += s
+    broadcast('line', { line: s })
+  }
+  child.stdout.on('data', onChunk)
+  child.stderr.on('data', onChunk)
+  child.on('close', (code) => {
+    const screenshotCount = freezeScreenshots(run.id, run.startedAt)
+    fs.writeFileSync(path.join(RUNS_DIR, run.id, 'output.txt'), currentOutput)
+    updateRun(run.id, {
+      endedAt: Date.now(),
+      exitCode: code,
+      screenshotCount,
+      status: 'awaiting-review',
+    })
+    currentRunId = null
+    broadcast('done', { id: run.id, exitCode: code, screenshotCount })
+  })
+  return run
 }
 
 function listSpecs(): string[] {
@@ -79,7 +160,23 @@ function listSpecs(): string[] {
     .map(n => path.join('e2e', n))
 }
 
-// --- HTML page ------------------------------------------------------------
+function listFrozenShots(runId: string): { rel: string; size: number }[] {
+  const root = path.join(RUNS_DIR, runId, 'screenshots')
+  if (!fs.existsSync(root)) return []
+  const out: { rel: string; size: number }[] = []
+  ;(function walk(d: string) {
+    for (const e of fs.readdirSync(d, { withFileTypes: true })) {
+      const p = path.join(d, e.name)
+      if (e.isDirectory()) walk(p)
+      else if (/\.(png|jpe?g)$/i.test(e.name)) {
+        out.push({ rel: path.relative(root, p), size: fs.statSync(p).size })
+      }
+    }
+  })(root)
+  return out.sort((a, b) => a.rel.localeCompare(b.rel))
+}
+
+// ---------- HTML page (SPA with hash routing) -----------------------------
 const HTML = `<!doctype html>
 <html lang="en"><head>
 <meta charset="utf-8">
@@ -90,24 +187,47 @@ const HTML = `<!doctype html>
   body { margin: 0; font: 14px/1.4 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; background: #0b0b0c; color: #eee; }
   header { position: sticky; top: 0; z-index: 10; padding: 12px 16px; background: #111; border-bottom: 1px solid #2a2a2a; display: flex; gap: 12px; align-items: center; flex-wrap: wrap; }
   header h1 { font-size: 14px; margin: 0; font-weight: 600; }
+  header h1 a { color: inherit; text-decoration: none; }
   header .right { margin-left: auto; display: flex; gap: 8px; align-items: center; }
-  select, button { background: #1a1a1c; color: #eee; border: 1px solid #333; border-radius: 6px; padding: 6px 10px; font: inherit; cursor: pointer; }
+  select, button, input, textarea { background: #1a1a1c; color: #eee; border: 1px solid #333; border-radius: 6px; padding: 6px 10px; font: inherit; }
+  button { cursor: pointer; }
   select:hover, button:hover { background: #222226; }
-  button.primary { background: #0066cc; border-color: #0066cc; }
+  button.primary { background: #0066cc; border-color: #0066cc; color: #fff; }
   button.primary:hover { background: #0077ee; }
+  button.danger { background: #6b1a1a; border-color: #6b1a1a; color: #fff; }
+  button.success { background: #1d6f1d; border-color: #1d6f1d; color: #fff; }
   button:disabled { opacity: 0.5; cursor: not-allowed; }
   main { padding: 16px; }
   .group { margin-bottom: 24px; }
   .group h2 { font-size: 12px; color: #888; text-transform: uppercase; letter-spacing: 0.06em; margin: 0 0 8px; font-weight: 600; }
+  table { width: 100%; border-collapse: collapse; }
+  table th, table td { padding: 10px 12px; text-align: left; border-bottom: 1px solid #1f1f22; vertical-align: top; }
+  table th { font-size: 11px; color: #888; text-transform: uppercase; letter-spacing: 0.06em; font-weight: 600; }
+  table tr:hover td { background: #14141a; }
+  table tr.clickable { cursor: pointer; }
   .grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(360px, 1fr)); gap: 12px; }
   figure { margin: 0; background: #131316; border: 1px solid #262629; border-radius: 8px; overflow: hidden; }
   figure img { display: block; width: 100%; cursor: zoom-in; background: #000; }
   figcaption { padding: 6px 10px; font-size: 11px; color: #999; display: flex; justify-content: space-between; }
-  pre.output { background: #0a0a0c; border: 1px solid #2a2a2a; border-radius: 6px; padding: 10px; max-height: 300px; overflow: auto; font: 11px/1.4 ui-monospace,monospace; white-space: pre-wrap; }
-  .empty { color: #666; padding: 20px; text-align: center; }
-  .badge { padding: 2px 6px; background: #2a2a2c; border-radius: 4px; font-size: 11px; }
-  .badge.running { background: #0a4d0a; }
-  a { color: #4aa3ff; }
+  pre.output { background: #0a0a0c; border: 1px solid #2a2a2a; border-radius: 6px; padding: 10px; max-height: 280px; overflow: auto; font: 11px/1.4 ui-monospace,monospace; white-space: pre-wrap; }
+  .empty { color: #666; padding: 28px; text-align: center; }
+  .badge { padding: 2px 8px; border-radius: 4px; font-size: 11px; font-weight: 600; display: inline-block; }
+  .badge.running { background: #0a4d0a; color: #afe9af; }
+  .badge.awaiting { background: #4d3d0a; color: #f5d77a; }
+  .badge.reviewed { background: #0a3a4d; color: #a4d8ee; }
+  .badge.passed { background: #0a4d0a; color: #afe9af; }
+  .badge.failed { background: #4d0a0a; color: #ee9c9c; }
+  .decision-approved { color: #afe9af; }
+  .decision-changes-requested { color: #f5d77a; }
+  .decision-rejected { color: #ee9c9c; }
+  a { color: #4aa3ff; text-decoration: none; }
+  a:hover { text-decoration: underline; }
+  textarea { width: 100%; min-height: 80px; resize: vertical; font-family: inherit; }
+  .review-form { background: #131316; border: 1px solid #262629; border-radius: 8px; padding: 14px; margin: 16px 0; }
+  .review-form .row { display: flex; gap: 10px; align-items: center; margin-top: 10px; }
+  .review-existing { background: #131316; border: 1px solid #262629; border-radius: 8px; padding: 14px; margin: 16px 0; }
+  .review-existing h3 { margin: 0 0 6px; font-size: 13px; color: #aaa; }
+  .review-existing p { margin: 0; white-space: pre-wrap; }
   /* Lightbox */
   dialog { background: rgba(0,0,0,0.95); border: none; max-width: 100vw; max-height: 100vh; padding: 0; }
   dialog img { max-width: 100vw; max-height: 100vh; display: block; cursor: zoom-out; }
@@ -116,33 +236,40 @@ const HTML = `<!doctype html>
 </head>
 <body>
 <header>
-  <h1>Ask · review</h1>
+  <h1><a href="#/">Ask · review</a></h1>
   <span id="status" class="badge">idle</span>
   <div class="right">
-    <select id="spec">
-      <option value="">All specs</option>
-    </select>
-    <button id="run" class="primary">Run</button>
+    <select id="spec"><option value="">All specs</option></select>
+    <button id="run" class="primary">New run</button>
     <a href="http://localhost:5173/dev/markdown" target="_blank"><button>/dev/markdown ↗</button></a>
     <a href="http://localhost:5173/" target="_blank"><button>app ↗</button></a>
   </div>
 </header>
-<main>
-  <pre id="output" class="output" hidden></pre>
-  <div id="shots"></div>
-</main>
+<main id="view"></main>
 <dialog id="lightbox"><img alt=""></dialog>
 <script>
+const view = document.getElementById('view');
 const specEl = document.getElementById('spec');
 const runEl = document.getElementById('run');
 const statusEl = document.getElementById('status');
-const outputEl = document.getElementById('output');
-const shotsEl = document.getElementById('shots');
 const lightbox = document.getElementById('lightbox');
 const lightboxImg = lightbox.querySelector('img');
-
 lightboxImg.addEventListener('click', () => lightbox.close());
 lightbox.addEventListener('click', (e) => { if (e.target === lightbox) lightbox.close(); });
+
+function ago(ms) {
+  const s = (Date.now() - ms) / 1000;
+  if (s < 60) return Math.round(s) + 's ago';
+  if (s < 3600) return Math.round(s/60) + 'm ago';
+  if (s < 86400) return Math.round(s/3600) + 'h ago';
+  return Math.round(s/86400) + 'd ago';
+}
+function fmt(bytes) {
+  if (bytes < 1024) return bytes + ' B';
+  if (bytes < 1024*1024) return (bytes/1024).toFixed(1) + ' KB';
+  return (bytes/1024/1024).toFixed(1) + ' MB';
+}
+function escape(s) { return String(s).replace(/[&<>]/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;'}[c])); }
 
 async function loadSpecs() {
   const r = await fetch('/api/specs').then(r => r.json());
@@ -153,101 +280,186 @@ async function loadSpecs() {
   }
 }
 
-function fmt(bytes) {
-  if (bytes < 1024) return bytes + ' B';
-  if (bytes < 1024*1024) return (bytes / 1024).toFixed(1) + ' KB';
-  return (bytes / 1024 / 1024).toFixed(1) + ' MB';
+// ---------- list view -----------------------------------------------------
+async function renderList() {
+  const runs = await fetch('/api/runs').then(r => r.json());
+  if (!runs.length) {
+    view.innerHTML = '<div class="empty">No runs yet — pick a spec and hit "New run".</div>';
+    return;
+  }
+  const rows = runs.map(r => {
+    const passed = r.exitCode === 0;
+    const exitBadge = r.exitCode === null
+      ? '<span class="badge running">running</span>'
+      : passed ? '<span class="badge passed">passed</span>'
+               : '<span class="badge failed">failed</span>';
+    const statusBadge = '<span class="badge ' + (
+      r.status === 'running' ? 'running' :
+      r.status === 'reviewed' ? 'reviewed' :
+      'awaiting'
+    ) + '">' + r.status + '</span>';
+    const decision = r.review
+      ? '<span class="decision-' + r.review.decision + '">' + r.review.decision + '</span> · ' + escape(r.review.summary).slice(0, 80)
+      : '—';
+    return '<tr class="clickable" data-id="' + r.id + '">' +
+      '<td>' + ago(r.startedAt) + '<br><span style="color:#666;font-size:11px">' + r.id + '</span></td>' +
+      '<td>' + escape(r.spec || '(all specs)').replace(/^e2e\\//,'') + '</td>' +
+      '<td>' + exitBadge + '</td>' +
+      '<td>' + statusBadge + '</td>' +
+      '<td>' + r.screenshotCount + '</td>' +
+      '<td>' + decision + '</td>' +
+    '</tr>';
+  }).join('');
+  view.innerHTML =
+    '<table>' +
+      '<thead><tr><th>When</th><th>Spec</th><th>Result</th><th>Review</th><th>Shots</th><th>Decision · Summary</th></tr></thead>' +
+      '<tbody>' + rows + '</tbody>' +
+    '</table>';
+  view.querySelectorAll('tr.clickable').forEach(tr => {
+    tr.addEventListener('click', () => location.hash = '#/run/' + tr.dataset.id);
+  });
 }
 
-function ago(ms) {
-  const s = (Date.now() - ms) / 1000;
-  if (s < 60) return Math.round(s) + 's ago';
-  if (s < 3600) return Math.round(s/60) + 'm ago';
-  return Math.round(s/3600) + 'h ago';
-}
+// ---------- detail view ---------------------------------------------------
+async function renderDetail(id) {
+  const r = await fetch('/api/runs/' + id).then(r => r.json());
+  if (r.error) { view.innerHTML = '<div class="empty">Run not found.</div>'; return; }
+  const passedBadge = r.exitCode === null
+    ? '<span class="badge running">running</span>'
+    : r.exitCode === 0 ? '<span class="badge passed">passed</span>' : '<span class="badge failed">failed</span>';
 
-async function loadShots() {
-  const r = await fetch('/api/screenshots').then(r => r.json());
-  shotsEl.innerHTML = '';
-  if (!r.length) { shotsEl.innerHTML = '<p class="empty">No screenshots yet — pick a spec and hit Run.</p>'; return; }
-  // group by top directory
-  const groups = new Map();
-  for (const s of r) {
+  let reviewSection = '';
+  if (r.review) {
+    reviewSection = '<div class="review-existing">' +
+      '<h3>Review · <span class="decision-' + r.review.decision + '">' + r.review.decision + '</span> · ' + ago(r.review.reviewedAt) + '</h3>' +
+      '<p>' + escape(r.review.summary) + '</p>' +
+      '<div class="row"><button id="reopen">Reopen</button></div>' +
+    '</div>';
+  } else if (r.status !== 'running') {
+    reviewSection = '<div class="review-form">' +
+      '<h3 style="margin:0 0 8px;font-size:13px;color:#aaa">Mark this run reviewed</h3>' +
+      '<textarea id="summary" placeholder="What did you decide? What needs follow-up?"></textarea>' +
+      '<div class="row">' +
+        '<button class="success" data-decision="approved">Approve</button>' +
+        '<button data-decision="changes-requested">Changes requested</button>' +
+        '<button class="danger" data-decision="rejected">Reject</button>' +
+      '</div>' +
+    '</div>';
+  }
+
+  const shotGroups = new Map();
+  for (const s of r.screenshots) {
     const parts = s.rel.split('/');
     const g = parts.length > 1 ? parts[0] : '(root)';
-    if (!groups.has(g)) groups.set(g, []);
-    groups.get(g).push(s);
+    if (!shotGroups.has(g)) shotGroups.set(g, []);
+    shotGroups.get(g).push(s);
   }
-  for (const [g, items] of groups) {
-    const groupDiv = document.createElement('div');
-    groupDiv.className = 'group';
-    const h = document.createElement('h2'); h.textContent = g + ' — ' + items.length; groupDiv.appendChild(h);
-    const grid = document.createElement('div'); grid.className = 'grid';
-    for (const s of items) {
-      const fig = document.createElement('figure');
-      const img = document.createElement('img');
-      img.src = '/shots/' + encodeURI(s.rel) + '?t=' + s.mtime;
-      img.loading = 'lazy';
-      img.alt = s.rel;
-      img.addEventListener('click', () => { lightboxImg.src = img.src; lightbox.showModal(); });
-      const cap = document.createElement('figcaption');
-      cap.innerHTML = '<span>' + s.rel.split('/').pop() + '</span><span>' + fmt(s.size) + ' · ' + ago(s.mtime) + '</span>';
-      fig.appendChild(img); fig.appendChild(cap);
-      grid.appendChild(fig);
+  let shotsHtml = '';
+  if (!r.screenshots.length) {
+    shotsHtml = '<div class="empty">This run captured no screenshots.</div>';
+  } else {
+    for (const [g, items] of shotGroups) {
+      shotsHtml += '<div class="group"><h2>' + escape(g) + ' — ' + items.length + '</h2><div class="grid">' +
+        items.map(s =>
+          '<figure><img loading="lazy" src="/runs/' + r.id + '/shots/' + encodeURI(s.rel) + '" alt="' + escape(s.rel) + '" />' +
+          '<figcaption><span>' + escape(s.rel.split("/").pop()) + '</span><span>' + fmt(s.size) + '</span></figcaption></figure>'
+        ).join('') + '</div></div>';
     }
-    groupDiv.appendChild(grid);
-    shotsEl.appendChild(groupDiv);
   }
+
+  view.innerHTML =
+    '<p style="margin:0 0 12px"><a href="#/">← all runs</a></p>' +
+    '<h2 style="margin:0 0 4px;font-size:16px">' + escape(r.spec || '(all specs)').replace(/^e2e\\//,'') + '</h2>' +
+    '<p style="margin:0 0 14px;color:#888;font-size:12px">' + r.id + ' · started ' + ago(r.startedAt) + ' · ' + passedBadge + '</p>' +
+    reviewSection +
+    '<details' + (r.exitCode === 0 ? '' : ' open') + '><summary style="cursor:pointer;color:#888;margin:8px 0;font-size:12px">Output</summary>' +
+      '<pre class="output" id="run-output">' + escape(r.output ?? '') + '</pre>' +
+    '</details>' +
+    shotsHtml;
+
+  view.querySelectorAll('figure img').forEach(img => {
+    img.addEventListener('click', () => { lightboxImg.src = img.src; lightbox.showModal(); });
+  });
+  view.querySelectorAll('button[data-decision]').forEach(b => {
+    b.addEventListener('click', async () => {
+      const summary = (document.getElementById('summary')).value.trim() || '(no notes)';
+      await fetch('/api/runs/' + r.id + '/review', {
+        method: 'POST', headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ summary, decision: b.dataset.decision }),
+      });
+      renderDetail(r.id);
+    });
+  });
+  const reopen = document.getElementById('reopen');
+  if (reopen) reopen.addEventListener('click', async () => {
+    await fetch('/api/runs/' + r.id + '/review', { method: 'DELETE' });
+    renderDetail(r.id);
+  });
 }
 
+// ---------- routing -------------------------------------------------------
+function route() {
+  const m = location.hash.match(/^#\\/run\\/(.+)$/);
+  if (m) renderDetail(m[1]); else renderList();
+}
+window.addEventListener('hashchange', route);
+
+// ---------- run controls --------------------------------------------------
 runEl.addEventListener('click', async () => {
-  outputEl.hidden = false;
-  outputEl.textContent = '';
-  statusEl.textContent = 'running…'; statusEl.className = 'badge running';
-  runEl.disabled = true;
-  await fetch('/api/run', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ spec: specEl.value }) });
+  const r = await fetch('/api/run', {
+    method: 'POST', headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ spec: specEl.value }),
+  }).then(r => r.json());
+  if (r.id) location.hash = '#/run/' + r.id;
 });
 
 const es = new EventSource('/api/output');
+es.addEventListener('started', () => { statusEl.textContent = 'running…'; statusEl.className = 'badge running'; runEl.disabled = true; });
 es.addEventListener('line', (e) => {
-  const { line } = JSON.parse(e.data);
-  outputEl.hidden = false;
-  outputEl.textContent += line;
-  outputEl.scrollTop = outputEl.scrollHeight;
+  const out = document.getElementById('run-output');
+  if (out) { out.textContent += JSON.parse(e.data).line; out.scrollTop = out.scrollHeight; }
 });
 es.addEventListener('done', () => {
   statusEl.textContent = 'idle'; statusEl.className = 'badge';
   runEl.disabled = false;
-  loadShots();
+  route();   // reload current view (list or detail) so new shots appear
 });
 
 loadSpecs();
-loadShots();
-setInterval(loadShots, 5000);
+route();
+setInterval(() => { if (!location.hash.startsWith('#/run/')) renderList(); }, 5000);
 </script>
 </body></html>`
 
-// --- HTTP server ----------------------------------------------------------
+// ---------- HTTP server ---------------------------------------------------
 const server = http.createServer(async (req, res) => {
   const url = new URL(req.url ?? '/', `http://localhost:${PORT}`)
   const p = url.pathname
 
   if (p === '/' && req.method === 'GET') {
     res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' })
-    res.end(HTML)
-    return
+    res.end(HTML); return
   }
 
   if (p === '/api/specs' && req.method === 'GET') {
     res.writeHead(200, { 'Content-Type': 'application/json' })
-    res.end(JSON.stringify(listSpecs()))
-    return
+    res.end(JSON.stringify(listSpecs())); return
   }
 
-  if (p === '/api/screenshots' && req.method === 'GET') {
+  if (p === '/api/runs' && req.method === 'GET') {
     res.writeHead(200, { 'Content-Type': 'application/json' })
-    res.end(JSON.stringify(listScreenshots()))
-    return
+    res.end(JSON.stringify(loadRuns())); return
+  }
+
+  const runDetail = p.match(/^\/api\/runs\/([^/]+)$/)
+  if (runDetail && req.method === 'GET') {
+    const r = getRun(runDetail[1])
+    if (!r) { res.writeHead(404); res.end(JSON.stringify({ error: 'not found' })); return }
+    const outputPath = path.join(RUNS_DIR, r.id, 'output.txt')
+    const output = fs.existsSync(outputPath) ? fs.readFileSync(outputPath, 'utf-8')
+                  : (currentRunId === r.id ? currentOutput : '')
+    res.writeHead(200, { 'Content-Type': 'application/json' })
+    res.end(JSON.stringify({ ...r, output, screenshots: listFrozenShots(r.id) })); return
   }
 
   if (p === '/api/run' && req.method === 'POST') {
@@ -256,11 +468,40 @@ const server = http.createServer(async (req, res) => {
     req.on('end', () => {
       let spec = ''
       try { spec = (JSON.parse(body) as { spec?: string }).spec ?? '' } catch { /* */ }
-      const ok = runPlaywright(spec)
-      res.writeHead(ok ? 202 : 409, { 'Content-Type': 'application/json' })
-      res.end(JSON.stringify({ ok }))
+      const run = startRun(spec)
+      if (!run) { res.writeHead(409, { 'Content-Type': 'application/json' }); res.end(JSON.stringify({ error: 'a run is already in progress' })); return }
+      res.writeHead(202, { 'Content-Type': 'application/json' })
+      res.end(JSON.stringify({ id: run.id }))
     })
     return
+  }
+
+  const review = p.match(/^\/api\/runs\/([^/]+)\/review$/)
+  if (review && req.method === 'POST') {
+    let body = ''
+    req.on('data', d => body += d)
+    req.on('end', () => {
+      try {
+        const { summary, decision } = JSON.parse(body) as { summary: string; decision: Review['decision'] }
+        const r = updateRun(review[1], {
+          status: 'reviewed',
+          review: { summary, decision, reviewedAt: Date.now() },
+        })
+        if (!r) { res.writeHead(404); res.end(JSON.stringify({ error: 'not found' })); return }
+        res.writeHead(200, { 'Content-Type': 'application/json' })
+        res.end(JSON.stringify(r))
+      } catch (e) {
+        res.writeHead(400); res.end(JSON.stringify({ error: String(e) }))
+      }
+    })
+    return
+  }
+
+  if (review && req.method === 'DELETE') {
+    const r = updateRun(review[1], { status: 'awaiting-review', review: null })
+    if (!r) { res.writeHead(404); res.end(JSON.stringify({ error: 'not found' })); return }
+    res.writeHead(200, { 'Content-Type': 'application/json' })
+    res.end(JSON.stringify(r)); return
   }
 
   if (p === '/api/output' && req.method === 'GET') {
@@ -270,27 +511,21 @@ const server = http.createServer(async (req, res) => {
       'Connection': 'keep-alive',
     })
     res.write(': connected\n\n')
-    if (runOutput) res.write(`event: line\ndata: ${JSON.stringify({ line: runOutput })}\n\n`)
     sseClients.push(res)
-    const interval = setInterval(() => {
-      if (!runRunning) {
-        res.write('event: done\ndata: {}\n\n')
-      }
-    }, 1000)
     req.on('close', () => {
-      clearInterval(interval)
       const i = sseClients.indexOf(res); if (i >= 0) sseClients.splice(i, 1)
     })
     return
   }
 
-  if (p.startsWith('/shots/') && req.method === 'GET') {
-    const rel = decodeURIComponent(p.replace('/shots/', ''))
-    const full = path.join(SHOTS, rel)
-    if (!full.startsWith(SHOTS) || !fs.existsSync(full)) { res.writeHead(404); res.end('not found'); return }
-    res.writeHead(200, { 'Content-Type': 'image/png', 'Cache-Control': 'public, max-age=60' })
-    fs.createReadStream(full).pipe(res)
-    return
+  const runShot = p.match(/^\/runs\/([^/]+)\/shots\/(.+)$/)
+  if (runShot && req.method === 'GET') {
+    const [, id, rel] = runShot
+    const full = path.join(RUNS_DIR, id, 'screenshots', decodeURIComponent(rel))
+    const root = path.join(RUNS_DIR, id, 'screenshots')
+    if (!full.startsWith(root) || !fs.existsSync(full)) { res.writeHead(404); res.end('not found'); return }
+    res.writeHead(200, { 'Content-Type': 'image/png', 'Cache-Control': 'public, max-age=300' })
+    fs.createReadStream(full).pipe(res); return
   }
 
   res.writeHead(404); res.end('not found')

--- a/web/scripts/review-server.ts
+++ b/web/scripts/review-server.ts
@@ -402,10 +402,12 @@ const HTML = `<!doctype html>
   .panel h3 { margin: 0 0 8px; font-size: 13px; color: var(--muted); }
   .panel .row { display: flex; gap: 10px; align-items: center; flex-wrap: wrap; }
   .panel .help { color: var(--muted); font-size: 12px; margin-top: 10px; line-height: 1.6; }
-  /* Run summary header */
-  .run-hero h1 { margin: 0 0 4px; font-size: 22px; line-height: 1.25; }
-  .run-hero p.lead { margin: 0 0 8px; color: var(--muted); font-size: 14px; line-height: 1.55; }
-  .run-hero .meta { color: var(--muted); font-size: 12px; }
+  /* Run summary header — compact one-line strip; full prose lives in the side panel */
+  .run-hero { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; margin: 0 0 8px; }
+  .run-hero h1 { margin: 0; font-size: 16px; line-height: 1.25; font-weight: 600; flex: 0 1 auto; }
+  .run-hero .meta { color: var(--muted); font-size: 11px; }
+  .run-hero .info-btn { background: transparent; border: none; padding: 2px 6px; color: var(--muted); cursor: pointer; font-size: 12px; }
+  .run-hero .info-btn:hover { color: var(--primary); }
   /* ----- Sticky mini-map flowchart -----
      Dot color now means "where you are":
        - default grey   = step you haven't viewed
@@ -413,28 +415,25 @@ const HTML = `<!doctype html>
        - dark           = step you already passed
      A separate small badge by the number indicates feedback count, so
      "I left a note here" is no longer confused with "I'm here". */
-  .mini-map { position: sticky; top: 0; z-index: 15; background: var(--bg); padding: 10px 0 12px; border-bottom: 1px solid var(--border); margin: 0 0 12px; }
-  .mini-map .label { font-size: 11px; color: var(--muted); text-transform: uppercase; letter-spacing: 0.06em; margin-bottom: 8px; }
-  .mini-map .nodes { display: flex; gap: 0; align-items: stretch; overflow-x: auto; padding-bottom: 2px; }
-  .mini-map .node { flex: 1 1 0; min-width: 80px; display: flex; flex-direction: column; align-items: center; cursor: pointer; padding: 4px; border-radius: 6px; position: relative; }
+  .mini-map { position: sticky; top: 0; z-index: 15; background: var(--bg); padding: 6px 0 8px; border-bottom: 1px solid var(--border); margin: 0 0 8px; }
+  .mini-map .nodes { display: flex; gap: 0; align-items: center; overflow-x: auto; padding-bottom: 2px; }
+  .mini-map .node { flex: 1 1 0; min-width: 70px; display: flex; flex-direction: row; align-items: center; gap: 6px; cursor: pointer; padding: 4px 6px; border-radius: 6px; position: relative; justify-content: center; }
   .mini-map .node:hover { background: var(--row-hover); }
-  .mini-map .node .dot { width: 26px; height: 26px; border-radius: 50%; background: var(--dot); color: #fff; display: flex; align-items: center; justify-content: center; font-size: 11px; font-weight: 700; transition: transform .12s ease, box-shadow .12s ease, background .12s ease; }
+  .mini-map .node .dot { width: 22px; height: 22px; border-radius: 50%; background: var(--dot); color: #fff; display: flex; align-items: center; justify-content: center; font-size: 11px; font-weight: 700; flex-shrink: 0; transition: transform .12s ease, box-shadow .12s ease, background .12s ease; }
   .mini-map .node.passed .dot { background: var(--muted); }
-  .mini-map .node.current .dot { background: var(--primary); box-shadow: 0 0 0 4px rgba(0,102,204,0.22); transform: scale(1.08); }
-  .mini-map .node .cap { font-size: 11px; color: var(--text); margin-top: 5px; max-width: 110px; text-align: center; line-height: 1.25; }
+  .mini-map .node.current .dot { background: var(--primary); box-shadow: 0 0 0 3px rgba(0,102,204,0.22); }
+  .mini-map .node .cap { font-size: 11px; color: var(--text); line-height: 1.2; max-width: 110px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
   .mini-map .node.current .cap { font-weight: 600; }
-  .mini-map .node .fb-count { position: absolute; top: 0; right: 18%; min-width: 16px; height: 16px; padding: 0 4px; border-radius: 8px; background: var(--success); color: #fff; font-size: 10px; font-weight: 700; display: flex; align-items: center; justify-content: center; border: 2px solid var(--bg); }
-  .mini-map .arrow { flex: 0 0 22px; align-self: center; height: 2px; background: var(--rail); margin-top: 13px; }
+  .mini-map .node .fb-count { position: absolute; top: -2px; left: 22px; min-width: 14px; height: 14px; padding: 0 3px; border-radius: 7px; background: var(--success); color: #fff; font-size: 9px; font-weight: 700; display: flex; align-items: center; justify-content: center; border: 2px solid var(--bg); }
+  .mini-map .arrow { flex: 0 0 14px; height: 2px; background: var(--rail); }
   /* ----- Slide (one step at a time) ----- */
-  .story-info { padding: 14px 18px; }
-  .story-info h2 { font-size: 14px; margin: 0 0 4px; }
-  .story-info .desc { color: var(--muted); font-size: 13px; margin: 0; line-height: 1.55; }
-  .slide { padding: 22px 22px 18px; }
-  .slide .step-meta { color: var(--muted); font-size: 12px; margin: 0 0 4px; }
-  .slide .step-title { font-size: 18px; font-weight: 600; margin: 0 0 6px; }
-  .slide .step-desc { color: var(--muted); font-size: 14px; line-height: 1.6; margin: 0 0 16px; max-width: 760px; }
-  .slide .step-shot-wrap { display: flex; justify-content: center; align-items: center; background: var(--code-bg); border: 1px solid var(--border); border-radius: 8px; padding: 12px; margin-bottom: 12px; min-height: 200px; }
-  .slide .step-shot { max-width: 100%; max-height: calc(100vh - 360px); object-fit: contain; cursor: zoom-in; border-radius: 4px; }
+  .slide { padding: 12px 16px 14px; }
+  .slide .step-head { display: flex; align-items: baseline; gap: 10px; flex-wrap: wrap; margin: 0 0 6px; }
+  .slide .step-meta { color: var(--muted); font-size: 11px; margin: 0; }
+  .slide .step-title { font-size: 16px; font-weight: 600; margin: 0; }
+  .slide .step-desc { color: var(--muted); font-size: 12px; line-height: 1.5; margin: 0 0 8px; max-width: 920px; }
+  .slide .step-shot-wrap { display: flex; justify-content: center; align-items: center; background: var(--code-bg); border: 1px solid var(--border); border-radius: 8px; padding: 8px; margin-bottom: 8px; min-height: 200px; }
+  .slide .step-shot { max-width: 100%; max-height: calc(100vh - 320px); object-fit: contain; cursor: zoom-in; border-radius: 4px; }
   .slide .quick { margin-top: 0; display: flex; gap: 6px; flex-wrap: wrap; }
   .slide .quick button { font-size: 13px; padding: 6px 12px 6px 10px; display: inline-flex; align-items: center; gap: 6px; }
   .slide .quick button svg { width: 18px; height: 18px; flex-shrink: 0; }
@@ -447,20 +446,24 @@ const HTML = `<!doctype html>
   .slide .fb-row .x { color: var(--muted); cursor: pointer; display: inline-flex; align-items: center; padding: 0 2px; }
   .slide .fb-row .x svg { width: 14px; height: 14px; }
   .slide .fb-row .x:hover { color: var(--danger); }
-  /* ----- Prev / Next nav under the slide ----- */
-  .slide-nav { display: flex; justify-content: space-between; gap: 12px; margin: 18px 0 0; }
-  .slide-nav button { padding: 9px 16px; display: inline-flex; align-items: center; gap: 6px; font-size: 14px; }
-  .slide-nav button svg { width: 16px; height: 16px; }
-  .slide-nav button:disabled { visibility: hidden; }
-  .slide-nav .step-counter { color: var(--muted); font-size: 12px; align-self: center; }
-  /* ----- Sticky review form pinned to the bottom ----- */
-  .review-sticky { position: sticky; bottom: 0; z-index: 14; background: var(--panel); border: 1px solid var(--border); border-radius: 10px; padding: 14px 16px; margin: 24px 0 0; box-shadow: 0 -4px 14px rgba(0,0,0,0.06); }
+  /* ----- Slide nav row: prev | quick-tags | next ----- */
+  .slide-nav { display: flex; align-items: center; gap: 8px; margin: 8px 0 0; }
+  .slide-nav > #prev, .slide-nav > #next { padding: 6px 12px; display: inline-flex; align-items: center; gap: 4px; font-size: 13px; flex-shrink: 0; }
+  .slide-nav > #prev svg, .slide-nav > #next svg { width: 14px; height: 14px; }
+  .slide-nav > #prev:disabled, .slide-nav > #next:disabled { visibility: hidden; }
+  .slide-nav .quick { flex: 1; display: flex; gap: 6px; flex-wrap: wrap; justify-content: center; margin: 0; }
+  /* ----- Compact, collapsible review form pinned to the bottom ----- */
+  .review-sticky { position: sticky; bottom: 0; z-index: 14; background: var(--panel); border: 1px solid var(--border); border-radius: 10px; padding: 8px 12px; margin: 12px 0 0; box-shadow: 0 -4px 14px rgba(0,0,0,0.06); }
   [data-theme="dark"] .review-sticky { box-shadow: 0 -4px 14px rgba(0,0,0,0.3); }
-  .review-sticky .head { display: flex; justify-content: space-between; align-items: baseline; gap: 8px; flex-wrap: wrap; margin-bottom: 8px; }
-  .review-sticky .head h3 { margin: 0; font-size: 13px; color: var(--muted); }
-  .review-sticky textarea { min-height: 50px; }
-  .review-sticky .row { margin-top: 8px; }
-  .review-sticky .help { color: var(--muted); font-size: 11px; margin-top: 6px; line-height: 1.5; }
+  .review-sticky .head { display: flex; justify-content: space-between; align-items: center; gap: 8px; flex-wrap: wrap; }
+  .review-sticky .head h3 { margin: 0; font-size: 12px; color: var(--muted); }
+  .review-sticky[open] .head { margin-bottom: 8px; }
+  .review-sticky textarea { min-height: 42px; }
+  .review-sticky .row { margin-top: 6px; display: flex; gap: 6px; flex-wrap: wrap; }
+  .review-sticky .row button { padding: 5px 10px; font-size: 12px; }
+  .review-sticky .help { display: none; }
+  .review-sticky summary { cursor: pointer; list-style: none; }
+  .review-sticky summary::-webkit-details-marker { display: none; }
   /* Lightbox with zoom/pan */
   dialog#lightbox { background: rgba(0,0,0,0.95); border: none; width: 100vw; height: 100vh; max-width: 100vw; max-height: 100vh; padding: 0; margin: 0; overflow: hidden; }
   dialog#lightbox::backdrop { background: rgba(0,0,0,0.9); }
@@ -488,6 +491,7 @@ const HTML = `<!doctype html>
 <aside id="side-panel" aria-hidden="true">
   <button id="close-panel" aria-label="Close menu" title="Close"></button>
   <h1><a href="#/">Ask · review</a></h1>
+  <div class="group" id="panel-about"></div>
   <div class="group">
     <label for="spec">Spec</label>
     <select id="spec"><option value="">All specs</option></select>
@@ -707,30 +711,30 @@ async function renderDetail(id) {
   if (isNaN(slideIdx) || slideIdx < 0) slideIdx = 0;
   if (slideIdx >= allSteps.length) slideIdx = Math.max(0, allSteps.length - 1);
 
-  // ----- review form (rendered separately, pinned to bottom) -----
+  // ----- review form (collapsible, pinned to bottom) -----
   let reviewBody = '';
   if (r.review) {
-    reviewBody = '<div class="head"><h3>Reviewed · <span class="decision-' + r.review.decision + '">' + r.review.decision + '</span> · ' + ago(r.review.reviewedAt) + '</h3>' +
-      '<button id="reopen">Reopen</button></div>' +
-      '<p style="margin:0;white-space:pre-wrap;font-size:13px">' + escape(r.review.summary || '(no summary)') + '</p>';
+    reviewBody = '<details class="review-sticky" id="review-sticky" open>' +
+      '<summary class="head"><h3>Reviewed · <span class="decision-' + r.review.decision + '">' + r.review.decision + '</span> · ' + ago(r.review.reviewedAt) + '</h3>' +
+      '<button id="reopen">Reopen</button></summary>' +
+      '<p style="margin:0;white-space:pre-wrap;font-size:13px">' + escape(r.review.summary || '(no summary)') + '</p>' +
+      '</details>';
   } else if (r.status !== 'running') {
-    reviewBody = '<div class="head"><h3>Overall review</h3>' +
-      '<span class="muted">Use per-step tags above for specifics; only the overall decision is required to finalize.</span></div>' +
-      '<textarea id="summary" placeholder="Optional — anything global to call out? (per-step quick-tags above replace most typing)"></textarea>' +
+    reviewBody = '<details class="review-sticky" id="review-sticky">' +
+      '<summary class="head"><h3>Overall review — click to add an overall comment / approve / reject</h3></summary>' +
+      '<textarea id="summary" placeholder="Optional — anything global? Per-step quick-tags above replace most typing."></textarea>' +
       '<div class="row">' +
         '<button class="success" data-decision="approved">Approve</button>' +
         '<button data-decision="changes-requested">Changes requested</button>' +
         '<button class="danger" data-decision="rejected">Reject</button>' +
       '</div>' +
-      '<p class="help"><strong>Approve</strong> = stop nagging unless web/src or ask/scripts changes. ' +
-        '<strong>Changes / Reject</strong> = log as known-not-ready, suppress stale alerts. ' +
-        'Submitting never re-runs the test — that\\'s always explicit via <em>New run</em>.</p>';
+      '</details>';
   }
 
   // ----- mini-map flowchart (sticky) -----
   let miniMap = '';
   if (allSteps.length) {
-    miniMap = '<div class="mini-map" id="mini-map"><div class="label">Where you are</div><div class="nodes">' +
+    miniMap = '<div class="mini-map" id="mini-map"><div class="nodes">' +
       allSteps.map(({ s, st }, i) => {
         const count = fbCountFor(s.path, st.idx);
         const isCurrent = i === slideIdx;
@@ -754,33 +758,28 @@ async function renderDetail(id) {
     const { s, st } = allSteps[slideIdx];
     const stepFb = fb.filter(x => x.storyPath === s.path && x.stepIdx === st.idx);
     slideHtml =
-      (stories.length === 1
-        ? '<div class="story-info panel" style="margin-top:0;margin-bottom:0;border-bottom-left-radius:0;border-bottom-right-radius:0;border-bottom:0">' +
-            '<h2>' + escape(s.title || s.testTitle) + '</h2>' +
-            (s.description ? '<p class="desc">' + escape(s.description) + '</p>' : '') +
-          '</div>'
-        : '') +
-      '<div class="panel slide" style="margin-top:' + (stories.length === 1 ? '0' : '16px') + ';border-top-left-radius:' + (stories.length === 1 ? '0' : '8px') + ';border-top-right-radius:' + (stories.length === 1 ? '0' : '8px') + '" data-story-path="' + escape(s.path) + '" data-step="' + st.idx + '">' +
-        '<p class="step-meta">Step ' + (slideIdx+1) + ' of ' + allSteps.length + ' · ' + st.durationMs + 'ms</p>' +
-        '<h2 class="step-title">' + escape(st.title) + '</h2>' +
+      '<div class="panel slide" data-story-path="' + escape(s.path) + '" data-step="' + st.idx + '">' +
+        '<div class="step-head">' +
+          '<h2 class="step-title">' + escape(st.title) + '</h2>' +
+          '<span class="step-meta">Step ' + (slideIdx+1) + ' / ' + allSteps.length + ' · ' + st.durationMs + 'ms</span>' +
+        '</div>' +
         (st.description ? '<p class="step-desc">' + escape(st.description) + '</p>' : '') +
         (st.file ? '<div class="step-shot-wrap"><img class="step-shot" src="/runs/' + r.id + '/story/' + encodeURI(s.path) + '/' + encodeURI(st.file) + '" alt="' + escape(st.title) + '"></div>' : '') +
-        '<div class="quick">' +
-          KINDS.map(k => '<button data-kind="' + k.id + '">' + k.icon + '<span>' + k.label + '</span></button>').join('') +
-          '<button data-kind="other">' + SVG.other + '<span>Comment</span></button>' +
+        '<div class="slide-nav">' +
+          '<button id="prev"' + (slideIdx === 0 ? ' disabled' : '') + '>' + SVG.arrowLeft + '<span>Previous</span></button>' +
+          '<div class="quick">' +
+            KINDS.map(k => '<button data-kind="' + k.id + '">' + k.icon + '<span>' + k.label + '</span></button>').join('') +
+            '<button data-kind="other">' + SVG.other + '<span>Comment</span></button>' +
+          '</div>' +
+          '<button id="next"' + (slideIdx === allSteps.length-1 ? ' disabled' : '') + '><span>Next</span>' + SVG.arrowRight + '</button>' +
         '</div>' +
-        '<div class="fb-list">' +
+        (stepFb.length ? '<div class="fb-list">' +
           stepFb.map(f => '<div class="fb-row">' +
             '<span class="kind">' + (KINDS.find(k=>k.id===f.kind)?.icon ?? SVG.other) + escape(f.kind) + '</span>' +
             '<span class="text">' + escape(f.text || '') + '</span>' +
             '<span class="x" data-at="' + f.at + '" title="remove">' + SVG.remove + '</span>' +
           '</div>').join('') +
-        '</div>' +
-        '<div class="slide-nav">' +
-          '<button id="prev"' + (slideIdx === 0 ? ' disabled' : '') + '>' + SVG.arrowLeft + '<span>Previous</span></button>' +
-          '<span class="step-counter">' + (slideIdx+1) + ' / ' + allSteps.length + '   ·   ← / → to navigate</span>' +
-          '<button id="next"' + (slideIdx === allSteps.length-1 ? ' disabled' : '') + '><span>Next</span>' + SVG.arrowRight + '</button>' +
-        '</div>' +
+        '</div>' : '') +
       '</div>';
   }
 
@@ -803,24 +802,43 @@ async function renderDetail(id) {
     }
   }
 
-  // ----- friendly hero -----
+  // ----- friendly hero (one-line strip; full prose in the side panel) -----
   const primaryStory = stories[0];
   const heroTitle = primaryStory?.title || (r.spec || '(all specs)').replace(/^e2e\\//, '').replace(/\\.spec\\.ts$/, '');
   const heroDesc = primaryStory?.description || '';
+  // Stash run prose for the side panel "About" section
+  window.__askRunInfo = {
+    title: heroTitle,
+    description: heroDesc,
+    spec: (r.spec || '(all specs)').replace(/^e2e\\//, ''),
+    id: r.id,
+    startedAt: r.startedAt,
+  };
+  const aboutEl = document.getElementById('panel-about');
+  if (aboutEl) {
+    aboutEl.innerHTML =
+      '<label>About this run</label>' +
+      '<div style="font-size:13px;font-weight:600">' + escape(heroTitle) + '</div>' +
+      (heroDesc ? '<div class="muted" style="font-size:12px;line-height:1.55">' + escape(heroDesc) + '</div>' : '') +
+      '<div class="muted" style="font-size:11px">' + escape(window.__askRunInfo.spec) + ' · ' + r.id + ' · started ' + ago(r.startedAt) + '</div>';
+  }
 
   view.innerHTML =
-    '<p style="margin:0 0 12px"><a href="#/">← all runs</a></p>' +
     '<div class="run-hero">' +
+      '<a href="#/" class="muted" style="font-size:12px">← all runs</a>' +
       '<h1>' + escape(heroTitle) + '</h1>' +
-      (heroDesc ? '<p class="lead">' + escape(heroDesc) + '</p>' : '') +
-      '<p class="meta">' + escape(r.spec || '(all specs)').replace(/^e2e\\//,'') + ' · ' + r.id + ' · started ' + ago(r.startedAt) + ' · ' + passedBadge + staleBadge + '</p>' +
+      passedBadge + staleBadge +
+      '<button class="info-btn" id="hero-info" title="Show full description">about</button>' +
     '</div>' +
     miniMap +
     slideHtml +
     shotsHtml +
-    (reviewBody ? '<div class="review-sticky" id="review-sticky">' + reviewBody + '</div>' : '') +
+    (reviewBody || '') +
     '<details' + (r.exitCode === 0 ? '' : ' open') + ' style="margin-top:16px"><summary style="cursor:pointer" class="muted">Output</summary>' +
       '<pre class="output" id="run-output">' + escape(r.output ?? '') + '</pre></details>';
+
+  const heroInfoBtn = document.getElementById('hero-info');
+  if (heroInfoBtn) heroInfoBtn.addEventListener('click', () => setPanel(true));
 
   // image lightbox
   view.querySelectorAll('img.step-shot, figure img').forEach(img => {

--- a/web/scripts/review-server.ts
+++ b/web/scripts/review-server.ts
@@ -429,15 +429,15 @@ const HTML = `<!doctype html>
   /* ----- Slide: image left, sidebar right (title/description/feedback)
      The image always sits at the top of the panel; text on the right grows
      downward without ever pushing the image. ----- */
-  .slide { display: grid; grid-template-columns: minmax(0, 1fr) 300px; grid-template-rows: auto auto; gap: 14px; padding: 12px 14px 14px; }
+  .slide { display: grid; grid-template-columns: 320px minmax(0, 1fr); grid-template-rows: auto auto; gap: 16px; padding: 14px 16px 14px; }
   @media (max-width: 900px) { .slide { grid-template-columns: 1fr; } }
-  .slide .step-image { grid-column: 1; grid-row: 1; }
-  .slide .step-side  { grid-column: 2; grid-row: 1; display: flex; flex-direction: column; gap: 10px; min-width: 0; }
+  .slide .step-side  { grid-column: 1; grid-row: 1; display: flex; flex-direction: column; gap: 12px; min-width: 0; }
+  .slide .step-image { grid-column: 2; grid-row: 1; }
   .slide .slide-nav  { grid-column: 1 / -1; grid-row: 2; }
-  .slide .step-head { display: flex; align-items: baseline; gap: 8px; flex-wrap: wrap; }
-  .slide .step-meta { color: var(--muted); font-size: 11px; margin: 0; }
-  .slide .step-title { font-size: 16px; font-weight: 600; margin: 0; line-height: 1.3; }
-  .slide .step-desc { color: var(--text); font-size: 13px; line-height: 1.55; margin: 0; }
+  .slide .step-head { display: flex; align-items: baseline; gap: 10px; flex-wrap: wrap; }
+  .slide .step-meta { color: var(--muted); font-size: 12px; margin: 0; }
+  .slide .step-title { font-size: 22px; font-weight: 600; margin: 0; line-height: 1.25; }
+  .slide .step-desc { color: var(--text); font-size: 15px; line-height: 1.6; margin: 0; }
   .slide .step-shot-wrap { display: flex; justify-content: center; align-items: center; background: var(--code-bg); border: 1px solid var(--border); border-radius: 8px; padding: 8px; min-height: 200px; }
   .slide .step-shot { max-width: 100%; max-height: calc(100vh - 240px); object-fit: contain; cursor: zoom-in; border-radius: 4px; }
   .slide .quick { margin-top: 0; display: flex; gap: 6px; flex-wrap: wrap; }
@@ -529,7 +529,7 @@ const HTML = `<!doctype html>
 // No network dependency, scales cleanly, inherits the button text color.
 const SVG = {
   ok:        '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M9 12.75 11.25 15 15 9.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"/></svg>',
-  bug:       '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="7" y="8" width="10" height="12" rx="5"/><path d="M12 8V5M9 5l-1-2M15 5l1-2M7 12H4M20 12h-3M7 16H4M20 16h-3M7 20l-2 1M17 20l2 1"/></svg>',
+  bug:       '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><ellipse cx="12" cy="13" rx="4.5" ry="6.5"/><line x1="12" y1="6.5" x2="12" y2="19.5"/><path d="M10 5 L8.5 3"/><path d="M14 5 L15.5 3"/><path d="M7.7 9 L4.5 7"/><path d="M16.3 9 L19.5 7"/><path d="M7.5 13 L4 13"/><path d="M16.5 13 L20 13"/><path d="M7.7 17 L4.5 19"/><path d="M16.3 17 L19.5 19"/></svg>',
   style:     '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3a9 9 0 1 0 0 18 1.5 1.5 0 0 0 0-3 1.5 1.5 0 0 1 0-3h2.5a4.5 4.5 0 0 0 4.5-4.5C19 6.4 15.86 3 12 3z"/><circle cx="7.5" cy="11" r=".75" fill="currentColor"/><circle cx="11" cy="7.5" r=".75" fill="currentColor"/><circle cx="15.5" cy="9.5" r=".75" fill="currentColor"/></svg>',
   copy:      '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M8 4h8a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2z"/><path d="M9 9h6M9 13h6M9 17h4"/></svg>',
   confusing: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 5.25h.008v.008H12v-.008Z"/></svg>',

--- a/web/scripts/review-server.ts
+++ b/web/scripts/review-server.ts
@@ -73,6 +73,49 @@ interface Run {
   status: 'running' | 'awaiting-review' | 'reviewed'
   review: Review | null
   gitHead: string | null    // sha at run start (for staleness detection)
+  planId?: string | null    // when set, run belongs to a plan (new-style)
+  planVersion?: string | null
+}
+
+// ---------- plan model (new-style, additive) ------------------------------
+interface PlanCase {
+  id: string
+  scriptId: string
+  surface: 'web' | 'askmac'
+  title: string
+  spec?: string             // Playwright spec relative to web/e2e (web cases)
+  driver?: string           // e.g. "computer-use" (askmac cases)
+  deps: string[]
+  status: 'implemented' | 'pending' | 'skipped'
+}
+interface Plan {
+  id: string
+  title: string
+  version: string
+  description: string
+  cases: PlanCase[]
+}
+interface TestedSnapshot {
+  git: { head: string; shortHead: string; branch: string; dirty: boolean; summary: string }
+  scripts: Array<{ id: string; version: string }>
+  vault: 'dev' | 'prod' | 'unknown'
+}
+interface RunMeta {
+  planId: string
+  planVersion: string
+  scope: 'all' | { caseIds: string[] }
+  caseStoryMap: Record<string, string>   // caseId -> story slug (storyPath)
+  tested: TestedSnapshot | null
+}
+interface CaseResult {
+  caseId: string
+  title: string
+  surface: 'web' | 'askmac'
+  status: 'passed' | 'failed' | 'skipped' | 'pending' | 'running'
+  storyPath: string | null
+  stepCount: number
+  feedback: Array<{ kind: string; count: number }>
+  decision: Review['decision'] | null
 }
 
 function loadRuns(): Run[] {
@@ -171,11 +214,19 @@ function freezeScreenshots(runId: string, since: number): number {
   return n
 }
 
-function startRun(spec: string): Run | null {
+interface StartRunOpts {
+  spec: string
+  planId?: string
+  scope?: 'all' | { caseIds: string[] }
+}
+
+function startRun(opts: StartRunOpts | string): Run | null {
+  // Back-compat: accept legacy string spec arg
+  const o: StartRunOpts = typeof opts === 'string' ? { spec: opts } : opts
   if (currentRunId) return null
   const run: Run = {
     id: newRunId(),
-    spec,
+    spec: o.spec,
     startedAt: Date.now(),
     endedAt: null,
     exitCode: null,
@@ -183,15 +234,36 @@ function startRun(spec: string): Run | null {
     status: 'running',
     review: null,
     gitHead: currentGitHead(),
+    planId: o.planId ?? null,
+    planVersion: o.planId ? (getPlan(o.planId)?.version ?? null) : null,
   }
   fs.mkdirSync(path.join(RUNS_DIR, run.id), { recursive: true })
   saveRuns([run, ...loadRuns()])
+
+  // Persist run meta when this is a plan-scoped run.
+  if (o.planId) {
+    const plan = getPlan(o.planId)
+    const scope: RunMeta['scope'] = o.scope ?? 'all'
+    // Phase 1: caseStoryMap is populated by convention — story slug == caseId.
+    // The story recorder slugifies testInfo.titlePath; specs should set the
+    // test title to the case id so the produced story slug matches.
+    const caseStoryMap: Record<string, string> = {}
+    if (plan) for (const c of plan.cases) caseStoryMap[c.id] = c.id
+    saveRunMeta(run.id, {
+      planId: o.planId,
+      planVersion: plan?.version ?? '',
+      scope,
+      caseStoryMap,
+      tested: captureTestedSnapshot(),
+    })
+  }
+
   currentRunId = run.id
   currentOutput = ''
   broadcast('started', { id: run.id })
 
   const args = ['playwright', 'test']
-  if (spec) args.push(spec)
+  if (o.spec) args.push(o.spec)
   const child = spawn('npx', args, { cwd: WEB, env: { ...process.env, FORCE_COLOR: '0' } })
   const onChunk = (d: Buffer) => {
     const s = d.toString()
@@ -275,6 +347,142 @@ function loadFeedback(runId: string): Feedback[] {
 }
 function saveFeedback(runId: string, fb: Feedback[]) {
   fs.writeFileSync(path.join(RUNS_DIR, runId, 'feedback.json'), JSON.stringify(fb, null, 2))
+}
+
+// ---------- plans + tested snapshot + case results -----------------------
+// Plans are *source* artifacts, so they live under web/review-plans/ in git.
+// Runs (web/.review/runs/) are local-only and gitignored.
+const PLANS_DIR = path.join(WEB, 'review-plans')
+const SCRIPTS_DIR = path.join(REPO, 'ask', 'scripts')
+
+function loadPlans(): Plan[] {
+  if (!fs.existsSync(PLANS_DIR)) return []
+  const out: Plan[] = []
+  for (const f of fs.readdirSync(PLANS_DIR)) {
+    if (!f.endsWith('.json')) continue
+    try { out.push(JSON.parse(fs.readFileSync(path.join(PLANS_DIR, f), 'utf-8')) as Plan) }
+    catch { /* skip malformed */ }
+  }
+  return out.sort((a, b) => a.title.localeCompare(b.title))
+}
+function getPlan(id: string): Plan | undefined { return loadPlans().find(p => p.id === id) }
+
+function captureTestedSnapshot(): TestedSnapshot {
+  const head = currentGitHead() ?? ''
+  const shortHead = head ? head.slice(0, 7) : ''
+  const branch = git(['rev-parse', '--abbrev-ref', 'HEAD'])
+  const status = git(['status', '--porcelain'])
+  const scripts: TestedSnapshot['scripts'] = []
+  if (fs.existsSync(SCRIPTS_DIR)) {
+    for (const e of fs.readdirSync(SCRIPTS_DIR, { withFileTypes: true })) {
+      if (!e.isDirectory()) continue
+      const m = path.join(SCRIPTS_DIR, e.name, 'manifest.json')
+      if (!fs.existsSync(m)) continue
+      try {
+        const j = JSON.parse(fs.readFileSync(m, 'utf-8')) as { version?: string }
+        scripts.push({ id: e.name, version: String(j.version ?? '') })
+      } catch { /* skip */ }
+    }
+  }
+  return {
+    git: {
+      head, shortHead, branch,
+      dirty: status.length > 0,
+      summary: status ? `${status.split('\n').filter(Boolean).length} dirty file(s)` : 'clean',
+    },
+    scripts,
+    vault: 'unknown',
+  }
+}
+
+function runMetaPath(runId: string): string { return path.join(RUNS_DIR, runId, 'meta.json') }
+function loadRunMeta(runId: string): RunMeta | null {
+  const p = runMetaPath(runId)
+  if (!fs.existsSync(p)) return null
+  try { return JSON.parse(fs.readFileSync(p, 'utf-8')) as RunMeta } catch { return null }
+}
+function saveRunMeta(runId: string, meta: RunMeta) {
+  fs.mkdirSync(path.join(RUNS_DIR, runId), { recursive: true })
+  fs.writeFileSync(runMetaPath(runId), JSON.stringify(meta, null, 2))
+}
+
+function loadCaseReview(runId: string, caseId: string): Review | null {
+  const p = path.join(RUNS_DIR, runId, 'cases', caseId, 'review.json')
+  if (!fs.existsSync(p)) return null
+  try { return JSON.parse(fs.readFileSync(p, 'utf-8')) as Review } catch { return null }
+}
+function saveCaseReview(runId: string, caseId: string, review: Review | null) {
+  const dir = path.join(RUNS_DIR, runId, 'cases', caseId)
+  fs.mkdirSync(dir, { recursive: true })
+  const p = path.join(dir, 'review.json')
+  if (!review) { try { fs.unlinkSync(p) } catch { /* */ } return }
+  fs.writeFileSync(p, JSON.stringify(review, null, 2))
+}
+
+/** Resolve the storyPath (story dir name) for a case. Looks in run meta first,
+ *  then falls back to a story whose `caseId` field matches. */
+function resolveCaseStoryPath(runId: string, caseId: string): string | null {
+  const meta = loadRunMeta(runId)
+  const fromMeta = meta?.caseStoryMap?.[caseId]
+  if (fromMeta) return fromMeta
+  // Fall back: search frozen stories for an embedded caseId field
+  const root = path.join(RUNS_DIR, runId, 'story')
+  if (!fs.existsSync(root)) return null
+  for (const e of fs.readdirSync(root, { withFileTypes: true })) {
+    if (!e.isDirectory()) continue
+    const j = path.join(root, e.name, 'story.json')
+    if (!fs.existsSync(j)) continue
+    try {
+      const data = JSON.parse(fs.readFileSync(j, 'utf-8')) as { caseId?: string }
+      if (data.caseId === caseId) return e.name
+    } catch { /* skip */ }
+  }
+  return null
+}
+
+function caseResultsForRun(run: Run): CaseResult[] {
+  const meta = loadRunMeta(run.id)
+  if (!meta) return []
+  const plan = getPlan(meta.planId)
+  if (!plan) return []
+  const inScope = (cid: string) => meta.scope === 'all' || meta.scope.caseIds.includes(cid)
+  const fb = loadFeedback(run.id)
+  return plan.cases.map(c => {
+    const storyPath = resolveCaseStoryPath(run.id, c.id)
+    let stepCount = 0
+    if (storyPath) {
+      const j = path.join(RUNS_DIR, run.id, 'story', storyPath, 'story.json')
+      try { stepCount = (JSON.parse(fs.readFileSync(j, 'utf-8')) as { steps?: unknown[] }).steps?.length ?? 0 } catch { /* */ }
+    }
+    const caseFb = storyPath ? fb.filter(f => f.storyPath === storyPath) : []
+    const counts = new Map<string, number>()
+    for (const f of caseFb) counts.set(f.kind, (counts.get(f.kind) ?? 0) + 1)
+    const review = loadCaseReview(run.id, c.id)
+    let status: CaseResult['status'] = 'pending'
+    if (c.status === 'pending') status = 'pending'
+    else if (!inScope(c.id)) status = 'skipped'
+    else if (run.status === 'running' && !storyPath) status = 'running'
+    else if (storyPath) status = run.exitCode === null ? 'running' : run.exitCode === 0 ? 'passed' : 'failed'
+    else status = 'pending'
+    return {
+      caseId: c.id,
+      title: c.title,
+      surface: c.surface,
+      status,
+      storyPath,
+      stepCount,
+      feedback: Array.from(counts.entries()).map(([kind, count]) => ({ kind, count })),
+      decision: review?.decision ?? null,
+    }
+  })
+}
+
+function runDecisionRollup(results: CaseResult[]): Review['decision'] | null {
+  const considered = results.filter(r => r.status === 'passed' || r.status === 'failed')
+  if (!considered.length) return null
+  if (considered.some(r => r.decision === 'rejected')) return 'rejected'
+  if (considered.every(r => r.decision === 'approved')) return 'approved'
+  return 'changes-requested'
 }
 
 // ---------- HTML page (SPA with hash routing) -----------------------------
@@ -741,9 +949,18 @@ async function renderList() {
 }
 
 // ---------- detail view ---------------------------------------------------
-async function renderDetail(id) {
+// scope: { caseId, planId } when entered via #/plan/:id/run/:runId/:caseId
+async function renderDetail(id, scope) {
   const r = await fetch('/api/runs/' + id).then(r => r.json());
   if (r.error) { view.innerHTML = '<div class="empty">Run not found.</div>'; return; }
+  // If scoped to a case, filter stories to that one case's storyPath.
+  if (scope && scope.caseId) {
+    const cr = (r.caseResults || []).find(c => c.caseId === scope.caseId);
+    const storyPath = cr?.storyPath;
+    if (storyPath) r.stories = (r.stories || []).filter(s => s.path === storyPath);
+    else r.stories = [];
+    r.__scope = scope;
+  }
   const fb = r.feedback || [];
   const passedBadge = r.exitCode === null
     ? '<span class="badge running">running</span>'
@@ -894,9 +1111,21 @@ async function renderDetail(id) {
       '<div class="muted" style="font-size:11px">' + escape(window.__askRunInfo.spec) + ' · ' + r.id + ' · started ' + ago(r.startedAt) + '</div>';
   }
 
+  // Breadcrumb depends on whether we're scoped to a plan + case
+  const sc = r.__scope;
+  const breadcrumb = sc
+    ? '<a href="#/" class="muted" style="font-size:12px">plans</a>' +
+      ' <span class="muted">›</span> ' +
+      '<a href="#/plan/' + escape(sc.planId) + '" class="muted" style="font-size:12px">' + escape(sc.planId) + '</a>' +
+      ' <span class="muted">›</span> ' +
+      '<a href="#/plan/' + escape(sc.planId) + '/run/' + escape(r.id) + '" class="muted" style="font-size:12px">run</a>' +
+      ' <span class="muted">›</span> ' +
+      '<span class="muted" style="font-size:12px">' + escape(sc.caseId) + '</span>'
+    : '<a href="#/" class="muted" style="font-size:12px">← all runs</a>';
+
   view.innerHTML =
     '<div class="run-hero">' +
-      '<a href="#/" class="muted" style="font-size:12px">← all runs</a>' +
+      breadcrumb +
       '<h1>' + escape(heroTitle) + '</h1>' +
       passedBadge + staleBadge +
       '<button class="info-btn" id="hero-info" title="Show full description">about</button>' +
@@ -1227,10 +1456,202 @@ function setupSlideInteractions(runId, current, fb, refresh) {
   }
 }
 
+// =============================================================================
+// Plan-first views: plans index, plan detail, run rollup. The case slideshow
+// reuses renderDetail() with a caseId scope (filters stories to that one).
+// =============================================================================
+async function renderPlansList() {
+  const [plans, runs] = await Promise.all([
+    fetch('/api/plans').then(r => r.json()),
+    fetch('/api/runs').then(r => r.json()),
+  ]);
+  // Last run per plan (newest first because /api/runs is sorted that way)
+  const lastByPlan = new Map();
+  for (const r of runs) { if (r.planId && !lastByPlan.has(r.planId)) lastByPlan.set(r.planId, r); }
+  if (!plans.length) {
+    view.innerHTML =
+      '<div class="empty">No plans yet. Drop a JSON plan into <code>web/.review/plans/</code> and reload.<br><br>' +
+      '<a href="#/all-runs" class="muted">→ legacy: all runs</a></div>';
+    return;
+  }
+  const rows = plans.map(p => {
+    const last = lastByPlan.get(p.id);
+    const implemented = p.cases.filter(c => c.status === 'implemented').length;
+    const pending = p.cases.filter(c => c.status === 'pending').length;
+    const lastStr = last ? ago(last.startedAt) + ' · ' + (last.gitHead ? last.gitHead.slice(0,7) : '—') : 'never';
+    const lastBadge = !last ? '<span class="muted">—</span>'
+      : last.exitCode === null ? '<span class="badge running">running</span>'
+      : last.exitCode === 0    ? '<span class="badge passed">passed</span>'
+                               : '<span class="badge failed">failed</span>';
+    return '<tr class="clickable" data-id="' + p.id + '">' +
+      '<td><strong>' + escape(p.title) + '</strong> <span class="muted">v' + escape(p.version) + '</span><br>' +
+        '<span class="muted" style="font-size:11px">' + escape(p.id) + '</span></td>' +
+      '<td>' + implemented + ' / ' + p.cases.length + ' implemented' +
+        (pending ? ' <span class="muted">(' + pending + ' pending)</span>' : '') + '</td>' +
+      '<td>' + lastStr + '</td>' +
+      '<td>' + lastBadge + '</td>' +
+    '</tr>';
+  }).join('');
+  view.innerHTML =
+    '<h1 style="margin:8px 0 12px;font-size:20px">Test plans</h1>' +
+    '<table><thead><tr><th>Plan</th><th>Coverage</th><th>Last run</th><th>Result</th></tr></thead>' +
+    '<tbody>' + rows + '</tbody></table>' +
+    '<div style="margin-top:14px"><a href="#/all-runs" class="muted">→ legacy: all runs</a></div>';
+  view.querySelectorAll('tr.clickable').forEach(tr => {
+    tr.addEventListener('click', () => location.hash = '#/plan/' + tr.dataset.id);
+  });
+}
+
+async function renderPlanDetail(planId) {
+  const [plan, runs] = await Promise.all([
+    fetch('/api/plans/' + planId).then(r => r.json()),
+    fetch('/api/plans/' + planId + '/runs').then(r => r.json()),
+  ]);
+  if (plan.error) { view.innerHTML = '<div class="empty">Plan not found.</div>'; return; }
+  const lastRun = runs[0];
+
+  // Per-case last result lookup (Phase 1: cheap, fetches the latest run only)
+  let lastCaseResults = [];
+  if (lastRun) {
+    const r = await fetch('/api/runs/' + lastRun.id).then(r => r.json());
+    lastCaseResults = r.caseResults || [];
+  }
+  const lastByCase = new Map(lastCaseResults.map(c => [c.caseId, c]));
+
+  const caseRows = plan.cases.map(c => {
+    const last = lastByCase.get(c.id);
+    const statusBadge = c.status === 'pending' ? '<span class="badge" style="background:var(--pill-bg);color:var(--muted)">pending</span>'
+      : c.status === 'skipped' ? '<span class="badge" style="background:var(--pill-bg);color:var(--muted)">skipped</span>'
+      : !last ? '<span class="muted">—</span>'
+      : last.status === 'passed' ? '<span class="badge passed">passed</span>'
+      : last.status === 'failed' ? '<span class="badge failed">failed</span>'
+      : last.status === 'running' ? '<span class="badge running">running</span>'
+      : '<span class="muted">—</span>';
+    const fbStr = last && last.feedback.length
+      ? last.feedback.map(f => f.count + ' ' + f.kind).join(' · ')
+      : '<span class="muted">—</span>';
+    const decision = last && last.decision
+      ? '<span class="decision-' + last.decision + '">' + last.decision + '</span>'
+      : '<span class="muted">—</span>';
+    const surfaceTag = '<span class="badge" style="background:var(--pill-bg);color:var(--muted)">' + c.surface + '</span>';
+    return '<tr><td><strong>' + escape(c.title) + '</strong> ' + surfaceTag + '<br><span class="muted" style="font-size:11px">' + escape(c.id) + (c.deps.length ? ' · deps: ' + c.deps.map(escape).join(', ') : '') + '</span></td>' +
+      '<td>' + statusBadge + '</td>' +
+      '<td>' + (last && last.stepCount ? last.stepCount + ' steps' : '<span class="muted">—</span>') + '</td>' +
+      '<td>' + fbStr + '</td>' +
+      '<td>' + decision + '</td>' +
+    '</tr>';
+  }).join('');
+
+  const runRows = runs.length ? runs.map(r => {
+    const exitBadge = r.exitCode === null ? '<span class="badge running">running</span>'
+      : r.exitCode === 0 ? '<span class="badge passed">passed</span>' : '<span class="badge failed">failed</span>';
+    const sha = r.gitHead ? r.gitHead.slice(0,7) : '—';
+    return '<tr class="clickable" data-id="' + r.id + '">' +
+      '<td>' + ago(r.startedAt) + '<br><span class="muted">' + r.id + '</span></td>' +
+      '<td>' + sha + '</td>' +
+      '<td>' + exitBadge + '</td>' +
+      '<td>' + (r.review ? '<span class="decision-' + r.review.decision + '">' + r.review.decision + '</span>' : '<span class="muted">—</span>') + '</td>' +
+    '</tr>';
+  }).join('') : '<tr><td colspan="4" class="muted" style="padding:18px;text-align:center">No runs yet — click "New run" to start.</td></tr>';
+
+  view.innerHTML =
+    '<div class="run-hero"><a href="#/" class="muted" style="font-size:12px">← all plans</a>' +
+      '<h1>' + escape(plan.title) + '</h1>' +
+      '<span class="muted">v' + escape(plan.version) + '</span></div>' +
+    (plan.description ? '<p class="muted" style="margin:0 0 12px;line-height:1.55">' + escape(plan.description) + '</p>' : '') +
+    '<div class="panel"><div class="row" style="justify-content:space-between"><h3 style="margin:0">Cases</h3>' +
+      '<button class="primary" id="new-plan-run">New run · all implemented</button></div>' +
+    '<table style="margin-top:10px"><thead><tr><th>Case</th><th>Last status</th><th>Steps</th><th>Pins (last run)</th><th>Decision</th></tr></thead>' +
+    '<tbody>' + caseRows + '</tbody></table></div>' +
+    '<div class="panel"><h3 style="margin:0 0 8px">Run history</h3>' +
+    '<table><thead><tr><th>When</th><th>Git</th><th>Result</th><th>Decision</th></tr></thead><tbody>' + runRows + '</tbody></table></div>';
+
+  document.getElementById('new-plan-run').addEventListener('click', async () => {
+    const r = await fetch('/api/plans/' + planId + '/runs', {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ scope: 'all' }),
+    }).then(r => r.json());
+    if (r.id) location.hash = '#/plan/' + planId + '/run/' + r.id;
+  });
+  view.querySelectorAll('tr.clickable').forEach(tr => {
+    tr.addEventListener('click', () => location.hash = '#/plan/' + planId + '/run/' + tr.dataset.id);
+  });
+}
+
+async function renderRunRollup(planId, runId) {
+  const [plan, run] = await Promise.all([
+    fetch('/api/plans/' + planId).then(r => r.json()),
+    fetch('/api/runs/' + runId).then(r => r.json()),
+  ]);
+  if (run.error || plan.error) { view.innerHTML = '<div class="empty">Run not found.</div>'; return; }
+  const tested = run.meta?.tested;
+  const t = tested?.git;
+  const headerBits = [];
+  if (t) headerBits.push('<span class="muted">git</span> <code>' + escape(t.shortHead) + '</code> <span class="muted">on</span> <code>' + escape(t.branch) + '</code>' + (t.dirty ? ' <span class="badge stale">dirty</span>' : ''));
+  headerBits.push('<span class="muted">started</span> ' + ago(run.startedAt));
+  if (run.endedAt) headerBits.push('<span class="muted">ended</span> ' + ago(run.endedAt));
+
+  const exitBadge = run.exitCode === null ? '<span class="badge running">running</span>'
+    : run.exitCode === 0 ? '<span class="badge passed">passed</span>' : '<span class="badge failed">failed</span>';
+  const decisionBadge = run.decisionRollup
+    ? ' · <span class="decision-' + run.decisionRollup + '">rollup: ' + run.decisionRollup + '</span>' : '';
+
+  const caseRows = (run.caseResults || []).map(c => {
+    const status = c.status === 'pending' ? '<span class="badge" style="background:var(--pill-bg);color:var(--muted)">pending</span>'
+      : c.status === 'skipped' ? '<span class="badge" style="background:var(--pill-bg);color:var(--muted)">skipped</span>'
+      : c.status === 'passed' ? '<span class="badge passed">passed</span>'
+      : c.status === 'failed' ? '<span class="badge failed">failed</span>'
+      : '<span class="badge running">running</span>';
+    const surfaceTag = '<span class="badge" style="background:var(--pill-bg);color:var(--muted)">' + c.surface + '</span>';
+    const fbStr = c.feedback.length ? c.feedback.map(f => f.count + ' ' + f.kind).join(' · ') : '<span class="muted">—</span>';
+    const drillIn = c.storyPath
+      ? '<a href="#/plan/' + escape(planId) + '/run/' + escape(runId) + '/' + escape(c.caseId) + '">open →</a>'
+      : '<span class="muted">no run</span>';
+    return '<tr><td><strong>' + escape(c.title) + '</strong> ' + surfaceTag + '<br><span class="muted" style="font-size:11px">' + escape(c.caseId) + '</span></td>' +
+      '<td>' + status + '</td>' +
+      '<td>' + (c.stepCount || '<span class="muted">—</span>') + '</td>' +
+      '<td>' + fbStr + '</td>' +
+      '<td>' + (c.decision ? '<span class="decision-' + c.decision + '">' + c.decision + '</span>' : '<span class="muted">—</span>') + '</td>' +
+      '<td>' + drillIn + '</td>' +
+    '</tr>';
+  }).join('');
+
+  const scriptsLine = tested?.scripts?.length
+    ? '<p class="muted" style="margin:0 0 12px;font-size:12px">Scripts at run start: ' +
+      tested.scripts.slice(0, 8).map(s => escape(s.id) + '@' + escape(s.version)).join(', ') +
+      (tested.scripts.length > 8 ? ' …' : '') + '</p>'
+    : '';
+
+  view.innerHTML =
+    '<div class="run-hero"><a href="#/plan/' + escape(planId) + '" class="muted" style="font-size:12px">← ' + escape(plan.title) + '</a>' +
+      '<h1>Run ' + escape(run.id) + '</h1>' + exitBadge + '<span>' + decisionBadge + '</span></div>' +
+    '<p class="muted" style="margin:0 0 6px;font-size:12px">' + headerBits.join(' · ') + '</p>' +
+    scriptsLine +
+    '<div class="panel"><h3 style="margin:0 0 8px">Cases in this run</h3>' +
+    '<table><thead><tr><th>Case</th><th>Status</th><th>Steps</th><th>Pins</th><th>Decision</th><th></th></tr></thead>' +
+    '<tbody>' + caseRows + '</tbody></table></div>' +
+    '<details' + (run.exitCode === 0 ? '' : ' open') + ' style="margin-top:16px"><summary style="cursor:pointer" class="muted">Output</summary>' +
+    '<pre class="output" id="run-output">' + escape(run.output ?? '') + '</pre></details>';
+}
+
 // ---------- routing -------------------------------------------------------
 function route() {
-  const m = location.hash.match(/^#\\/run\\/(.+)$/);
-  if (m) renderDetail(m[1]); else renderList();
+  const h = location.hash;
+  // #/plan/:id/run/:runId/:caseId
+  let m = h.match(/^#\\/plan\\/([^/]+)\\/run\\/([^/]+)\\/([^/]+)$/);
+  if (m) { renderDetail(m[2], { caseId: m[3], planId: m[1] }); return; }
+  // #/plan/:id/run/:runId
+  m = h.match(/^#\\/plan\\/([^/]+)\\/run\\/([^/]+)$/);
+  if (m) { renderRunRollup(m[1], m[2]); return; }
+  // #/plan/:id
+  m = h.match(/^#\\/plan\\/([^/]+)$/);
+  if (m) { renderPlanDetail(m[1]); return; }
+  // #/run/:id (legacy)
+  m = h.match(/^#\\/run\\/(.+)$/);
+  if (m) { renderDetail(m[1]); return; }
+  // #/all-runs (legacy table)
+  if (h === '#/all-runs') { renderList(); return; }
+  renderPlansList();
 }
 window.addEventListener('hashchange', route);
 
@@ -1307,6 +1728,8 @@ const server = http.createServer(async (req, res) => {
     const output = fs.existsSync(outputPath) ? fs.readFileSync(outputPath, 'utf-8')
                   : (currentRunId === r.id ? currentOutput : '')
     res.writeHead(200, { 'Content-Type': 'application/json' })
+    const meta = loadRunMeta(r.id)
+    const caseResults = r.planId ? caseResultsForRun(r) : []
     res.end(JSON.stringify({
       ...r,
       output,
@@ -1314,6 +1737,9 @@ const server = http.createServer(async (req, res) => {
       stories: listFrozenStories(r.id),
       feedback: loadFeedback(r.id),
       stale: isPotentiallyStale(r),
+      meta,
+      caseResults,
+      decisionRollup: r.planId ? runDecisionRollup(caseResults) : null,
     })); return
   }
 
@@ -1413,6 +1839,82 @@ const server = http.createServer(async (req, res) => {
       const i = sseClients.indexOf(res); if (i >= 0) sseClients.splice(i, 1)
     })
     return
+  }
+
+  // ---------- plan + case API (additive) ----------
+  if (p === '/api/plans' && req.method === 'GET') {
+    res.writeHead(200, { 'Content-Type': 'application/json' })
+    res.end(JSON.stringify(loadPlans())); return
+  }
+  const planDetail = p.match(/^\/api\/plans\/([^/]+)$/)
+  if (planDetail && req.method === 'GET') {
+    const plan = getPlan(planDetail[1])
+    if (!plan) { res.writeHead(404); res.end(JSON.stringify({ error: 'not found' })); return }
+    res.writeHead(200, { 'Content-Type': 'application/json' })
+    res.end(JSON.stringify(plan)); return
+  }
+  const planRuns = p.match(/^\/api\/plans\/([^/]+)\/runs$/)
+  if (planRuns && req.method === 'GET') {
+    const all = loadRuns().filter(r => r.planId === planRuns[1])
+      .map(r => ({ ...r, stale: isPotentiallyStale(r) }))
+    res.writeHead(200, { 'Content-Type': 'application/json' })
+    res.end(JSON.stringify(all)); return
+  }
+  if (planRuns && req.method === 'POST') {
+    let body = ''
+    req.on('data', d => body += d)
+    req.on('end', () => {
+      const plan = getPlan(planRuns[1])
+      if (!plan) { res.writeHead(404); res.end(JSON.stringify({ error: 'plan not found' })); return }
+      let scope: RunMeta['scope'] = 'all'
+      try { const parsed = JSON.parse(body || '{}'); if (parsed.scope) scope = parsed.scope } catch { /* */ }
+      // Resolve which spec(s) to run for the chosen cases.
+      const wantedIds = scope === 'all' ? null : new Set(scope.caseIds)
+      const specs = plan.cases
+        .filter(c => c.status === 'implemented' && c.spec)
+        .filter(c => !wantedIds || wantedIds.has(c.id))
+        .map(c => `e2e/${c.spec}`)
+      if (!specs.length) { res.writeHead(400); res.end(JSON.stringify({ error: 'no implemented cases match the scope' })); return }
+      // Phase 1: if multiple specs, Playwright runs them all in one invocation
+      // when we omit the spec arg and let it match by directory. For now we
+      // accept the case where a single case is selected; multi-spec runs use
+      // an empty spec arg so Playwright runs the project default.
+      const spec = specs.length === 1 ? specs[0] : ''
+      const run = startRun({ spec, planId: plan.id, scope })
+      if (!run) { res.writeHead(409); res.end(JSON.stringify({ error: 'a run is already in progress' })); return }
+      res.writeHead(202, { 'Content-Type': 'application/json' })
+      res.end(JSON.stringify({ id: run.id }))
+    })
+    return
+  }
+  const caseDetail = p.match(/^\/api\/runs\/([^/]+)\/cases\/([^/]+)$/)
+  if (caseDetail && req.method === 'GET') {
+    const r = getRun(caseDetail[1])
+    if (!r) { res.writeHead(404); res.end(JSON.stringify({ error: 'run not found' })); return }
+    const storyPath = resolveCaseStoryPath(r.id, caseDetail[2])
+    const stories = listFrozenStories(r.id)
+    const story = storyPath ? stories.find(s => s.path === storyPath) ?? null : null
+    const fb = loadFeedback(r.id).filter(f => storyPath ? f.storyPath === storyPath : false)
+    const review = loadCaseReview(r.id, caseDetail[2])
+    res.writeHead(200, { 'Content-Type': 'application/json' })
+    res.end(JSON.stringify({ caseId: caseDetail[2], story, feedback: fb, review })); return
+  }
+  const caseReview = p.match(/^\/api\/runs\/([^/]+)\/cases\/([^/]+)\/review$/)
+  if (caseReview && req.method === 'POST') {
+    let body = ''
+    req.on('data', d => body += d)
+    req.on('end', () => {
+      try {
+        const { summary, decision } = JSON.parse(body) as { summary: string; decision: Review['decision'] }
+        saveCaseReview(caseReview[1], caseReview[2], { summary: summary || '', decision, reviewedAt: Date.now() })
+        res.writeHead(200, { 'Content-Type': 'application/json' }); res.end(JSON.stringify({ ok: true }))
+      } catch (e) { res.writeHead(400); res.end(JSON.stringify({ error: String(e) })) }
+    })
+    return
+  }
+  if (caseReview && req.method === 'DELETE') {
+    saveCaseReview(caseReview[1], caseReview[2], null)
+    res.writeHead(200, { 'Content-Type': 'application/json' }); res.end(JSON.stringify({ ok: true })); return
   }
 
   // Frozen ad-hoc screenshot

--- a/web/scripts/review-server.ts
+++ b/web/scripts/review-server.ts
@@ -78,15 +78,25 @@ interface Run {
 }
 
 // ---------- plan model (new-style, additive) ------------------------------
+interface PlanStep {
+  id: string                // unique within the case
+  title: string
+  description: string
+  // Execution directives (web cases). Pending askmac cases omit these.
+  nav?: string              // page.goto(<path>)
+  waitMs?: number           // page.waitForTimeout(ms)
+}
 interface PlanCase {
   id: string
   scriptId: string
   surface: 'web' | 'askmac'
   title: string
+  description?: string      // human-readable case description
   spec?: string             // Playwright spec relative to web/e2e (web cases)
   driver?: string           // e.g. "computer-use" (askmac cases)
   deps: string[]
   status: 'implemented' | 'pending' | 'skipped'
+  steps?: PlanStep[]        // declared steps — source of truth for the spec
 }
 interface Plan {
   id: string
@@ -1536,9 +1546,10 @@ async function renderPlanDetail(planId) {
       ? '<span class="decision-' + last.decision + '">' + last.decision + '</span>'
       : '<span class="muted">—</span>';
     const surfaceTag = '<span class="badge" style="background:var(--pill-bg);color:var(--muted)">' + c.surface + '</span>';
-    return '<tr><td><strong>' + escape(c.title) + '</strong> ' + surfaceTag + '<br><span class="muted" style="font-size:11px">' + escape(c.id) + (c.deps.length ? ' · deps: ' + c.deps.map(escape).join(', ') : '') + '</span></td>' +
+    const declaredSteps = c.steps && c.steps.length ? c.steps.length + ' planned' : '—';
+    return '<tr class="clickable case-row" data-caseid="' + escape(c.id) + '"><td><strong>' + escape(c.title) + '</strong> ' + surfaceTag + '<br><span class="muted" style="font-size:11px">' + escape(c.id) + (c.deps.length ? ' · deps: ' + c.deps.map(escape).join(', ') : '') + '</span></td>' +
       '<td>' + statusBadge + '</td>' +
-      '<td>' + (last && last.stepCount ? last.stepCount + ' steps' : '<span class="muted">—</span>') + '</td>' +
+      '<td>' + (last && last.stepCount ? last.stepCount + ' steps' : '<span class="muted">' + declaredSteps + '</span>') + '</td>' +
       '<td>' + fbStr + '</td>' +
       '<td>' + decision + '</td>' +
     '</tr>';
@@ -1576,7 +1587,10 @@ async function renderPlanDetail(planId) {
     if (r.id) location.hash = '#/plan/' + planId + '/run/' + r.id;
   });
   view.querySelectorAll('tr.clickable').forEach(tr => {
-    tr.addEventListener('click', () => location.hash = '#/plan/' + planId + '/run/' + tr.dataset.id);
+    tr.addEventListener('click', () => {
+      if (tr.dataset.caseid) location.hash = '#/plan/' + planId + '/case/' + tr.dataset.caseid;
+      else if (tr.dataset.id) location.hash = '#/plan/' + planId + '/run/' + tr.dataset.id;
+    });
   });
 }
 
@@ -1636,12 +1650,105 @@ async function renderRunRollup(planId, runId) {
     '<pre class="output" id="run-output">' + escape(run.output ?? '') + '</pre></details>';
 }
 
+async function renderCaseDetail(planId, caseId) {
+  const r = await fetch('/api/plans/' + planId + '/cases/' + caseId).then(r => r.json());
+  if (r.error) { view.innerHTML = '<div class="empty">Case not found.</div>'; return; }
+  const c = r.case;
+  const surfaceTag = '<span class="badge" style="background:var(--pill-bg);color:var(--muted)">' + escape(c.surface) + '</span>';
+  const statusBadge = c.status === 'implemented'
+    ? '<span class="badge passed">implemented</span>'
+    : c.status === 'pending'
+      ? '<span class="badge" style="background:var(--pill-bg);color:var(--muted)">pending</span>'
+      : '<span class="badge" style="background:var(--pill-bg);color:var(--muted)">' + escape(c.status) + '</span>';
+  const depsLine = c.deps && c.deps.length
+    ? '<span class="muted">deps:</span> ' + c.deps.map(d => '<code>' + escape(d) + '</code>').join(' · ')
+    : '<span class="muted">no dependencies</span>';
+  const driverLine = c.spec
+    ? '<span class="muted">spec:</span> <code>' + escape(c.spec) + '</code>'
+    : c.driver
+      ? '<span class="muted">driver:</span> <code>' + escape(c.driver) + '</code>'
+      : '';
+
+  const stepsHtml = (c.steps || []).map((s, i) => {
+    const directive = s.nav ? '<code>nav → ' + escape(s.nav) + '</code>'
+      : s.waitMs ? '<code>wait ' + s.waitMs + 'ms</code>'
+      : '<span class="muted">—</span>';
+    return '<tr>' +
+      '<td style="width:50px"><strong>' + (i+1) + '</strong></td>' +
+      '<td><strong>' + escape(s.title) + '</strong><br>' +
+        '<span class="muted" style="font-size:11px">' + escape(s.id) + '</span></td>' +
+      '<td>' + escape(s.description) + '</td>' +
+      '<td style="width:160px">' + directive + '</td>' +
+    '</tr>';
+  }).join('');
+
+  const historyRows = (r.history || []).length
+    ? r.history.map(h => {
+        const status = h.status === 'passed' ? '<span class="badge passed">passed</span>'
+          : h.status === 'failed' ? '<span class="badge failed">failed</span>'
+          : '<span class="badge running">' + escape(h.status) + '</span>';
+        const fb = h.feedback.length ? h.feedback.map(f => f.count + ' ' + f.kind).join(' · ') : '<span class="muted">—</span>';
+        const decision = h.decision ? '<span class="decision-' + h.decision + '">' + h.decision + '</span>' : '<span class="muted">—</span>';
+        return '<tr class="clickable" data-runid="' + escape(h.runId) + '">' +
+          '<td>' + ago(h.startedAt) + '<br><span class="muted">' + escape(h.runId) + '</span></td>' +
+          '<td>' + status + '</td>' +
+          '<td>' + h.stepCount + ' steps</td>' +
+          '<td>' + fb + '</td>' +
+          '<td>' + decision + '</td>' +
+          '<td><a href="#/plan/' + escape(planId) + '/run/' + escape(h.runId) + '/' + escape(c.id) + '">open →</a></td>' +
+        '</tr>';
+      }).join('')
+    : '<tr><td colspan="6" class="muted" style="padding:18px;text-align:center">No runs of this case yet.</td></tr>';
+
+  const isPending = c.status === 'pending';
+  const runScopedBtn = !isPending
+    ? '<button class="primary" id="run-this-case">Run only this case</button>'
+    : '<span class="muted" style="font-size:12px">This case is pending — driver is <code>' + escape(c.driver || 'not set') + '</code> (Phase 3).</span>';
+
+  view.innerHTML =
+    '<div class="run-hero">' +
+      '<a href="#/plan/' + escape(planId) + '" class="muted" style="font-size:12px">← ' + escape(r.plan.title) + '</a>' +
+      '<h1>' + escape(c.title) + '</h1>' + surfaceTag + statusBadge +
+    '</div>' +
+    (c.description ? '<p class="muted" style="margin:0 0 8px;line-height:1.55">' + escape(c.description) + '</p>' : '') +
+    '<p class="muted" style="margin:0 0 14px;font-size:12px">' + depsLine + (driverLine ? ' · ' + driverLine : '') + '</p>' +
+    '<div class="panel"><div class="row" style="justify-content:space-between"><h3 style="margin:0">Declared steps · ' + (c.steps ? c.steps.length : 0) + '</h3>' + runScopedBtn + '</div>' +
+    (c.steps && c.steps.length
+      ? '<table style="margin-top:10px"><thead><tr><th>#</th><th>Step</th><th>Description</th><th>Directive</th></tr></thead>' +
+        '<tbody>' + stepsHtml + '</tbody></table>'
+      : '<p class="muted" style="margin:8px 0 0">No steps declared yet.</p>') +
+    '</div>' +
+    '<div class="panel"><h3 style="margin:0 0 8px">Run history for this case</h3>' +
+    '<table><thead><tr><th>When</th><th>Status</th><th>Steps</th><th>Pins</th><th>Decision</th><th></th></tr></thead>' +
+    '<tbody>' + historyRows + '</tbody></table></div>';
+
+  const runBtn = document.getElementById('run-this-case');
+  if (runBtn) {
+    runBtn.addEventListener('click', async () => {
+      const r = await fetch('/api/plans/' + planId + '/runs', {
+        method: 'POST', headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ scope: { caseIds: [c.id] } }),
+      }).then(r => r.json());
+      if (r.id) location.hash = '#/plan/' + planId + '/run/' + r.id;
+      else if (r.error) alert(r.error);
+    });
+  }
+  view.querySelectorAll('tr.clickable').forEach(tr => {
+    tr.addEventListener('click', () => {
+      location.hash = '#/plan/' + planId + '/run/' + tr.dataset.runid + '/' + c.id;
+    });
+  });
+}
+
 // ---------- routing -------------------------------------------------------
 function route() {
   const h = location.hash;
   // #/plan/:id/run/:runId/:caseId
   let m = h.match(/^#\\/plan\\/([^/]+)\\/run\\/([^/]+)\\/([^/]+)$/);
   if (m) { renderDetail(m[2], { caseId: m[3], planId: m[1] }); return; }
+  // #/plan/:id/case/:caseId — case detail view (declared steps, history)
+  m = h.match(/^#\\/plan\\/([^/]+)\\/case\\/([^/]+)$/);
+  if (m) { renderCaseDetail(m[1], m[2]); return; }
   // #/plan/:id/run/:runId
   m = h.match(/^#\\/plan\\/([^/]+)\\/run\\/([^/]+)$/);
   if (m) { renderRunRollup(m[1], m[2]); return; }
@@ -1892,6 +1999,31 @@ const server = http.createServer(async (req, res) => {
       res.writeHead(202, { 'Content-Type': 'application/json' })
       res.end(JSON.stringify({ id: run.id }))
     })
+    return
+  }
+  // Plan-level case detail — used by the case detail route to show the
+  // declared case + its last result across all runs of this plan.
+  const planCaseDetail = p.match(/^\/api\/plans\/([^/]+)\/cases\/([^/]+)$/)
+  if (planCaseDetail && req.method === 'GET') {
+    const plan = getPlan(planCaseDetail[1])
+    if (!plan) { res.writeHead(404); res.end(JSON.stringify({ error: 'plan not found' })); return }
+    const c = plan.cases.find(c => c.id === planCaseDetail[2])
+    if (!c) { res.writeHead(404); res.end(JSON.stringify({ error: 'case not found' })); return }
+    // Walk runs of this plan (newest first) and gather: last result + history.
+    const runs = loadRuns().filter(r => r.planId === plan.id)
+    const history: Array<{ runId: string; startedAt: number; status: CaseResult['status']; stepCount: number; feedback: CaseResult['feedback']; decision: CaseResult['decision'] }> = []
+    for (const r of runs) {
+      const results = caseResultsForRun(r)
+      const cr = results.find(x => x.caseId === c.id)
+      if (!cr) continue
+      if (cr.status === 'pending' || cr.status === 'skipped') continue
+      history.push({
+        runId: r.id, startedAt: r.startedAt, status: cr.status,
+        stepCount: cr.stepCount, feedback: cr.feedback, decision: cr.decision,
+      })
+    }
+    res.writeHead(200, { 'Content-Type': 'application/json' })
+    res.end(JSON.stringify({ plan: { id: plan.id, title: plan.title, version: plan.version }, case: c, history }))
     return
   }
   const caseDetail = p.match(/^\/api\/runs\/([^/]+)\/cases\/([^/]+)$/)

--- a/web/scripts/review-server.ts
+++ b/web/scripts/review-server.ts
@@ -1743,24 +1743,60 @@ async function renderRunRollup(planId, runId) {
   const decisionBadge = run.decisionRollup
     ? ' · <span class="decision-' + run.decisionRollup + '">rollup: ' + run.decisionRollup + '</span>' : '';
 
-  const caseRows = (run.caseResults || []).map(c => {
-    const status = c.status === 'pending' ? '<span class="badge" style="background:var(--pill-bg);color:var(--muted)">pending</span>'
-      : c.status === 'skipped' ? '<span class="badge" style="background:var(--pill-bg);color:var(--muted)">skipped</span>'
-      : c.status === 'passed' ? '<span class="badge passed">passed</span>'
-      : c.status === 'failed' ? '<span class="badge failed">failed</span>'
-      : '<span class="badge running">running</span>';
-    const surfaceTag = '<span class="badge" style="background:var(--pill-bg);color:var(--muted)">' + c.surface + '</span>';
-    const fbStr = c.feedback.length ? c.feedback.map(f => f.count + ' ' + f.kind).join(' · ') : '<span class="muted">—</span>';
-    const drillIn = c.storyPath
-      ? '<a href="#/plan/' + escape(planId) + '/run/' + escape(runId) + '/' + escape(c.caseId) + '">open →</a>'
-      : '<span class="muted">no run</span>';
-    return '<tr><td><strong>' + escape(c.title) + '</strong> ' + surfaceTag + '<br><span class="muted" style="font-size:11px">' + escape(c.caseId) + '</span></td>' +
-      '<td>' + status + '</td>' +
-      '<td>' + (c.stepCount || '<span class="muted">—</span>') + '</td>' +
-      '<td>' + fbStr + '</td>' +
-      '<td>' + (c.decision ? '<span class="decision-' + c.decision + '">' + c.decision + '</span>' : '<span class="muted">—</span>') + '</td>' +
-      '<td>' + drillIn + '</td>' +
-    '</tr>';
+  // Build a story map so each case can show real screenshots when available.
+  const storyByPath = new Map();
+  for (const s of (run.stories || [])) storyByPath.set(s.path, s);
+
+  // Find the plan-declared case for richer info (description, declared steps).
+  const planCases = new Map((plan.cases || []).map(c => [c.id, c]));
+
+  const caseCards = (run.caseResults || []).map(c => {
+    const planCase = planCases.get(c.caseId);
+    const story = c.storyPath ? storyByPath.get(c.storyPath) : null;
+    const surfaceTag = '<span class="surface-pill">' + escape(c.surface) + '</span>';
+    const statusBadge = c.status === 'passed'   ? '<span class="badge passed">passed</span>'
+      : c.status === 'failed'                   ? '<span class="badge failed">failed</span>'
+      : c.status === 'running'                  ? '<span class="badge running">running</span>'
+      : c.status === 'skipped'                  ? '<span class="badge" style="background:var(--pill-bg);color:var(--muted)">skipped</span>'
+      :                                           '<span class="badge" style="background:var(--pill-bg);color:var(--muted)">' + escape(c.status) + '</span>';
+    const fbLine = c.feedback.length ? c.feedback.map(f => f.count + ' ' + f.kind).join(' · ') : 'no pins';
+    const decisionTag = c.decision ? ' · <span class="decision-' + c.decision + '">' + escape(c.decision) + '</span>' : '';
+
+    // Build the strip from declared steps; swap in real screenshots when present.
+    const declared = planCase?.steps || (story?.steps || []).map((s, i) => ({ id: 'step-' + i, title: s.title, description: '' }));
+    const stripCells = declared.map((ds, i) => {
+      const captured = story?.steps?.[i];
+      if (captured?.file) {
+        const url = '/runs/' + escape(run.id) + '/story/' + encodeURI(story.path) + '/' + encodeURI(captured.file);
+        return '<div class="thumb" data-step="' + i + '">' +
+          '<div class="img"><span class="num">' + (i+1) + '</span><img loading="lazy" src="' + url + '"></div>' +
+          '<div class="cap">' + escape(ds.title) + '</div>' +
+        '</div>';
+      }
+      const dir = ds.nav ? 'nav → ' + ds.nav : (typeof ds.waitMs === 'number' ? 'wait ' + ds.waitMs + 'ms' : '');
+      return '<div class="thumb placeholder" data-step="' + i + '">' +
+        '<div class="img"><div class="ph-num">' + (i+1) + '</div>' +
+          (dir ? '<div class="ph-dir">' + escape(dir) + '</div>' : '') + '</div>' +
+        '<div class="cap">' + escape(ds.title) + '</div>' +
+      '</div>';
+    }).join('');
+    const stripHtml = declared.length ? '<div class="strip">' + stripCells + '</div>' : '';
+
+    const actions = c.storyPath
+      ? '<button class="primary" data-act="open-slides" data-caseid="' + escape(c.caseId) + '">Open story →</button>'
+      : (planCase?.status === 'pending'
+          ? '<span class="muted" style="font-size:12px">pending — no run captured</span>'
+          : '<span class="muted" style="font-size:12px">no story (test failed before any step)</span>');
+
+    return '<div class="card" data-caseid="' + escape(c.caseId) + '" data-runid="' + escape(run.id) + '" data-storypath="' + escape(c.storyPath || '') + '">' +
+      '<div class="head"><h2>' + escape(c.title) + '</h2>' + surfaceTag + statusBadge + '</div>' +
+      (planCase?.description ? '<p class="desc">' + escape(planCase.description) + '</p>' : '') +
+      '<div class="meta">' +
+        '<span>' + (c.stepCount || declared.length) + ' steps · <strong>' + fbLine + '</strong>' + decisionTag + '</span>' +
+      '</div>' +
+      stripHtml +
+      '<div class="actions">' + actions + '</div>' +
+    '</div>';
   }).join('');
 
   const scriptsLine = tested?.scripts?.length
@@ -1774,11 +1810,43 @@ async function renderRunRollup(planId, runId) {
       '<h1>Run ' + escape(run.id) + '</h1>' + exitBadge + '<span>' + decisionBadge + '</span></div>' +
     '<p class="muted" style="margin:0 0 6px;font-size:12px">' + headerBits.join(' · ') + '</p>' +
     scriptsLine +
-    '<div class="panel"><h3 style="margin:0 0 8px">Cases in this run</h3>' +
-    '<table><thead><tr><th>Case</th><th>Status</th><th>Steps</th><th>Pins</th><th>Decision</th><th></th></tr></thead>' +
-    '<tbody>' + caseRows + '</tbody></table></div>' +
-    '<details' + (run.exitCode === 0 ? '' : ' open') + ' style="margin-top:16px"><summary style="cursor:pointer" class="muted">Output</summary>' +
+    '<div class="gallery">' + caseCards + '</div>' +
+    '<details' + (run.exitCode === 0 ? '' : ' open') + ' style="margin-top:16px"><summary style="cursor:pointer" class="muted">Run output</summary>' +
     '<pre class="output" id="run-output">' + escape(run.output ?? '') + '</pre></details>';
+
+  // Card click → open the case's slideshow if a story exists, else go to case detail.
+  view.querySelectorAll('.gallery .card').forEach(card => {
+    card.addEventListener('click', (ev) => {
+      if (ev.target.closest('button')) return;
+      if (ev.target.closest('.thumb')) return;
+      const cid = card.dataset.caseid;
+      const sp = card.dataset.storypath;
+      if (sp) location.hash = '#/plan/' + planId + '/run/' + runId + '/' + cid;
+      else    location.hash = '#/plan/' + planId + '/case/' + cid;
+    });
+  });
+  // Thumb click → jump to that step in the slideshow.
+  view.querySelectorAll('.gallery .thumb').forEach(thumb => {
+    thumb.addEventListener('click', (ev) => {
+      ev.stopPropagation();
+      const card = thumb.closest('.card');
+      const cid = card?.dataset.caseid;
+      const sp = card?.dataset.storypath;
+      const stepIdx = parseInt(thumb.dataset.step, 10);
+      if (sp && cid && !thumb.classList.contains('placeholder')) {
+        try { sessionStorage.setItem('slide:' + runId, String(stepIdx)); } catch { /* */ }
+        location.hash = '#/plan/' + planId + '/run/' + runId + '/' + cid;
+      }
+    });
+  });
+  // "Open story →" button
+  view.querySelectorAll('button[data-act="open-slides"]').forEach(b => {
+    b.addEventListener('click', (ev) => {
+      ev.stopPropagation();
+      const cid = b.dataset.caseid;
+      location.hash = '#/plan/' + planId + '/run/' + runId + '/' + cid;
+    });
+  });
 }
 
 async function renderCaseDetail(planId, caseId) {
@@ -1924,13 +1992,19 @@ es.addEventListener('done', async (e) => {
     try {
       const r = await fetch('/api/runs/' + finishedId).then(r => r.json());
       if (r && r.planId && Array.isArray(r.caseResults)) {
-        const firstCase = r.caseResults.find(c => c.storyPath && (c.status === 'passed' || c.status === 'failed'));
-        if (firstCase) {
-          // If the user is on a slideshow already, don't yank them.
-          if (!location.hash.match(/^#\\/plan\\/[^/]+\\/run\\/[^/]+\\/[^/]+$/)) {
-            location.hash = '#/plan/' + r.planId + '/run/' + finishedId + '/' + firstCase.caseId;
-            return;
+        const finished = r.caseResults.filter(c => c.storyPath && (c.status === 'passed' || c.status === 'failed'));
+        // Don't yank them out of a slideshow they navigated to mid-run.
+        const onSlideshow = !!location.hash.match(/^#\\/plan\\/[^/]+\\/run\\/[^/]+\\/[^/]+$/);
+        if (!onSlideshow && finished.length > 0) {
+          // Multi-case runs → land on the rollup (gallery of cases) so the
+          // user can pick which one to dive into. Single-case runs → drop
+          // straight into that case's slideshow.
+          if (finished.length === 1) {
+            location.hash = '#/plan/' + r.planId + '/run/' + finishedId + '/' + finished[0].caseId;
+          } else {
+            location.hash = '#/plan/' + r.planId + '/run/' + finishedId;
           }
+          return;
         }
       }
     } catch { /* fall through to route() */ }

--- a/web/scripts/review-server.ts
+++ b/web/scripts/review-server.ts
@@ -747,6 +747,33 @@ const HTML = `<!doctype html>
   figure { margin: 0; background: var(--panel); border: 1px solid var(--border); border-radius: 8px; overflow: hidden; box-shadow: var(--shadow); }
   figure img { display: block; width: 100%; cursor: zoom-in; background: var(--code-bg); }
   figcaption { padding: 7px 10px; font-size: 11px; color: var(--muted); display: flex; justify-content: space-between; border-top: 1px solid var(--border); }
+  /* ----- Cards (plan + case galleries) ----- */
+  .gallery { display: grid; grid-template-columns: 1fr; gap: 14px; }
+  .card { background: var(--panel); border: 1px solid var(--border); border-radius: 10px; padding: 14px 16px; box-shadow: var(--shadow); cursor: pointer; transition: transform .12s ease, box-shadow .12s ease, border-color .12s ease; }
+  .card:hover { border-color: var(--primary); transform: translateY(-1px); box-shadow: 0 4px 14px rgba(0,0,0,0.06); }
+  [data-theme="dark"] .card:hover { box-shadow: 0 4px 14px rgba(0,0,0,0.5); }
+  .card .head { display: flex; align-items: baseline; gap: 10px; flex-wrap: wrap; margin-bottom: 4px; }
+  .card .head h2 { margin: 0; font-size: 17px; font-weight: 600; }
+  .card .head .ver { color: var(--muted); font-size: 12px; }
+  .card .desc { color: var(--text); font-size: 13px; line-height: 1.55; margin: 4px 0 10px; }
+  .card .meta { color: var(--muted); font-size: 12px; display: flex; flex-wrap: wrap; gap: 14px; }
+  .card .meta code { background: var(--code-bg); padding: 1px 5px; border-radius: 3px; font-size: 11px; }
+  .card .actions { margin-top: 10px; display: flex; gap: 6px; flex-wrap: wrap; }
+  .card .actions button { font-size: 12px; padding: 5px 12px; }
+  /* Step thumbnail strip */
+  .strip { display: flex; gap: 8px; margin-top: 12px; overflow-x: auto; padding-bottom: 4px; }
+  .thumb { flex: 0 0 130px; border: 1px solid var(--border); border-radius: 6px; overflow: hidden; cursor: pointer; background: var(--panel); transition: border-color .12s ease, transform .12s ease; }
+  .thumb:hover { border-color: var(--primary); transform: translateY(-1px); }
+  .thumb .img { aspect-ratio: 16/10; background: var(--code-bg); position: relative; display: flex; align-items: center; justify-content: center; overflow: hidden; }
+  .thumb .img img { width: 100%; height: 100%; object-fit: cover; display: block; }
+  /* placeholder slate for unreached / pending steps */
+  .thumb.placeholder .img { background: linear-gradient(135deg, var(--code-bg), var(--row-hover)); padding: 8px; flex-direction: column; gap: 4px; text-align: center; }
+  .thumb.placeholder .img .ph-num { font-size: 22px; font-weight: 700; color: var(--muted); line-height: 1; }
+  .thumb.placeholder .img .ph-dir { font-size: 10px; color: var(--muted); font-family: ui-monospace, monospace; }
+  .thumb .num { position: absolute; top: 4px; left: 4px; background: rgba(0,0,0,.55); color: #fff; font-size: 10px; font-weight: 700; padding: 1px 6px; border-radius: 8px; z-index: 1; }
+  .thumb .cap { padding: 6px 7px; font-size: 11px; color: var(--text); line-height: 1.25; max-height: 30px; overflow: hidden; text-overflow: ellipsis; }
+  .surface-pill { font-size: 10px; padding: 1px 6px; border-radius: 4px; background: var(--pill-bg); color: var(--muted); text-transform: uppercase; letter-spacing: 0.04em; }
+  .deps-line code { background: var(--code-bg); padding: 1px 5px; border-radius: 3px; font-size: 11px; margin-right: 4px; }
 </style>
 </head>
 <body data-theme="light">
@@ -1477,40 +1504,61 @@ async function renderPlansList() {
     fetch('/api/plans').then(r => r.json()),
     fetch('/api/runs').then(r => r.json()),
   ]);
-  // Last run per plan (newest first because /api/runs is sorted that way)
   const lastByPlan = new Map();
   for (const r of runs) { if (r.planId && !lastByPlan.has(r.planId)) lastByPlan.set(r.planId, r); }
   if (!plans.length) {
     view.innerHTML =
-      '<div class="empty">No plans yet. Drop a JSON plan into <code>web/.review/plans/</code> and reload.<br><br>' +
+      '<div class="empty">No plans yet. Drop a JSON plan into <code>web/review-plans/</code> and reload.<br><br>' +
       '<a href="#/all-runs" class="muted">→ legacy: all runs</a></div>';
     return;
   }
-  const rows = plans.map(p => {
+  // For each plan, fetch the latest run's stories so we can show 4 case-cover thumbnails.
+  const planCovers = await Promise.all(plans.map(async p => {
+    const last = lastByPlan.get(p.id);
+    if (!last) return { id: p.id, thumbs: [] };
+    try {
+      const detail = await fetch('/api/runs/' + last.id).then(r => r.json());
+      const thumbs = (detail.stories || []).slice(0, 4).map(s => {
+        const first = s.steps?.[0];
+        return first?.file ? '/runs/' + last.id + '/story/' + encodeURI(s.path) + '/' + encodeURI(first.file) : null;
+      }).filter(Boolean);
+      return { id: p.id, thumbs };
+    } catch { return { id: p.id, thumbs: [] }; }
+  }));
+  const coverFor = (pid) => (planCovers.find(c => c.id === pid)?.thumbs) || [];
+
+  const cards = plans.map(p => {
     const last = lastByPlan.get(p.id);
     const implemented = p.cases.filter(c => c.status === 'implemented').length;
     const pending = p.cases.filter(c => c.status === 'pending').length;
-    const lastStr = last ? ago(last.startedAt) + ' · ' + (last.gitHead ? last.gitHead.slice(0,7) : '—') : 'never';
-    const lastBadge = !last ? '<span class="muted">—</span>'
+    const lastBadge = !last ? '<span class="muted">never run</span>'
       : last.exitCode === null ? '<span class="badge running">running</span>'
       : last.exitCode === 0    ? '<span class="badge passed">passed</span>'
                                : '<span class="badge failed">failed</span>';
-    return '<tr class="clickable" data-id="' + p.id + '">' +
-      '<td><strong>' + escape(p.title) + '</strong> <span class="muted">v' + escape(p.version) + '</span><br>' +
-        '<span class="muted" style="font-size:11px">' + escape(p.id) + '</span></td>' +
-      '<td>' + implemented + ' / ' + p.cases.length + ' implemented' +
-        (pending ? ' <span class="muted">(' + pending + ' pending)</span>' : '') + '</td>' +
-      '<td>' + lastStr + '</td>' +
-      '<td>' + lastBadge + '</td>' +
-    '</tr>';
+    const lastStr = last
+      ? ago(last.startedAt) + (last.gitHead ? ' · <code>' + escape(last.gitHead.slice(0,7)) + '</code>' : '')
+      : '';
+    const thumbs = coverFor(p.id);
+    const stripHtml = thumbs.length
+      ? '<div class="strip">' + thumbs.map((t, i) => '<div class="thumb"><div class="img"><span class="num">' + (i+1) + '</span><img loading="lazy" src="' + t + '"></div></div>').join('') + '</div>'
+      : '';
+    return '<div class="card" data-id="' + escape(p.id) + '">' +
+      '<div class="head"><h2>' + escape(p.title) + '</h2><span class="ver">v' + escape(p.version) + '</span>' + lastBadge + '</div>' +
+      (p.description ? '<p class="desc">' + escape(p.description) + '</p>' : '') +
+      '<div class="meta">' +
+        '<span><strong>' + p.cases.length + '</strong> cases · ' + implemented + ' implemented' + (pending ? ' · ' + pending + ' pending' : '') + '</span>' +
+        (last ? '<span>last run ' + lastStr + '</span>' : '') +
+      '</div>' +
+      stripHtml +
+    '</div>';
   }).join('');
+
   view.innerHTML =
-    '<h1 style="margin:8px 0 12px;font-size:20px">Test plans</h1>' +
-    '<table><thead><tr><th>Plan</th><th>Coverage</th><th>Last run</th><th>Result</th></tr></thead>' +
-    '<tbody>' + rows + '</tbody></table>' +
-    '<div style="margin-top:14px"><a href="#/all-runs" class="muted">→ legacy: all runs</a></div>';
-  view.querySelectorAll('tr.clickable').forEach(tr => {
-    tr.addEventListener('click', () => location.hash = '#/plan/' + tr.dataset.id);
+    '<h1 style="margin:8px 0 14px;font-size:20px">Test plans</h1>' +
+    '<div class="gallery">' + cards + '</div>' +
+    '<div style="margin-top:18px"><a href="#/all-runs" class="muted" style="font-size:12px">→ legacy: all runs</a></div>';
+  view.querySelectorAll('.card').forEach(card => {
+    card.addEventListener('click', () => location.hash = '#/plan/' + card.dataset.id);
   });
 }
 
@@ -1522,39 +1570,79 @@ async function renderPlanDetail(planId) {
   if (plan.error) { view.innerHTML = '<div class="empty">Plan not found.</div>'; return; }
   const lastRun = runs[0];
 
-  // Per-case last result lookup (Phase 1: cheap, fetches the latest run only)
+  // Last-run case data (steps + files for thumbnails) when available.
+  let lastDetail = null;
   let lastCaseResults = [];
   if (lastRun) {
-    const r = await fetch('/api/runs/' + lastRun.id).then(r => r.json());
-    lastCaseResults = r.caseResults || [];
+    lastDetail = await fetch('/api/runs/' + lastRun.id).then(r => r.json());
+    lastCaseResults = lastDetail.caseResults || [];
   }
   const lastByCase = new Map(lastCaseResults.map(c => [c.caseId, c]));
+  const storyByCase = new Map();
+  for (const s of (lastDetail?.stories || [])) storyByCase.set(s.path, s);
 
-  const caseRows = plan.cases.map(c => {
+  // Build a case card. Pre-run cases show placeholder slates with the
+  // declared step titles + directives so the story is browsable before
+  // any run exists. Post-run cases swap in real screenshots.
+  const cardFor = (c) => {
     const last = lastByCase.get(c.id);
-    const statusBadge = c.status === 'pending' ? '<span class="badge" style="background:var(--pill-bg);color:var(--muted)">pending</span>'
-      : c.status === 'skipped' ? '<span class="badge" style="background:var(--pill-bg);color:var(--muted)">skipped</span>'
-      : !last ? '<span class="muted">—</span>'
-      : last.status === 'passed' ? '<span class="badge passed">passed</span>'
-      : last.status === 'failed' ? '<span class="badge failed">failed</span>'
+    const story = (last?.storyPath && storyByCase.get(last.storyPath)) || null;
+    const statusBadge = c.status === 'pending'
+      ? '<span class="badge" style="background:var(--pill-bg);color:var(--muted)">pending · phase 3</span>'
+      : c.status === 'skipped'
+      ? '<span class="badge" style="background:var(--pill-bg);color:var(--muted)">skipped</span>'
+      : !last
+      ? '<span class="muted" style="font-size:12px">never run</span>'
+      : last.status === 'passed'  ? '<span class="badge passed">passed</span>'
+      : last.status === 'failed'  ? '<span class="badge failed">failed</span>'
       : last.status === 'running' ? '<span class="badge running">running</span>'
       : '<span class="muted">—</span>';
-    const fbStr = last && last.feedback.length
+    const surfaceTag = '<span class="surface-pill">' + escape(c.surface) + '</span>';
+    const depsLine = c.deps.length
+      ? '<span class="deps-line"><span class="muted">deps:</span> ' + c.deps.map(d => '<code>' + escape(d) + '</code>').join('') + '</span>'
+      : '';
+    const fbLine = last?.feedback?.length
       ? last.feedback.map(f => f.count + ' ' + f.kind).join(' · ')
-      : '<span class="muted">—</span>';
-    const decision = last && last.decision
-      ? '<span class="decision-' + last.decision + '">' + last.decision + '</span>'
-      : '<span class="muted">—</span>';
-    const surfaceTag = '<span class="badge" style="background:var(--pill-bg);color:var(--muted)">' + c.surface + '</span>';
-    const declaredSteps = c.steps && c.steps.length ? c.steps.length + ' planned' : '—';
-    return '<tr class="clickable case-row" data-caseid="' + escape(c.id) + '"><td><strong>' + escape(c.title) + '</strong> ' + surfaceTag + '<br><span class="muted" style="font-size:11px">' + escape(c.id) + (c.deps.length ? ' · deps: ' + c.deps.map(escape).join(', ') : '') + '</span></td>' +
-      '<td>' + statusBadge + '</td>' +
-      '<td>' + (last && last.stepCount ? last.stepCount + ' steps' : '<span class="muted">' + declaredSteps + '</span>') + '</td>' +
-      '<td>' + fbStr + '</td>' +
-      '<td>' + decision + '</td>' +
-    '</tr>';
-  }).join('');
+      : '';
 
+    // Build the strip: real captured images for a finished run, otherwise
+    // placeholder slates with step number + directive label.
+    const declared = c.steps || [];
+    const stripCells = declared.map((s, i) => {
+      const captured = story?.steps?.[i];
+      if (captured?.file) {
+        const url = '/runs/' + lastRun.id + '/story/' + encodeURI(story.path) + '/' + encodeURI(captured.file);
+        return '<div class="thumb" data-step="' + i + '">' +
+          '<div class="img"><span class="num">' + (i+1) + '</span><img loading="lazy" src="' + url + '"></div>' +
+          '<div class="cap">' + escape(s.title) + '</div>' +
+        '</div>';
+      }
+      const dir = s.nav ? 'nav → ' + s.nav : (typeof s.waitMs === 'number' ? 'wait ' + s.waitMs + 'ms' : '');
+      return '<div class="thumb placeholder" data-step="' + i + '">' +
+        '<div class="img"><div class="ph-num">' + (i+1) + '</div>' +
+          (dir ? '<div class="ph-dir">' + escape(dir) + '</div>' : '') + '</div>' +
+        '<div class="cap">' + escape(s.title) + '</div>' +
+      '</div>';
+    }).join('');
+    const stripHtml = declared.length ? '<div class="strip">' + stripCells + '</div>' : '';
+
+    const actions = c.status === 'implemented'
+      ? '<button class="primary" data-act="run" data-caseid="' + escape(c.id) + '">Run only this case</button>' +
+        '<button data-act="open" data-caseid="' + escape(c.id) + '">Open case</button>'
+      : '<button data-act="open" data-caseid="' + escape(c.id) + '">Open case</button>';
+
+    return '<div class="card" data-caseid="' + escape(c.id) + '" data-runid="' + escape(lastRun?.id || '') + '" data-storypath="' + escape(story?.path || '') + '">' +
+      '<div class="head"><h2>' + escape(c.title) + '</h2>' + surfaceTag + statusBadge + '</div>' +
+      (c.description ? '<p class="desc">' + escape(c.description) + '</p>' : '') +
+      '<div class="meta">' + depsLine +
+        (last ? '<span>' + last.stepCount + ' steps · ' + (fbLine ? '<strong>' + fbLine + '</strong>' : 'no pins') + '</span>' : '') +
+      '</div>' +
+      stripHtml +
+      '<div class="actions">' + actions + '</div>' +
+    '</div>';
+  };
+
+  // Run history kept compact in a collapsed details panel.
   const runRows = runs.length ? runs.map(r => {
     const exitBadge = r.exitCode === null ? '<span class="badge running">running</span>'
       : r.exitCode === 0 ? '<span class="badge passed">passed</span>' : '<span class="badge failed">failed</span>';
@@ -1565,32 +1653,75 @@ async function renderPlanDetail(planId) {
       '<td>' + exitBadge + '</td>' +
       '<td>' + (r.review ? '<span class="decision-' + r.review.decision + '">' + r.review.decision + '</span>' : '<span class="muted">—</span>') + '</td>' +
     '</tr>';
-  }).join('') : '<tr><td colspan="4" class="muted" style="padding:18px;text-align:center">No runs yet — click "New run" to start.</td></tr>';
+  }).join('') : '<tr><td colspan="4" class="muted" style="padding:18px;text-align:center">No runs yet — click "New run" above.</td></tr>';
 
   view.innerHTML =
     '<div class="run-hero"><a href="#/" class="muted" style="font-size:12px">← all plans</a>' +
       '<h1>' + escape(plan.title) + '</h1>' +
       '<span class="muted">v' + escape(plan.version) + '</span></div>' +
     (plan.description ? '<p class="muted" style="margin:0 0 12px;line-height:1.55">' + escape(plan.description) + '</p>' : '') +
-    '<div class="panel"><div class="row" style="justify-content:space-between"><h3 style="margin:0">Cases</h3>' +
-      '<button class="primary" id="new-plan-run">New run · all implemented</button></div>' +
-    '<table style="margin-top:10px"><thead><tr><th>Case</th><th>Last status</th><th>Steps</th><th>Pins (last run)</th><th>Decision</th></tr></thead>' +
-    '<tbody>' + caseRows + '</tbody></table></div>' +
-    '<div class="panel"><h3 style="margin:0 0 8px">Run history</h3>' +
-    '<table><thead><tr><th>When</th><th>Git</th><th>Result</th><th>Decision</th></tr></thead><tbody>' + runRows + '</tbody></table></div>';
+    '<div style="display:flex;justify-content:flex-end;margin:0 0 12px"><button class="primary" id="new-plan-run">New run · all implemented</button></div>' +
+    '<div class="gallery">' + plan.cases.map(cardFor).join('') + '</div>' +
+    '<details class="panel" style="margin-top:18px"><summary class="muted" style="cursor:pointer">Run history (' + runs.length + ')</summary>' +
+    '<table style="margin-top:10px"><thead><tr><th>When</th><th>Git</th><th>Result</th><th>Decision</th></tr></thead><tbody>' + runRows + '</tbody></table></details>';
 
   document.getElementById('new-plan-run').addEventListener('click', async () => {
     const r = await fetch('/api/plans/' + planId + '/runs', {
       method: 'POST', headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ scope: 'all' }),
     }).then(r => r.json());
+    if (r.error) { alert(r.error); return; }
     if (r.id) location.hash = '#/plan/' + planId + '/run/' + r.id;
   });
-  view.querySelectorAll('tr.clickable').forEach(tr => {
-    tr.addEventListener('click', () => {
-      if (tr.dataset.caseid) location.hash = '#/plan/' + planId + '/case/' + tr.dataset.caseid;
-      else if (tr.dataset.id) location.hash = '#/plan/' + planId + '/run/' + tr.dataset.id;
+  // Card-level click → open case detail
+  view.querySelectorAll('.gallery .card').forEach(card => {
+    card.addEventListener('click', (ev) => {
+      // Let nested buttons handle their own clicks
+      if (ev.target.closest('button')) return;
+      if (ev.target.closest('.thumb')) return;
+      location.hash = '#/plan/' + planId + '/case/' + card.dataset.caseid;
     });
+  });
+  // Thumb click → if there's a captured story, open the slideshow at that step
+  view.querySelectorAll('.gallery .thumb').forEach(thumb => {
+    thumb.addEventListener('click', (ev) => {
+      ev.stopPropagation();
+      const card = thumb.closest('.card');
+      const cid = card?.dataset.caseid;
+      const rid = card?.dataset.runid;
+      const stepIdx = parseInt(thumb.dataset.step, 10);
+      if (rid && cid && !thumb.classList.contains('placeholder')) {
+        // Set sessionStorage so the slideshow opens on the chosen step
+        try { sessionStorage.setItem('slide:' + rid, String(stepIdx)); } catch { /* */ }
+        location.hash = '#/plan/' + planId + '/run/' + rid + '/' + cid;
+      } else {
+        // Placeholder thumb → just open case detail
+        if (cid) location.hash = '#/plan/' + planId + '/case/' + cid;
+      }
+    });
+  });
+  // Action buttons
+  view.querySelectorAll('button[data-act]').forEach(b => {
+    b.addEventListener('click', async (ev) => {
+      ev.stopPropagation();
+      const cid = b.dataset.caseid;
+      if (b.dataset.act === 'open') {
+        location.hash = '#/plan/' + planId + '/case/' + cid;
+        return;
+      }
+      if (b.dataset.act === 'run') {
+        const r = await fetch('/api/plans/' + planId + '/runs', {
+          method: 'POST', headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ scope: { caseIds: [cid] } }),
+        }).then(r => r.json());
+        if (r.error) { alert(r.error); return; }
+        if (r.id) location.hash = '#/plan/' + planId + '/run/' + r.id;
+      }
+    });
+  });
+  // Run history rows (inside the collapsed details panel)
+  view.querySelectorAll('details tr.clickable').forEach(tr => {
+    tr.addEventListener('click', () => location.hash = '#/plan/' + planId + '/run/' + tr.dataset.id);
   });
 }
 
@@ -1780,9 +1911,30 @@ es.addEventListener('line', (e) => {
   const out = document.getElementById('run-output');
   if (out) { out.textContent += JSON.parse(e.data).line; out.scrollTop = out.scrollHeight; }
 });
-es.addEventListener('done', () => {
+es.addEventListener('done', async (e) => {
   statusEl.textContent = 'idle'; statusEl.className = 'badge';
   runEl.disabled = false;
+  // Auto-jump into the slideshow for the first finished case so the human
+  // sees the captured story without an extra click. Only if (a) the run had
+  // a plan and (b) the user hasn't navigated away during the run.
+  let payload = {};
+  try { payload = JSON.parse(e.data || '{}'); } catch { /* */ }
+  const finishedId = payload.id;
+  if (finishedId) {
+    try {
+      const r = await fetch('/api/runs/' + finishedId).then(r => r.json());
+      if (r && r.planId && Array.isArray(r.caseResults)) {
+        const firstCase = r.caseResults.find(c => c.storyPath && (c.status === 'passed' || c.status === 'failed'));
+        if (firstCase) {
+          // If the user is on a slideshow already, don't yank them.
+          if (!location.hash.match(/^#\\/plan\\/[^/]+\\/run\\/[^/]+\\/[^/]+$/)) {
+            location.hash = '#/plan/' + r.planId + '/run/' + finishedId + '/' + firstCase.caseId;
+            return;
+          }
+        }
+      }
+    } catch { /* fall through to route() */ }
+  }
   route();
 });
 

--- a/web/scripts/review-server.ts
+++ b/web/scripts/review-server.ts
@@ -823,6 +823,7 @@ function setPanel(open) {
 menuTrigger.addEventListener('click', () => setPanel(!sidePanel.classList.contains('open')));
 panelBackdrop.addEventListener('click', () => setPanel(false));
 closePanelBtn.innerHTML = SVG.remove;
+closePanelBtn.addEventListener('click', () => setPanel(false));
 
 // ---------- lightbox with zoom + pan ----------------------------------------
 const lightbox = document.getElementById('lightbox');

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -10,6 +10,7 @@ import TaskFeedScreen from './screens/TaskFeedScreen'
 import TaskThreadScreen from './screens/TaskThreadScreen'
 import SettingsScreen from './screens/SettingsScreen'
 import DebugScreen from './screens/DebugScreen'
+import MarkdownDevScreen from './screens/MarkdownDevScreen'
 
 export default function App() {
   return (
@@ -27,6 +28,7 @@ export default function App() {
             <Route path="/tasks/:taskID" element={<TaskThreadScreen />} />
             <Route path="/settings" element={<SettingsScreen />} />
             <Route path="/debug" element={<DebugScreen />} />
+            <Route path="/dev/markdown" element={<MarkdownDevScreen />} />
           </Routes>
         </AppShell>
       </BrowserRouter>

--- a/web/src/components/blocks/AgentSessionBlock.tsx
+++ b/web/src/components/blocks/AgentSessionBlock.tsx
@@ -136,6 +136,17 @@ export default function AgentSessionBlock({ block, payload, onRespond }: Props) 
           </div>
         </>
       )}
+      {/* Terminal / tmux badge row */}
+      {(payload.is_tmux || payload.tty) && (
+        <div className="flex items-center gap-1.5 flex-wrap">
+          <span className={`text-[10px] font-semibold px-1.5 py-0.5 rounded ${payload.is_tmux ? 'bg-purple-100 text-purple-700 dark:bg-purple-900/40 dark:text-purple-300' : 'bg-ask-sep text-ask-secondary'}`}>
+            {payload.is_tmux ? 'tmux' : 'terminal'}
+          </span>
+          <span className="text-[10px] text-ask-secondary font-mono truncate">
+            {payload.is_tmux ? payload.tmux_target : payload.tty}
+          </span>
+        </div>
+      )}
     </div>
   )
 }

--- a/web/src/components/layout/AppShell.tsx
+++ b/web/src/components/layout/AppShell.tsx
@@ -38,8 +38,14 @@ function usePhoneScale(containerRef: React.RefObject<HTMLDivElement | null>) {
     function update() {
       const el = containerRef.current
       if (!el) return
-      const availW = el.clientWidth
-      const availH = el.clientHeight
+      // clientWidth/Height include padding, but the phone renders inside that
+      // padding — so subtract it to get the actual space the phone can occupy.
+      // Without this, the scale comes out too large and the phone gets clipped.
+      const cs = getComputedStyle(el)
+      const padX = parseFloat(cs.paddingLeft || '0') + parseFloat(cs.paddingRight  || '0')
+      const padY = parseFloat(cs.paddingTop  || '0') + parseFloat(cs.paddingBottom || '0')
+      const availW = el.clientWidth  - padX
+      const availH = el.clientHeight - padY
       const s = Math.max(MIN_SCALE, Math.min(1, availW / PHONE_W, availH / PHONE_H))
       setScale(s)
     }

--- a/web/src/components/shared/Markdown.tsx
+++ b/web/src/components/shared/Markdown.tsx
@@ -7,6 +7,17 @@ interface Props {
   className?: string
 }
 
+// GitHub-flavoured markdown rendering for assistant messages.
+// Styling parallels github.com:
+//   - Headings: graduated sizes; h1/h2 get a bottom border
+//   - Paragraphs: comfortable spacing (mb-3) so text isn't cramped
+//   - Lists: list-outside so bullets hang in the margin
+//   - Inline code: subtle background + small horizontal padding
+//   - Code blocks: panel with rounded corners, distinct background, language label
+//   - Tables: bordered with alternating rows
+//   - Blockquotes: left bar, dim text
+//   - Links: accent color + underline
+//   - Horizontal rules + GFM strikethrough + task-list checkboxes
 export default function Markdown({ children, className = '' }: Props) {
   const { themeMode } = usePlatform()
   const isDark = themeMode === 'dark'
@@ -16,22 +27,88 @@ export default function Markdown({ children, className = '' }: Props) {
       remarkPlugins={[remarkGfm]}
       className={`prose ${isDark ? 'prose-invert' : ''} prose-sm max-w-none ${className}`}
       components={{
-        p: ({ children }) => <p className="mb-1.5 last:mb-0 text-sm leading-snug text-ask-text">{children}</p>,
-        h1: ({ children }) => <h1 className="text-base font-semibold mb-2 text-ask-text">{children}</h1>,
-        h2: ({ children }) => <h2 className="text-sm font-semibold mb-1 text-ask-text">{children}</h2>,
-        h3: ({ children }) => <h3 className="text-sm font-semibold mb-1 text-ask-text">{children}</h3>,
-        ul: ({ children }) => <ul className="list-disc list-inside mb-2 space-y-0.5">{children}</ul>,
-        ol: ({ children }) => <ol className="list-decimal list-inside mb-2 space-y-0.5">{children}</ol>,
-        li: ({ children }) => <li className="text-sm text-ask-text">{children}</li>,
-        code: ({ children, className }) => {
-          const isBlock = className?.includes('language-')
-          return isBlock
-            ? <code className="block bg-ask-card2 rounded p-2 text-xs font-mono overflow-x-auto whitespace-pre text-ask-text">{children}</code>
-            : <code className="bg-ask-card2 rounded px-1 text-xs font-mono text-ask-text">{children}</code>
-        },
-        pre: ({ children }) => <pre className="mb-2">{children}</pre>,
+        // Block-level
+        p: ({ children }) => <p className="mb-3 last:mb-0 text-[15px] leading-relaxed text-ask-text">{children}</p>,
+        h1: ({ children }) => <h1 className="text-[22px] font-semibold mt-4 mb-3 pb-1 border-b border-ask-sep text-ask-text first:mt-0">{children}</h1>,
+        h2: ({ children }) => <h2 className="text-[18px] font-semibold mt-4 mb-2 pb-1 border-b border-ask-sep text-ask-text first:mt-0">{children}</h2>,
+        h3: ({ children }) => <h3 className="text-[16px] font-semibold mt-3 mb-1.5 text-ask-text first:mt-0">{children}</h3>,
+        h4: ({ children }) => <h4 className="text-[15px] font-semibold mt-3 mb-1 text-ask-text first:mt-0">{children}</h4>,
+        h5: ({ children }) => <h5 className="text-[14px] font-semibold mt-2 mb-1 text-ask-text first:mt-0">{children}</h5>,
+        h6: ({ children }) => <h6 className="text-[13px] font-semibold mt-2 mb-1 uppercase tracking-wide text-ask-secondary first:mt-0">{children}</h6>,
+        ul: ({ children }) => <ul className="list-disc list-outside pl-5 mb-3 space-y-1 marker:text-ask-secondary">{children}</ul>,
+        ol: ({ children }) => <ol className="list-decimal list-outside pl-5 mb-3 space-y-1 marker:text-ask-secondary">{children}</ol>,
+        li: ({ children }) => <li className="text-[15px] leading-relaxed text-ask-text">{children}</li>,
+        hr: () => <hr className="my-4 border-0 h-px bg-ask-sep" />,
+        blockquote: ({ children }) => (
+          <blockquote className="my-3 pl-3 border-l-[3px] border-ask-sep text-ask-secondary [&>p]:text-ask-secondary">{children}</blockquote>
+        ),
+
+        // Inline
         strong: ({ children }) => <strong className="font-semibold text-ask-text">{children}</strong>,
-        blockquote: ({ children }) => <blockquote className="border-l-2 border-ask-sep pl-3 text-ask-secondary">{children}</blockquote>,
+        em: ({ children }) => <em className="italic">{children}</em>,
+        del: ({ children }) => <del className="text-ask-secondary line-through">{children}</del>,
+        a: ({ children, href }) => (
+          <a href={href} target="_blank" rel="noopener noreferrer" className="text-ask-blue underline underline-offset-2 hover:opacity-80">
+            {children}
+          </a>
+        ),
+
+        // Code: react-markdown calls `code` for both inline and block; only block has language-* className
+        code: ({ children, className: codeClass }) => {
+          const langMatch = /language-([^\s]+)/.exec(codeClass ?? '')
+          const isBlock = !!langMatch
+          if (!isBlock) {
+            return (
+              <code className="bg-ask-card2 rounded px-[0.35em] py-[0.15em] text-[0.875em] font-mono text-ask-text border border-ask-sep/60">
+                {children}
+              </code>
+            )
+          }
+          return (
+            <code className={`block font-mono text-[13px] leading-snug ${codeClass ?? ''}`}>
+              {children}
+            </code>
+          )
+        },
+        pre: ({ children }) => {
+          // Find the inner code element and pull its language for the label.
+          // We're given `children` typed as ReactNode, so probe defensively.
+          let lang = ''
+          // @ts-expect-error — runtime shape
+          const inner = children?.props?.className as string | undefined
+          const m = /language-([^\s]+)/.exec(inner ?? '')
+          if (m) lang = m[1]
+          return (
+            <div className="my-3 rounded-md overflow-hidden border border-ask-sep bg-ask-card2">
+              {lang && (
+                <div className="px-3 py-1 text-[11px] font-mono text-ask-secondary border-b border-ask-sep bg-ask-card2/60">
+                  {lang}
+                </div>
+              )}
+              <pre className="px-3 py-2 overflow-x-auto whitespace-pre text-ask-text">{children}</pre>
+            </div>
+          )
+        },
+
+        // Tables (GFM)
+        table: ({ children }) => (
+          <div className="my-3 overflow-x-auto rounded-md border border-ask-sep">
+            <table className="w-full border-collapse text-[14px]">{children}</table>
+          </div>
+        ),
+        thead: ({ children }) => <thead className="bg-ask-card2">{children}</thead>,
+        tbody: ({ children }) => <tbody>{children}</tbody>,
+        tr: ({ children }) => <tr className="border-b border-ask-sep last:border-b-0 even:bg-ask-card2/30">{children}</tr>,
+        th: ({ children }) => <th className="px-3 py-1.5 text-left font-semibold text-ask-text">{children}</th>,
+        td: ({ children }) => <td className="px-3 py-1.5 text-ask-text align-top">{children}</td>,
+
+        // Task-list checkboxes (GFM `- [x]`)
+        input: (props) => {
+          if (props.type === 'checkbox') {
+            return <input type="checkbox" disabled checked={props.checked} className="mr-1.5 align-middle accent-ask-blue" />
+          }
+          return <input {...props} />
+        },
       }}
     >
       {children}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -45,7 +45,15 @@ export async function getTaskMessages(taskID: string): Promise<TaskMessage[]> {
   const res = await fetch(`${BASE}/tasks/${taskID}/messages`)
   if (!res.ok) return []
   const data = await res.json() as { messages?: TaskMessage[] }
-  return data.messages ?? []
+  // Sort by timestamp first; sequenceNumber as tiebreaker. The backend's
+  // sequenceNumber counter can reset across AskMac TaskRegistry restarts,
+  // producing duplicates that group out-of-time-order messages together.
+  // Timestamp is monotonic per-write so it gives a reliable chat order.
+  return (data.messages ?? []).slice().sort((a, b) => {
+    const t = (a.timestamp ?? '').localeCompare(b.timestamp ?? '')
+    if (t !== 0) return t
+    return (a.sequenceNumber ?? 0) - (b.sequenceNumber ?? 0)
+  })
 }
 
 export async function getTaskArtifacts(taskID: string): Promise<TaskArtifact[]> {

--- a/web/src/screens/MarkdownDevScreen.tsx
+++ b/web/src/screens/MarkdownDevScreen.tsx
@@ -1,0 +1,65 @@
+import Markdown from '../components/shared/Markdown'
+
+const SHOWCASE = `# H1 heading — top-level
+
+Paragraph with **bold**, *italic*, ~~strike~~, \`inline code\`, and a [link](https://github.com).
+
+## H2 heading
+
+### H3 heading
+
+#### H4 heading
+
+##### H5 heading
+
+###### H6 heading
+
+Bulleted list:
+- first item with **emphasis** on a word
+- second item — long enough to wrap a couple of times so we can see how the bullet hangs in the margin instead of inline with the text. Lorem ipsum dolor sit amet.
+- third item with \`inline code\` like \`function foo()\`
+
+Numbered list:
+1. one
+2. two
+3. three
+
+Task list:
+- [x] done item
+- [ ] open item with \`code\`
+
+> Blockquote: this is a quoted line, dimmer than body text and indented with a left border bar. Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+
+\`\`\`bash
+$ echo "fenced code block — language label should appear above"
+$ ls -la /tmp | head -3
+$ git log --oneline -5
+\`\`\`
+
+\`\`\`python
+def hello(name: str) -> str:
+    return f"hi {name}"
+
+class Greeter:
+    def __init__(self, prefix: str):
+        self.prefix = prefix
+\`\`\`
+
+| Column A | Column B | Column C |
+|---|---|---|
+| row 1 cell | yes | 1.0 |
+| row 2 cell | no | 2.5 |
+| row 3 cell with **bold** | maybe | 3.14 |
+| row 4 cell with \`code\` | yes | 42 |
+
+---
+
+End of showcase.`
+
+export default function MarkdownDevScreen() {
+  return (
+    <div className="px-4 py-4">
+      <Markdown>{SHOWCASE}</Markdown>
+    </div>
+  )
+}

--- a/web/src/screens/ScriptDetailScreen.tsx
+++ b/web/src/screens/ScriptDetailScreen.tsx
@@ -50,11 +50,15 @@ function SessionRow({
         {showBlockDebugInfo && (
           <div className="flex items-center gap-1 mt-0.5 min-w-0">
             <span className={`px-1 py-px rounded text-[8px] font-semibold flex-shrink-0 ${
-              payload.tmux_target ? 'bg-ask-green/15 text-ask-green' :
-              payload.tty        ? 'bg-ask-blue/15 text-ask-blue'   :
-                                   'bg-ask-secondary/15 text-ask-secondary'
+              payload.tmux_target  ? 'bg-ask-green/15 text-ask-green' :
+              payload.tty          ? 'bg-ask-blue/15 text-ask-blue'   :
+              payload.is_headless  ? 'bg-ask-orange/15 text-ask-orange' :
+                                     'bg-ask-secondary/15 text-ask-secondary'
             }`}>
-              {payload.tmux_target ? 'tmux' : payload.tty ? 'terminal' : 'headless'}
+              {payload.tmux_target ? 'tmux'
+                : payload.tty ? 'terminal'
+                : payload.is_headless ? 'headless'
+                : 'in-process'}
             </span>
             <span className="font-mono text-[9px] text-ask-secondary/50 truncate">
               {payload.session_id}{payload.tmux_target ? ` · ${payload.tmux_target}` : ''}{payload.tty ? ` · ${payload.tty}` : ''}

--- a/web/src/screens/SessionChatScreen.tsx
+++ b/web/src/screens/SessionChatScreen.tsx
@@ -133,8 +133,10 @@ function PendingConfirmationBar({
 
 interface LocalMessage {
   key: string
-  role: 'user' | 'assistant'
+  role: 'user' | 'assistant' | 'approval'
   text: string
+  approvalTitle?: string
+  approvalBody?: string
 }
 
 function extractText(partsJSON: string): string {
@@ -216,6 +218,21 @@ export default function SessionChatScreen() {
     setSending(false)
   }
 
+  const handleApprove = async (value: string) => {
+    if (!sessionBlock || sending) return
+    setSending(true)
+    const pc = payload?.pending_confirmation
+    setLocalMessages(prev => [...prev, {
+      key: `approval-${Date.now()}`,
+      role: 'approval',
+      text: value,
+      approvalTitle: pc?.title,
+      approvalBody: pc?.body,
+    }])
+    await respond(sessionBlock.blockID, value)
+    setSending(false)
+  }
+
   const handleStop = async () => {
     if (!sessionBlock) return
     await respond(sessionBlock.blockID, '__close_session__')
@@ -279,10 +296,13 @@ export default function SessionChatScreen() {
         <span>Back</span>
       </button>
 
-      {/* Working indicator + title in center */}
-      <div className="flex-1 flex items-center justify-center gap-2">
+      {/* Working indicator + session name in center */}
+      <div className="flex-1 flex items-center justify-center gap-2 min-w-0 px-2">
         {payload?.is_working && (
-          <div className="w-2 h-2 rounded-full animate-pulse" style={{ backgroundColor: accentColor }} />
+          <div className="w-2 h-2 rounded-full animate-pulse flex-shrink-0" style={{ backgroundColor: accentColor }} />
+        )}
+        {payload?.project && (
+          <span className="text-[15px] font-semibold text-ask-text truncate">{payload.project}</span>
         )}
       </div>
 
@@ -313,6 +333,29 @@ export default function SessionChatScreen() {
                 <div key={msg.key} className="flex justify-end">
                   <div className="max-w-[80%] rounded-[20px] rounded-br-[5px] px-3.5 py-2.5 bg-ask-blue text-white text-[15px] leading-snug">
                     {msg.text}
+                  </div>
+                </div>
+              )
+            }
+            if (msg.role === 'approval') {
+              const lc = msg.text.toLowerCase()
+              const isDeny = lc === 'deny' || lc.startsWith('deny')
+              return (
+                <div key={msg.key} className="flex justify-end">
+                  <div className="max-w-[85%] rounded-2xl rounded-br-[5px] overflow-hidden border border-ask-sep/50 bg-ask-card2 text-right">
+                    {(msg.approvalTitle || msg.approvalBody) && (
+                      <div className="px-3 pt-2.5 pb-2 border-b border-ask-sep/40 text-left">
+                        {msg.approvalTitle && (
+                          <p className="text-[11px] font-semibold text-ask-secondary mb-1">{msg.approvalTitle}</p>
+                        )}
+                        {msg.approvalBody && (
+                          <p className="text-[12px] font-mono text-ask-text leading-snug break-all">{msg.approvalBody}</p>
+                        )}
+                      </div>
+                    )}
+                    <div className={`px-3 py-2 text-[13px] font-semibold ${isDeny ? 'text-ask-red' : 'text-ask-green'}`}>
+                      {msg.text}
+                    </div>
                   </div>
                 </div>
               )
@@ -374,7 +417,7 @@ export default function SessionChatScreen() {
           body={payload.pending_confirmation.body}
           options={payload.pending_confirmation.options}
           accentColor={accentColor}
-          onRespond={val => handleSend(val)}
+          onRespond={val => handleApprove(val)}
         />
       )}
       {sessionBlock && (
@@ -479,7 +522,7 @@ export default function SessionChatScreen() {
                 body={payload.pending_confirmation.body}
                 options={payload.pending_confirmation.options}
                 accentColor={accentColor}
-                onRespond={val => handleSend(val)}
+                onRespond={val => handleApprove(val)}
               />
             </div>
           )}


### PR DESCRIPTION
## Summary
- **codex-3 v0.2.8**: Fixed session eviction bug where `tty_exists('s004')` checked `/dev/s004` (doesn't exist on macOS) instead of `/dev/ttys004`. Also default to alive when a session has no tty/tmux routing yet to avoid evicting newly-created sessions.
- **claude-3 v0.5.2**: Switched liveness check from `session_alive` (terminal-manager returns `alive=False` for unregistered sessions, causing false evictions) to `discover_sessions` (process-based check). Guards against empty discovery result masking active sessions. Auto-discovers existing claude/codex processes on startup as transient sessions. Captures first user prompt as session display title.
- **Web UI**: Session name shown in chat header; terminal/tmux badge on session blocks.
- **AskMac**: Enhanced Sessions debug view with titles, types, state, and routing details.

## Test plan
- [ ] Codex session in tmux appears in AskMac/iPhone after sending a message and persists through heartbeat cycles (15s, 30s, 60s)
- [ ] Claude Code sessions survive AskMac restart
- [ ] Session display title shows first user message (e.g. "ask: fix the bug...")
- [ ] Terminal/tmux badge shows in session blocks on iPhone
- [ ] Session name shown in web chat header

🤖 Generated with [Claude Code](https://claude.com/claude-code)