### PR TITLE
fix: orphan daemon cleanup — watchdog in scripts + reaper in AskMac

### DIFF
--- a/AskMac/Sources/AskMac/Services/ScriptManager.swift
+++ b/AskMac/Sources/AskMac/Services/ScriptManager.swift
@@ -258,10 +258,74 @@ final class ScriptManager: @unchecked Sendable {
     }
 
     func start() {
+        reapOrphanedDaemons()
         discoverAndLaunch()
         ensureSDKInVault()
         purgeBlocksForDisabledScripts()
         startVaultWatcher()
+        observeAppTermination()
+    }
+
+    /// Kill any leftover script daemons from prior AskMac runs that didn't
+    /// shut down cleanly. They get reparented to launchd (PPID=1) and survive
+    /// AskMac quit, retaining AskMac's TCC identity — which makes macOS show
+    /// "AskMac would like to access X" prompts that are attributed to a long-
+    /// dead instance. Each script also has a parent-death watchdog as the
+    /// first line of defense; this reaper is the safety net for cases where
+    /// the watchdog hasn't ticked yet (5 s polling) or AskMac crashed mid-spawn.
+    private func reapOrphanedDaemons() {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/bin/ps")
+        task.arguments = ["-axo", "pid,ppid,command"]
+        let pipe = Pipe()
+        task.standardOutput = pipe
+        task.standardError = Pipe()
+        do { try task.run() } catch {
+            logger.error("orphan reaper: ps failed: \(error)")
+            return
+        }
+        // Read to EOF first — `ps` produces several KB and will block on a full
+        // pipe if we waitUntilExit before draining. Closing happens when ps exits.
+        guard let data = try? pipe.fileHandleForReading.readToEnd(),
+              let text = String(data: data, encoding: .utf8) else {
+            task.waitUntilExit()
+            return
+        }
+        task.waitUntilExit()
+        var killed: [Int32] = []
+        for line in text.split(separator: "\n") {
+            let parts = line.split(separator: " ", maxSplits: 2, omittingEmptySubsequences: true)
+            guard parts.count >= 3,
+                  let pid = Int32(parts[0]),
+                  let ppid = Int32(parts[1]),
+                  ppid == 1 else { continue }
+            let cmd = String(parts[2])
+            // Match Ask script daemons in either prod or dev vault. Use a
+            // deliberately tight pattern to avoid touching unrelated processes.
+            guard cmd.contains("/.ask/scripts/") || cmd.contains("/.ask/dev-vault/") || cmd.contains("/ask/dev-vault/")
+            else { continue }
+            guard cmd.hasSuffix("main.sh") || cmd.hasSuffix("main.py")
+                  || cmd.contains("main.sh ") || cmd.contains("main.py ") else { continue }
+            kill(pid, SIGKILL)
+            killed.append(pid)
+        }
+        if !killed.isEmpty {
+            let pidList = killed.map(String.init).joined(separator: ",")
+            logger.error("Reaped \(killed.count) orphaned Ask daemons from prior runs: \(pidList)")
+        }
+    }
+
+    /// Best-effort cleanup on app quit. Crash/force-quit doesn't trigger this —
+    /// that's what the reaper + per-script watchdog cover.
+    private var terminationObserver: NSObjectProtocol?
+    private func observeAppTermination() {
+        guard terminationObserver == nil else { return }
+        terminationObserver = NotificationCenter.default.addObserver(
+            forName: NSApplication.willTerminateNotification,
+            object: nil, queue: .main
+        ) { [weak self] _ in
+            self?.stop()
+        }
     }
 
     /// Copy ask_sdk.py from the app bundle to the vault root if it isn't already there.

--- a/ask/scripts/brew-monitor/main.sh
+++ b/ask/scripts/brew-monitor/main.sh
@@ -8,6 +8,13 @@ mkdir -p "$(dirname "$_LOCK")"
 exec 9>"$_LOCK"
 flock -n 9 || { printf '[brew-monitor] another instance already running, exiting\n' >&2; exit 0; }
 
