### PR TITLE
fix: bundle brew-monitor + GC empty-cwd no-routing zombie sessions

### DIFF
--- a/ask/scripts/claude-3/main.py
+++ b/ask/scripts/claude-3/main.py
@@ -1282,16 +1282,24 @@ class Claude3:
                 tty_dead = not (alive_result or {}).get('alive', True)
             else:
                 tty_dead = False
-            # Stale no-routing GC: session has neither tty nor tmux, has a cwd
-            # (so not the supervisor), been idle a while, and no live `claude`
-            # process matches that cwd. Evict to stop the registry from growing
-            # without bound when host apps spawn-and-exit claude rapidly.
+            # Stale no-routing GC: session has neither tty nor tmux and has been
+            # idle past the threshold. Evict to stop the registry from growing
+            # without bound when host apps (e.g. Agentic Engineering Manager)
+            # spawn-and-exit claude rapidly, leaving zombie session records.
+            #
+            # The supervisor session — the parent claude that spawned this
+            # daemon — also has no routing. If the user is actively using it
+            # last_seen stays fresh and it survives this check. If the user
+            # has been idle past the threshold, eviction is harmless: the next
+            # hook event will recreate the record via _registry.ensure().
+            #
+            # Sessions with an unknown cwd (host app didn't propagate it) are
+            # still eligible for GC — they're just as zombie as any other.
             no_routing_stale = (
                 not session.tty
                 and not session.tmux_target
-                and session.cwd  # supervisor session has empty cwd
                 and (now - float(session.last_seen)) > NO_ROUTING_STALE_SECS
-                and session.cwd not in live_cwds
+                and (not session.cwd or session.cwd not in live_cwds)
             )
 
             if not session.tmux_target and session.tty and tty_dead:

--- a/ask/scripts/claude-3/manifest.json
+++ b/ask/scripts/claude-3/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "claude-3",
   "name": "Claude 3",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "setup": "setup.py",
   "description": "Feed-first Claude Code session supervisor — routes permissions and session history to iPhone",
   "entry": "main.py",

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -204,7 +204,7 @@ BUNDLE_SCRIPTS="$APP_PATH/Contents/Resources/Scripts"
 mkdir -p "$BUNDLE_SCRIPTS"
 # Scripts listed here ship as installable zips rather than being bundled into the app.
 # Users install them via Settings → Install Script (.zip).
-UNBUNDLED_SCRIPTS=("brew-monitor")
+UNBUNDLED_SCRIPTS=()
 # Copy ask_sdk.py so bundled scripts can import it without a deployed vault
 [[ -f "$SCRIPTS_SRC/ask_sdk.py" ]] && cp "$SCRIPTS_SRC/ask_sdk.py" "$BUNDLE_SCRIPTS/ask_sdk.py"
 for script_dir in "$SCRIPTS_SRC"/*/; do


### PR DESCRIPTION
## Summary

Two fixes surfaced by the work-machine diagnostic on v1.3.4.

### 1. brew-monitor never reached the vault
`build-release.sh` explicitly excluded brew-monitor from the app bundle (legacy from when it was a Swift binary). It's pure bash now. Without the bundle entry, the launch-time sync (`syncBundledScriptsToVaultIfNewer`) has nothing to sync, so the vault keeps the old flock-broken v3.2.1 forever — even after v1.3.4 shipped the fix.

Removing the exclusion means v1.3.5 bundles 3.2.2 and overwrites the bad copy on launch.

### 2. Empty-cwd zombie sessions never GC'd
claude-3's no-routing session GC skipped any session with empty cwd, on the assumption the supervisor is the only one. But other host apps (Agentic Engineering Manager) spawn claude sessions that also register with empty cwd. Work-machine diagnostic shows two such zombies persisting >10 hours.

Drop the cwd-emptiness exclusion. If the supervisor ever ages past `NO_ROUTING_STALE_SECS`, the next hook recreates it.

## Bumps
- claude-3 0.4.8 → 0.4.9

## Test plan
- [x] Unit-like: `bash -n scripts/build-release.sh`
- [ ] Cut v1.3.5, install on work machine, verify Homebrew enables cleanly + zombie sessions age out within 10 min