### PR TITLE
chore(release): update appcast for v1.2.1

### DIFF
--- a/docs/appcast.xml
+++ b/docs/appcast.xml
@@ -7,6 +7,19 @@
     <language>en</language>
     <!-- Release entries are prepended here by the release pipeline -->
     <item>
+      <title>Version 1.2.1</title>
+      <sparkle:version>1778613959</sparkle:version>
+      <sparkle:shortVersionString>1.2.1</sparkle:shortVersionString>
+      <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
+      <pubDate>Tue, 12 May 2026 19:28:38 +0000</pubDate>
+      <enclosure
+        url="https://github.com/Gr8Gatsby/ask/releases/download/v1.2.1/AskMac-1.2.1.dmg"
+        length="3782426"
+        type="application/octet-stream"
+        sparkle:edSignature="QpaeKl9Ho8xr/XrrBFLRO8v1UmzPuZfJGM3hKWn4wchxqQZYARGanHgunRcbSfoKWdUHI0SP5sVkVfmQjPCGAQ=="
+      />
+    </item>
+    <item>
       <title>Version 1.2.0</title>
       <sparkle:version>1778207998</sparkle:version>
       <sparkle:shortVersionString>1.2.0</sparkle:shortVersionString>


### PR DESCRIPTION
Sparkle appcast entry for v1.2.1.

Generated by build-release.sh — couldn't push directly to main due to branch protection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)