+# Parent-death watchdog — exit if AskMac (parent) goes away. Without this, when
+# AskMac is force-quit or crashes the script gets reparented to launchd and
+# lingers forever, retaining AskMac's TCC identity (causing ghost prompts).
+_ASK_PARENT=$PPID
+( while kill -0 "$_ASK_PARENT" 2>/dev/null; do sleep 5; done
+  pkill -P $$ 2>/dev/null; kill -TERM $$ 2>/dev/null ) &
+
 CHECK_INTERVAL=14400  # 4 hours
 
 BLOCK_UPDATES="brew-monitor-updates"

--- a/ask/scripts/brew-monitor/manifest.json
+++ b/ask/scripts/brew-monitor/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "brew-monitor",
   "name": "Homebrew",
-  "version": "3.2",
+  "version": "3.2.1",
   "description": "Checks for outdated Homebrew packages and lets you upgrade from iPhone",
   "entry": "main.sh",
   "icon": "shippingbox",

--- a/ask/scripts/claude-3/main.py
+++ b/ask/scripts/claude-3/main.py
@@ -1497,7 +1497,22 @@ class Claude3:
                 stdin_task.cancel()
 
 
+def _install_parent_watchdog():
+    """Exit if our parent (AskMac) goes away. Without this, a force-quit of
+    AskMac leaves the daemon reparented to launchd, retaining AskMac's TCC
+    identity and triggering ghost prompts on Documents/etc. access."""
+    import threading, time
+    def _watch():
+        while True:
+            time.sleep(5)
+            if os.getppid() == 1:
+                _log('parent (AskMac) gone — exiting', 'WARN')
+                os._exit(0)
+    threading.Thread(target=_watch, daemon=True).start()
+
+
 if __name__ == '__main__':
+    _install_parent_watchdog()
     try:
         asyncio.run(Claude3().run())
     except KeyboardInterrupt:

--- a/ask/scripts/codex-3/main.py
+++ b/ask/scripts/codex-3/main.py
@@ -945,7 +945,20 @@ class Codex3:
                 stdin_task.cancel()
 
 
+def _install_parent_watchdog():
+    """Exit if our parent (AskMac) goes away — see claude-3/main.py for context."""
+    import threading, time
+    def _watch():
+        while True:
+            time.sleep(5)
+            if os.getppid() == 1:
+                _log('parent (AskMac) gone — exiting', 'WARN')
+                os._exit(0)
+    threading.Thread(target=_watch, daemon=True).start()
+
+
 if __name__ == '__main__':
+    _install_parent_watchdog()
     try:
         asyncio.run(Codex3().run())
     except KeyboardInterrupt:

--- a/ask/scripts/codex-3/manifest.json
+++ b/ask/scripts/codex-3/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "codex-3",
   "name": "Codex 3",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "description": "Feed-first Codex session supervisor with tmux transport and task-backed history",
   "entry": "main.py",
   "icon": "sparkles",

--- a/ask/scripts/gdocs-history/main.py
+++ b/ask/scripts/gdocs-history/main.py
@@ -383,5 +383,19 @@ async def main():
     await mcp.initialize(client_name='gdocs-history')
     await run(mcp, test_mode=test_mode)
 
+def _install_parent_watchdog():
+    """Exit if our parent (AskMac) goes away — prevents zombie scripts that
+    retain AskMac's TCC identity and trigger ghost prompts."""
+    import threading, time
+    def _watch():
+        while True:
+            time.sleep(5)
+            if os.getppid() == 1:
+                print('[gdocs-history] parent (AskMac) gone — exiting', file=sys.stderr, flush=True)
+                os._exit(0)
+    threading.Thread(target=_watch, daemon=True).start()
+
+
 if __name__ == '__main__':
+    _install_parent_watchdog()
     asyncio.run(main())

--- a/ask/scripts/gdocs-history/manifest.json
+++ b/ask/scripts/gdocs-history/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "gdocs-history",
   "name": "Google Docs History",
-  "version": "1.0",
+  "version": "1.0.1",
   "description": "Shows Google Docs viewed in the last 30 days from Safari and Chrome",
   "entry": "main.py",
   "icon": "doc.text.magnifyingglass"

--- a/ask/scripts/github/main.sh
+++ b/ask/scripts/github/main.sh
@@ -12,6 +12,13 @@ mkdir -p "$(dirname "$_LOCK")"
 exec 9>"$_LOCK"
 flock -n 9 || { printf '[github] another instance already running, exiting\n' >&2; exit 0; }
 
