### PR TITLE
chore(release): update appcast for v1.3.2

### DIFF
--- a/docs/appcast.xml
+++ b/docs/appcast.xml
@@ -7,6 +7,19 @@
     <language>en</language>
     <!-- Release entries are prepended here by the release pipeline -->
     <item>
+      <title>Version 1.3.2</title>
+      <sparkle:version>1778628175</sparkle:version>
+      <sparkle:shortVersionString>1.3.2</sparkle:shortVersionString>
+      <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
+      <pubDate>Tue, 12 May 2026 23:25:47 +0000</pubDate>
+      <enclosure
+        url="https://github.com/Gr8Gatsby/ask/releases/download/v1.3.2/AskMac-1.3.2.dmg"
+        length="3942116"
+        type="application/octet-stream"
+        sparkle:edSignature="LBmkZPIFDceuQt128+7UvPIDtdbjY+18eh/Zvkz40VJ8o4Z7MiW9SHLRoFOoneoz3a0pfLmywJbFEBks91HfCg=="
+      />
+    </item>
+    <item>
       <title>Version 1.3.1</title>
       <sparkle:version>1778625855</sparkle:version>
       <sparkle:shortVersionString>1.3.1</sparkle:shortVersionString>


### PR DESCRIPTION
Sparkle appcast entry for v1.3.2.