### PR TITLE
chore(release): update appcast for v1.3.0

### DIFF
--- a/docs/appcast.xml
+++ b/docs/appcast.xml
@@ -7,6 +7,19 @@
     <language>en</language>
     <!-- Release entries are prepended here by the release pipeline -->
     <item>
+      <title>Version 1.3.0</title>
+      <sparkle:version>1778619579</sparkle:version>
+      <sparkle:shortVersionString>1.3.0</sparkle:shortVersionString>
+      <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
+      <pubDate>Tue, 12 May 2026 21:03:10 +0000</pubDate>
+      <enclosure
+        url="https://github.com/Gr8Gatsby/ask/releases/download/v1.3.0/AskMac-1.3.0.dmg"
+        length="3906430"
+        type="application/octet-stream"
+        sparkle:edSignature="eT9wKYvuYd/HJ7HA5b7Wp6SYgcOwvLekhp0z39Pf6szko6RS7q4/k/YlpdzI9L0DQ5qkVgWwDzskmBD8w41sDA=="
+      />
+    </item>
+    <item>
       <title>Version 1.2.1</title>
       <sparkle:version>1778613959</sparkle:version>
       <sparkle:shortVersionString>1.2.1</sparkle:shortVersionString>


### PR DESCRIPTION
Sparkle appcast entry for v1.3.0.

Generated by build-release.sh — branch protection forces a PR for main writes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)