### PR TITLE
fix(scripts): replace flock with portable PID-file lock in bash daemons

### DIFF
--- a/ask/scripts/brew-monitor/main.sh
+++ b/ask/scripts/brew-monitor/main.sh
@@ -5,8 +5,15 @@
 # Single-instance guard — exit if another copy is already running
 _LOCK="$HOME/.ask/run/brew-monitor.lock"
 mkdir -p "$(dirname "$_LOCK")"
-exec 9>"$_LOCK"
-flock -n 9 || { printf '[brew-monitor] another instance already running, exiting\n' >&2; exit 0; }
+if [ -f "$_LOCK" ]; then
+    _holder=$(cat "$_LOCK" 2>/dev/null)
+    if [ -n "$_holder" ] && kill -0 "$_holder" 2>/dev/null; then
+        printf '[brew-monitor] another instance already running (pid=%s), exiting\n' "$_holder" >&2
+        exit 0
+    fi
+fi
+echo "$$" > "$_LOCK"
+trap 'rm -f "$_LOCK"' EXIT
 
 # Parent-death watchdog — exit if AskMac (parent) goes away. Without this, when
 # AskMac is force-quit or crashes the script gets reparented to launchd and

--- a/ask/scripts/brew-monitor/manifest.json
+++ b/ask/scripts/brew-monitor/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "brew-monitor",
   "name": "Homebrew",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "description": "Checks for outdated Homebrew packages and lets you upgrade from iPhone",
   "entry": "main.sh",
   "icon": "shippingbox",

--- a/ask/scripts/github/main.sh
+++ b/ask/scripts/github/main.sh
@@ -9,8 +9,15 @@
 # Single-instance guard — exit if another copy is already running
 _LOCK="$HOME/.ask/run/github.lock"
 mkdir -p "$(dirname "$_LOCK")"
-exec 9>"$_LOCK"
-flock -n 9 || { printf '[github] another instance already running, exiting\n' >&2; exit 0; }
+if [ -f "$_LOCK" ]; then
+    _holder=$(cat "$_LOCK" 2>/dev/null)
+    if [ -n "$_holder" ] && kill -0 "$_holder" 2>/dev/null; then
+        printf '[github] another instance already running (pid=%s), exiting\n' "$_holder" >&2
+        exit 0
+    fi
+fi
+echo "$$" > "$_LOCK"
+trap 'rm -f "$_LOCK"' EXIT
 
 # Parent-death watchdog — exit if AskMac (parent) goes away. Without this, when
 # AskMac is force-quit or crashes the script gets reparented to launchd and

--- a/ask/scripts/github/manifest.json
+++ b/ask/scripts/github/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "github",
   "name": "Git Repos",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "description": "Monitor local git repos and push/pull changes from iPhone",
   "entry": "main.sh",
   "icon": "arrow.triangle.branch",

--- a/ask/scripts/hello-world/main.sh
+++ b/ask/scripts/hello-world/main.sh
@@ -5,8 +5,15 @@
 # Single-instance guard — exit if another copy is already running
 _LOCK="$HOME/.ask/run/hello-world.lock"
 mkdir -p "$(dirname "$_LOCK")"
-exec 9>"$_LOCK"
-flock -n 9 || { printf '[hello-world] another instance already running, exiting\n' >&2; exit 0; }
+if [ -f "$_LOCK" ]; then
+    _holder=$(cat "$_LOCK" 2>/dev/null)
+    if [ -n "$_holder" ] && kill -0 "$_holder" 2>/dev/null; then
+        printf '[hello-world] another instance already running (pid=%s), exiting\n' "$_holder" >&2
+        exit 0
+    fi
+fi
+echo "$$" > "$_LOCK"
+trap 'rm -f "$_LOCK"' EXIT
 
 # Parent-death watchdog — exit if AskMac (parent) goes away.
 _ASK_PARENT=$PPID

--- a/ask/scripts/hello-world/manifest.json
+++ b/ask/scripts/hello-world/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "hello-world",
   "name": "Hello World",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "A simple Hello World demo script",
   "entry": "main.sh",
   "icon": "hand.wave",

--- a/ask/scripts/ollama/main.sh
+++ b/ask/scripts/ollama/main.sh
@@ -5,8 +5,15 @@
 # Single-instance guard — exit if another copy is already running
 _LOCK="$HOME/.ask/run/ollama.lock"
 mkdir -p "$(dirname "$_LOCK")"
-exec 9>"$_LOCK"
-flock -n 9 || { printf '[ollama] another instance already running, exiting\n' >&2; exit 0; }
+if [ -f "$_LOCK" ]; then
+    _holder=$(cat "$_LOCK" 2>/dev/null)
+    if [ -n "$_holder" ] && kill -0 "$_holder" 2>/dev/null; then
+        printf '[ollama] another instance already running (pid=%s), exiting\n' "$_holder" >&2
+        exit 0
+    fi
+fi
+echo "$$" > "$_LOCK"
+trap 'rm -f "$_LOCK"' EXIT
 
 # Parent-death watchdog — exit if AskMac (parent) goes away.
 _ASK_PARENT=$PPID

--- a/ask/scripts/ollama/manifest.json
+++ b/ask/scripts/ollama/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "ollama",
   "name": "Ollama",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "Monitors Ollama status and surfaces available updates",
   "entry": "main.sh",
   "icon": "cpu",


### PR DESCRIPTION
## Summary
flock is a Linux util-linux command — macOS does not ship it. Every bash daemon (brew-monitor, github, hello-world, ollama) hit "flock: command not found" at startup and bailed via the "another instance already running" fallback. **None of them have ever actually run on macOS.**

Switch to a portable PID-file lock: store \$\$ in the lock file, check kill -0 on the holder to detect liveness, trap EXIT to clean up.

## Bumps
- brew-monitor 3.2.1 → 3.2.2
- hello-world 2.3.1 → 2.3.2
- github 3.5.1 → 3.5.2
- ollama 2.3.1 → 2.3.2

## Test plan
- [x] First run acquires lock
- [x] Lock cleaned up via trap on exit
- [x] Concurrent second run bails with "another instance running (pid=N)"
- [x] Stale lock from dead PID is overwritten (kill -0 fails → ignored)
- [x] bash -n syntax check on all four