+# Parent-death watchdog — exit if AskMac (parent) goes away. Without this, when
+# AskMac is force-quit or crashes the script gets reparented to launchd and
+# lingers forever, retaining AskMac's TCC identity (causing ghost prompts).
+_ASK_PARENT=$PPID
+( while kill -0 "$_ASK_PARENT" 2>/dev/null; do sleep 5; done
+  pkill -P $$ 2>/dev/null; kill -TERM $$ 2>/dev/null ) &
+
 REFRESH_SECS=300  # 5 minutes
 MAX_REPOS=100
 

--- a/ask/scripts/github/manifest.json
+++ b/ask/scripts/github/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "github",
   "name": "Git Repos",
-  "version": "3.5",
+  "version": "3.5.1",
   "description": "Monitor local git repos and push/pull changes from iPhone",
   "entry": "main.sh",
   "icon": "arrow.triangle.branch",

--- a/ask/scripts/hello-world/main.sh
+++ b/ask/scripts/hello-world/main.sh
@@ -8,6 +8,11 @@ mkdir -p "$(dirname "$_LOCK")"
 exec 9>"$_LOCK"
 flock -n 9 || { printf '[hello-world] another instance already running, exiting\n' >&2; exit 0; }
 
+# Parent-death watchdog — exit if AskMac (parent) goes away.
+_ASK_PARENT=$PPID
+( while kill -0 "$_ASK_PARENT" 2>/dev/null; do sleep 5; done
+  pkill -P $$ 2>/dev/null; kill -TERM $$ 2>/dev/null ) &
+
 CONFIRM_ID="hello-world-confirm"
 STATUS_ID="hello-world-status"
 RESET_DELAY=30

--- a/ask/scripts/hello-world/manifest.json
+++ b/ask/scripts/hello-world/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "hello-world",
   "name": "Hello World",
-  "version": "2.3",
+  "version": "2.3.1",
   "description": "A simple Hello World demo script",
   "entry": "main.sh",
   "icon": "hand.wave",

--- a/ask/scripts/ollama/main.sh
+++ b/ask/scripts/ollama/main.sh
@@ -8,6 +8,11 @@ mkdir -p "$(dirname "$_LOCK")"
 exec 9>"$_LOCK"
 flock -n 9 || { printf '[ollama] another instance already running, exiting\n' >&2; exit 0; }
 
+# Parent-death watchdog — exit if AskMac (parent) goes away.
+_ASK_PARENT=$PPID
+( while kill -0 "$_ASK_PARENT" 2>/dev/null; do sleep 5; done
+  pkill -P $$ 2>/dev/null; kill -TERM $$ 2>/dev/null ) &
+
 UPDATE_CHECK_INTERVAL=21600  # 6 hours
 OLLAMA_URL="http://localhost:11434"
 

--- a/ask/scripts/ollama/manifest.json
+++ b/ask/scripts/ollama/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "ollama",
   "name": "Ollama",
-  "version": "2.3",
+  "version": "2.3.1",
   "description": "Monitors Ollama status and surfaces available updates",
   "entry": "main.sh",
   "icon": "cpu",

--- a/ask/scripts/task-demo/main.py
+++ b/ask/scripts/task-demo/main.py
@@ -338,5 +338,18 @@ def _run(cmd: str) -> str:
         return ''
 
 
+def _install_parent_watchdog():
+    """Exit if our parent (AskMac) goes away."""
+    import threading, time
+    def _watch():
+        while True:
+            time.sleep(5)
+            if os.getppid() == 1:
+                print('[task-demo] parent (AskMac) gone — exiting', file=sys.stderr, flush=True)
+                os._exit(0)
+    threading.Thread(target=_watch, daemon=True).start()
+
+
 if __name__ == '__main__':
+    _install_parent_watchdog()
     asyncio.run(MCPClient().run())

--- a/ask/scripts/task-demo/manifest.json
+++ b/ask/scripts/task-demo/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "task-demo",
   "name": "Task Demo",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "End-to-end demo of the A2A task protocol: open_task, append_message, put_artifact. Runs automatically on startup.",
   "entry": "main.py",
   "icon": "checkmark.seal",

