### PR TITLE
chore(release): update appcast for v1.2.0

### DIFF
--- a/docs/appcast.xml
+++ b/docs/appcast.xml
@@ -7,6 +7,19 @@
     <language>en</language>
     <!-- Release entries are prepended here by the release pipeline -->
     <item>
+      <title>Version 1.2.0</title>
+      <sparkle:version>1778207998</sparkle:version>
+      <sparkle:shortVersionString>1.2.0</sparkle:shortVersionString>
+      <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
+      <pubDate>Fri, 08 May 2026 02:42:52 +0000</pubDate>
+      <enclosure
+        url="https://github.com/Gr8Gatsby/ask/releases/download/v1.2.0/AskMac-1.2.0.dmg"
+        length="3794749"
+        type="application/octet-stream"
+        sparkle:edSignature="+T2zm5rXFDMySRaqgbdg71OAJ+E1jri03WwZDHwKf5X68AIs8+d5jlmEN58cRuCJHdW1PQ5TxXIkQtymivJ1Dg=="
+      />
+    </item>
+    <item>
       <title>Version 1.1.0</title>
       <sparkle:version>1777482991</sparkle:version>
       <sparkle:shortVersionString>1.1.0</sparkle:shortVersionString>


### PR DESCRIPTION
Sparkle appcast entry for v1.2.0 release.

Generated by build-release.sh — couldn't push directly to main due to branch protection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)