### PR TITLE
fix(review): playwright auto-starts vite + sweep stale runs at server boot

### DIFF
--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -1,10 +1,14 @@
 import { defineConfig, devices } from '@playwright/test'
 
-// E2E config — runs against the live AskMac on port 4242 via the vite proxy
-// at localhost:5173. The vite dev server is assumed to already be running
-// (the user's normal dev workflow). If you're running these in CI without a
-// live AskMac, point BACKEND_PORT at the mock server (see web/mock/server.ts)
-// and start vite with that env var.
+// E2E config — runs against the vite proxy at localhost:5173. The proxy
+// forwards /api to BACKEND_PORT (4242 = AskMac, 4243 = mock).
+// If vite isn't already running, `webServer` below starts it; an existing
+// vite is reused via `reuseExistingServer`. When BACKEND_PORT=4243, vite
+// is started via `npm run dev:mock` so the mock server comes up alongside it.
+
+const backendPort = process.env.BACKEND_PORT ?? '4242'
+const useMock = backendPort === '4243'
+const viteCmd = useMock ? 'npm run dev:mock' : 'npm run dev'
 
 export default defineConfig({
   testDir: './e2e',
@@ -17,6 +21,14 @@ export default defineConfig({
     trace: 'retain-on-failure',
     video: 'retain-on-failure',
     screenshot: 'only-on-failure',
+  },
+  webServer: {
+    command: viteCmd,
+    url: 'http://localhost:5173',
+    reuseExistingServer: true,
+    timeout: 60_000,
+    stdout: 'ignore',
+    stderr: 'pipe',
   },
   projects: [
     {

--- a/web/scripts/review-server.ts
+++ b/web/scripts/review-server.ts
@@ -70,7 +70,7 @@ interface Run {
   endedAt: number | null
   exitCode: number | null
   screenshotCount: number
-  status: 'running' | 'awaiting-review' | 'reviewed'
+  status: 'running' | 'awaiting-review' | 'reviewed' | 'aborted'
   review: Review | null
   gitHead: string | null    // sha at run start (for staleness detection)
   planId?: string | null    // when set, run belongs to a plan (new-style)
@@ -2530,6 +2530,28 @@ const server = http.createServer(async (req, res) => {
 
   res.writeHead(404); res.end('not found')
 })
+
+// Sweep stale `running` runs at startup. If the previous server died or the
+// spawned Playwright child orphaned, those runs sit forever. Mark them aborted
+// so the dashboard doesn't show a phantom "still running" state.
+function sweepStaleRunsAtStartup() {
+  const runs = loadRuns()
+  let touched = 0
+  for (const r of runs) {
+    if (r.status === 'running') {
+      r.status = 'aborted'
+      r.endedAt = r.endedAt ?? Date.now()
+      r.exitCode = r.exitCode ?? -1
+      touched++
+    }
+  }
+  if (touched) {
+    saveRuns(runs)
+    console.log(`[review] swept ${touched} stale running run${touched === 1 ? '' : 's'} → aborted`)
+  }
+}
+
+sweepStaleRunsAtStartup()
 
 server.listen(PORT, () => {
   console.log(`Ask · review dashboard → http://localhost:${PORT}`)


### PR DESCRIPTION
## Why

Two test-infrastructure bugs surfaced when I audited the manual-script-sweep dashboard:

1. **Playwright runs fail with ERR_CONNECTION_REFUSED** when vite isn't already running on :5173. The May 3 runs all hit this and died silently — the full 20-case sweep had never actually completed a single time until today.
2. **Stale "running" runs sit forever** on the dashboard when the review-server dies before its spawned Playwright child closes (the close handler updates run status). The stuck run `20260503-101842` was an example.

## Changes

- `web/playwright.config.ts` — add a `webServer` block that starts vite (or `npm run dev:mock` when `BACKEND_PORT=4243`) with `reuseExistingServer: true` so an already-running vite isn't disturbed
- `web/scripts/review-server.ts` — add `sweepStaleRunsAtStartup()` that marks any `status: "running"` runs as `aborted` on relaunch; add `'aborted'` to the `Run` status union

40 lines, 2 files. Test-infra only — no shipping app code touched.

## Test plan

- [x] Restarted review server: `[review] swept 1 stale running run → aborted` printed on boot, the stuck run from May 3 now correctly displays as aborted
- [x] Smoke-ran `hello-world-web` via `POST /api/plans/manual-script-sweep/runs` → 5s, 8 PNGs captured
- [x] Full 10-case sweep ran in 47s, all 10 passed, 82 PNGs + 82 HTMLs frozen (this was the first time the sweep had ever completed end-to-end)

🤖 Generated with [Claude Code](https://claude.com/claude-code)