### PR TITLE
fix(ui): update-available popover body unreadable on dark background

### DIFF
--- a/AskMac/Sources/AskMac/Views/ScriptDetailView.swift
+++ b/AskMac/Sources/AskMac/Views/ScriptDetailView.swift
@@ -1650,7 +1650,7 @@ struct ScriptDetailView: View {
 
     @ViewBuilder
     private func updatePopoverView(entry: CatalogEntry) -> some View {
-        VStack(alignment: .leading, spacing: 12) {
+        VStack(alignment: .leading, spacing: 14) {
             HStack(spacing: 6) {
                 Image(systemName: "arrow.down.circle.fill")
                     .foregroundStyle(Color.accentColor)
@@ -1658,16 +1658,23 @@ struct ScriptDetailView: View {
                     .font(.headline)
                     .fontWeight(.semibold)
                 Spacer()
-                Text("\(script.version ?? "?") → \(entry.version)")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+                HStack(spacing: 4) {
+                    Text(script.version ?? "?").foregroundStyle(.secondary)
+                    Image(systemName: "arrow.right").font(.caption2).foregroundStyle(.tertiary)
+                    Text(entry.version).foregroundStyle(.primary).fontWeight(.medium)
+                }
+                .font(.caption)
             }
 
             if let log = entry.changelog, !log.isEmpty {
+                // Body uses .primary for readable contrast on the popover background
+                // (was .secondary, which on dark popovers reads as low-contrast grey-on-grey).
                 Text(log)
                     .font(.callout)
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(.primary)
                     .fixedSize(horizontal: false, vertical: true)
+                    .textSelection(.enabled)
+                    .padding(.vertical, 2)
             }
 
             if let err = updateError {


### PR DESCRIPTION
The changelog body in the update popover was hard to read in dark mode (`.secondary` on a dark popover background). Switched body text to `.primary` and reorganized the version delta to show old version in secondary + new version in primary medium weight.

Screenshot of the regression: see #109 follow-up — body text barely visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)