--- a/ask/scripts/terminal-manager/main.py
+++ b/ask/scripts/terminal-manager/main.py
@@ -2122,7 +2122,20 @@ async def main():
     _log('terminal-manager shutting down')
 
 
+def _install_parent_watchdog():
+    """Exit if our parent (AskMac) goes away — see claude-3/main.py for context."""
+    import threading, time
+    def _watch():
+        while True:
+            time.sleep(5)
+            if os.getppid() == 1:
+                _log('parent (AskMac) gone — exiting', 'WARN')
+                os._exit(0)
+    threading.Thread(target=_watch, daemon=True).start()
+
+
 if __name__ == '__main__':
+    _install_parent_watchdog()
     try:
         asyncio.run(main())
     except KeyboardInterrupt:

--- a/ask/scripts/terminal-manager/manifest.json
+++ b/ask/scripts/terminal-manager/manifest.json
@@ -2,7 +2,7 @@
   "id": "terminal-manager",
   "name": "Terminal Manager",
   "type": "system",
-  "version": "2.1.6",
+  "version": "2.1.7",
   "description": "Local terminal session registry and TUI detector. Tools are available to all scripts via AskMac MCP — not exposed to iPhone.",
   "entry": "main.py",
   "tools": [

--- a/ask/scripts/terminal-snapshot/main.py
+++ b/ask/scripts/terminal-snapshot/main.py
@@ -297,5 +297,18 @@ class TerminalSnapshot:
         await stdin_task
 
 
+def _install_parent_watchdog():
+    """Exit if our parent (AskMac) goes away — see claude-3/main.py for context."""
+    import threading, time
+    def _watch():
+        while True:
+            time.sleep(5)
+            if os.getppid() == 1:
+                _log('parent (AskMac) gone — exiting', 'WARN')
+                os._exit(0)
+    threading.Thread(target=_watch, daemon=True).start()
+
+
 if __name__ == '__main__':
+    _install_parent_watchdog()
     asyncio.run(TerminalSnapshot().run())

--- a/ask/scripts/terminal-snapshot/manifest.json
+++ b/ask/scripts/terminal-snapshot/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "terminal-snapshot",
   "name": "Terminal Snapshot",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "type": "tile",
   "entry": "main.py",
   "setup": "setup.py",

--- a/ask/scripts/web-traffic/main.py
+++ b/ask/scripts/web-traffic/main.py
@@ -359,5 +359,19 @@ async def main():
     await run(mcp, test_mode=test_mode)
 
 
+def _install_parent_watchdog():
+    """Exit if our parent (AskMac) goes away — prevents zombie scripts that
+    retain AskMac's TCC identity and trigger ghost prompts."""
+    import threading, time
+    def _watch():
+        while True:
+            time.sleep(5)
+            if os.getppid() == 1:
+                print('[web-traffic] parent (AskMac) gone — exiting', file=sys.stderr, flush=True)
+                os._exit(0)
+    threading.Thread(target=_watch, daemon=True).start()
+
+
 if __name__ == '__main__':
+    _install_parent_watchdog()
     asyncio.run(main())

--- a/ask/scripts/web-traffic/manifest.json
+++ b/ask/scripts/web-traffic/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "web-traffic",
   "name": "Web Traffic",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Parses browser history to show websites visited daily — Safari, Chrome, Brave, Firefox, Arc",
   "entry": "main.py",
   "icon": "globe",

--- a/docs/specs/script-robustness.md
+++ b/docs/specs/script-robustness.md
@@ -76,6 +76,16 @@ Only one installation can proceed at a time; concurrent installs are prevented.
 - A reload triggered by the file watcher during an active install is deferred until the install completes
 - The lock is released even if the install fails or is cancelled
 
+### 9. Daemon Orphan Cleanup
+
+Script daemons (the Python and bash `main.{py,sh}` processes that AskMac spawns) must not survive past the app lifetime.
+
+- Each daemon detects when its parent (AskMac) goes away and exits on its own within ≤5 seconds, even if AskMac was force-quit, crashed, or killed without firing termination notifications
+- On every AskMac launch, any leftover daemons from prior runs that were re-parented to launchd (PPID = 1) and are still running are killed before new daemons are spawned
+- The detection is scoped to processes whose command line points at `~/.ask/scripts/` or `~/.ask/dev-vault/` and ends in `main.sh` or `main.py` — unrelated processes are never touched
+- AskMac also stops all live daemons on the standard graceful-quit path (`NSApplication.willTerminateNotification`)
+- Why this matters: orphan daemons retain AskMac's code-signing identity, so any file access they perform after AskMac quit triggers TCC prompts attributed to "AskMac" — even when AskMac itself is closed. They also hold open Unix sockets at `~/.ask/sockets/*.sock`, conflicting with fresh daemons on next launch.
+
 ---
 
 ## Changelog
@@ -84,3 +94,4 @@ Only one installation can proceed at a time; concurrent installs are prevented.
 |---|---|
 | 2026-04-07 | Initial spec |
 | 2026-04-07 | Implemented all 8 features |
+| 2026-05-07 | Add requirement #9 (daemon orphan cleanup). Implementation: per-script `_install_parent_watchdog()` (Python) / `kill -0 $PPID` watchdog (bash) polling every 5 s; `ScriptManager.reapOrphanedDaemons()` runs `ps -axo pid,ppid,command`, filters PPID==1 + path matches AskMac script vaults, kills survivors via `SIGKILL`. Verified: hard-killed AskMac → 4 daemons exited within 7 s on their own; spawned a PPID=1 fake orphan, launched AskMac, orphan was reaped within 5 s |


### PR DESCRIPTION
## Summary

Script daemons were surviving past AskMac quit when AskMac crashed, was force-killed, or stopped from Xcode without firing termination notifications. They got reparented to launchd and accumulated indefinitely (62 on this dev machine, going back 10 days).

This caused the recurring **"AskMac would like to access files in your Documents folder"** TCC prompt that appears even when AskMac is closed — the orphans retain AskMac's signing identity, so any file access they perform gets attributed to "AskMac".

## Two-part fix

**1. Per-script parent-death watchdog (first line of defense)**
- Bash (brew-monitor, github, hello-world, ollama): backgrounded subshell polling `kill -0 $PPID` every 5 s; when parent is gone, `pkill -P $$` + SIGTERM self.
- Python (claude-3, codex-3, terminal-manager, terminal-snapshot, gdocs-history, web-traffic, task-demo): daemon thread polling `os.getppid() == 1` every 5 s; when true, `os._exit(0)`.

**2. Orphan reaper at AskMac launch (safety net)**
- `ScriptManager.reapOrphanedDaemons()` runs `ps -axo pid,ppid,command`, filters PPID == 1 + path contains `/.ask/{scripts,dev-vault}/` + ends in `main.{sh,py}`, kills survivors via SIGKILL.
- Tightly scoped match — never touches unrelated processes.
- Drains the `ps` stdout pipe BEFORE `waitUntilExit` (an early version of this code hung AskMac at startup; fixed here).
- `ScriptManager.observeAppTermination()` also calls `stop()` on `NSApplication.willTerminateNotification` for clean-quit cases.

Manifest bumps (patch-level) on all 11 touched scripts.

## Test plan

- [x] `claude-3/test_invariants.py` — 6/6 passed
- [x] `swift build` and `xcodebuild` — clean
- [x] Hard-kill AskMac (SIGKILL, no termination notification): 4 daemons all exited within 7 s without intervention
- [x] Spawned a detached PPID=1 fake orphan in `~/.ask/dev-vault/fake-orphan/`, launched AskMac, orphan reaped within 5 s, no other daemons affected, AskMac came up cleanly
- [x] Manually verified before/after: `ps -ef | awk '$3==1 && /dev-vault\/.*main\.(sh|py)/'` was 62 leaks → 0 after this fix takes effect
- [ ] Codex-3 messaging round-trip (uncovered area; not regressed expected since main loop changes are entry-point only)

## Why this matters

Even users who never see the TCC prompt benefit:
- Orphans hold open Unix sockets at `~/.ask/sockets/*.sock` that conflict with fresh daemons on next launch
- Some daemons periodically wake on timers and do filesystem/git/network work for a dead parent — wasted CPU + battery

🤖 Generated with [Claude Code](https://claude.com/claude-code)