### PR TITLE
feat(claude-3): terminal mirror loop for tmux sessions (behind ASK_MIRROR=1)

### DIFF
--- a/ask/scripts/claude-3/main.py
+++ b/ask/scripts/claude-3/main.py
@@ -41,6 +41,14 @@ SESSION_TTL = 86400   # 24 hours — disk-persisted sessions
 BLOCK_TTL = 3600      # agent_session block TTL in CloudKit
 PERMISSION_TIMEOUT = 180.0  # seconds to wait for iPhone response
 
+# Terminal-mirror feature: stream tmux pane scrollback into the chat as
+# role="terminal" messages. Off by default; opt in with ASK_MIRROR=1 until
+# clients render the new role.
+MIRROR_ENABLED_GLOBAL = os.environ.get('ASK_MIRROR') == '1'
+MIRROR_INTERVAL_SECS = 5
+MIRROR_MAX_CHUNK_BYTES = 20_000
+MIRROR_CAPTURE_LINES = 500   # rows of scrollback to capture per sample
+
 
 # ---------------------------------------------------------------------------
 # Logging / JSON helpers
@@ -195,6 +203,7 @@ class Claude3:
         self._initialized = False
         self._emitted_payloads: dict[str, str] = {}  # block_id → last serialized payload
         self._post_restart_reset_done = False  # reset transient states once after restart
+        self._mirror_tasks: dict[str, asyncio.Task] = {}  # session_id → terminal-mirror task
 
     # ------------------------------------------------------------------
     # MCP JSON-RPC primitives
@@ -437,6 +446,133 @@ class Claude3:
             title,
             path,
         )
+
+    # ------------------------------------------------------------------
+    # Terminal mirror — periodically capture tmux pane and emit as messages
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _diff_frame(old: str, new: str) -> str:
+        """Return the substring of `new` that's content NOT already in `old`.
+
+        Strategy: find the longest prefix of `new` that matches a suffix of
+        `old`; everything after that prefix is the new content. Covers two
+        common cases:
+          - Append: `new = old + appended` → emit just `appended`
+          - Scroll: `old = top + middle`, `new = middle + bottom` → emit just
+            `bottom`
+
+        Edits in the middle of the window (cursor moves up, rewrites a line)
+        produce no overlap match and fall back to emitting the whole frame.
+        """
+        if not old:
+            return new
+        if old == new:
+            return ''
+        old_lines = old.splitlines()
+        new_lines = new.splitlines()
+        max_overlap = min(len(old_lines), len(new_lines))
+        for k in range(max_overlap, 0, -1):
+            if new_lines[:k] == old_lines[-k:]:
+                tail = new_lines[k:]
+                return '\n'.join(tail)
+        return new
+
+    async def _capture_pane(self, target: str) -> tuple[str, str]:
+        """Returns (text, error) — error is '' on success, otherwise a code.
+
+        Codes: 'pane_gone', 'timeout', 'rpc_error'.
+        """
+        try:
+            result = await self._call_tool(
+                'capture_pane',
+                {'target': target, 'lines': MIRROR_CAPTURE_LINES},
+                timeout=4.0,
+            )
+        except asyncio.TimeoutError:
+            return '', 'timeout'
+        except Exception as exc:
+            _log(f'capture_pane rpc error for {target}: {exc!r}', 'WARN')
+            return '', 'rpc_error'
+        if not isinstance(result, dict):
+            return '', 'rpc_error'
+        if result.get('error') == 'pane_gone':
+            return '', 'pane_gone'
+        return result.get('text', '') or '', ''
+
+    async def _emit_terminal_chunk(self, session: SessionRecord, text: str):
+        """Append a terminal-mirror message, splitting if larger than the cap."""
+        if not text.strip():
+            return
+        if len(text.encode('utf-8')) <= MIRROR_MAX_CHUNK_BYTES:
+            await self.append_message(session.task_id, 'terminal', text)
+            return
+        # Split on line boundaries to stay under the limit
+        lines = text.splitlines()
+        buf: list[str] = []
+        buf_bytes = 0
+        for line in lines:
+            line_bytes = len(line.encode('utf-8')) + 1
+            if buf_bytes + line_bytes > MIRROR_MAX_CHUNK_BYTES and buf:
+                await self.append_message(session.task_id, 'terminal', '\n'.join(buf))
+                buf = []
+                buf_bytes = 0
+            buf.append(line)
+            buf_bytes += line_bytes
+        if buf:
+            await self.append_message(session.task_id, 'terminal', '\n'.join(buf))
+
+    async def _mirror_loop(self, session_id: str):
+        """Sample tmux pane every MIRROR_INTERVAL_SECS, emit new content.
+
+        Runs until the session is stopped, mirroring is disabled, the pane
+        reports gone, or the task is cancelled. The loop never raises out —
+        all errors are logged and the loop sleeps to the next tick.
+        """
+        _log(f'mirror_loop start session={session_id}')
+        while True:
+            await asyncio.sleep(MIRROR_INTERVAL_SECS)
+            session = self._registry.sessions.get(session_id)
+            if session is None or session.state == 'stopped':
+                _log(f'mirror_loop exit (session gone) session={session_id}')
+                return
+            if not session.tmux_target or not session.mirror_enabled:
+                _log(f'mirror_loop exit (no target / disabled) session={session_id}')
+                return
+            text, err = await self._capture_pane(session.tmux_target)
+            if err == 'pane_gone':
+                _log(f'mirror_loop exit (pane gone) session={session_id}')
+                return
+            if err:
+                # transient error — try again next tick
+                continue
+            diff = self._diff_frame(session.mirror_last_frame, text)
+            # Always advance the baseline, even on emit failure, to avoid
+            # amplification of identical chunks across ticks.
+            session.mirror_last_frame = text
+            if not diff:
+                continue
+            try:
+                await self._emit_terminal_chunk(session, diff)
+            except Exception as exc:
+                _log(f'mirror_loop emit failed for {session_id}: {exc!r}', 'WARN')
+
+    def _ensure_mirror_task(self, session: SessionRecord):
+        """Start a mirror loop for this session if eligible and not already running."""
+        if not MIRROR_ENABLED_GLOBAL:
+            return
+        if not session.tmux_target or not session.mirror_enabled:
+            return
+        existing = self._mirror_tasks.get(session.session_id)
+        if existing is not None and not existing.done():
+            return
+        task = asyncio.create_task(self._mirror_loop(session.session_id))
+        self._mirror_tasks[session.session_id] = task
+
+    def _cancel_mirror_task(self, session_id: str):
+        task = self._mirror_tasks.pop(session_id, None)
+        if task is not None and not task.done():
+            task.cancel()
 
     # ------------------------------------------------------------------
     # Terminal-manager routing
@@ -708,6 +844,9 @@ class Claude3:
         if session.session_id not in self._tty_monitors:
             self._tty_monitors.add(session.session_id)
             asyncio.create_task(self._monitor_tty_session(session.session_id))
+
+        # Start terminal-mirror loop for tmux sessions (no-op if not opted in)
+        self._ensure_mirror_task(session)
 
     async def _handle_pre_tool_use(self, msg: dict):
         raw_id = msg.get('session_id', '')
@@ -1211,6 +1350,7 @@ class Claude3:
                 await self._emit_session_block(session)
                 _save_registry(self._registry)
                 _log(f'migrated {session.session_id} to tmux: {session.tmux_target}')
+                self._ensure_mirror_task(session)
             else:
                 _log(f'migrate_to_tmux returned unexpected result: {result}', 'WARN')
         except Exception as e:
@@ -1258,6 +1398,7 @@ class Claude3:
                     result = await self._call_tool('pane_alive', {'target': session.tmux_target}, timeout=5.0)
                     if isinstance(result, dict) and not result.get('alive', True):
                         _log(f'tmux pane gone for {session.session_id} — marking stopped')
+                        self._cancel_mirror_task(session.session_id)
                         session.state = 'stopped'
                         session.stopped_at = datetime.datetime.now().timestamp()
                         self._registry.remove(session.session_id)
@@ -1304,6 +1445,7 @@ class Claude3:
 
             if not session.tmux_target and session.tty and tty_dead:
                 _log(f'session {session.session_id} TTY gone — marking stopped')
+                self._cancel_mirror_task(session.session_id)
                 session.state = 'stopped'
                 session.stopped_at = datetime.datetime.now().timestamp()
                 self._registry.remove(session.session_id)
@@ -1317,6 +1459,7 @@ class Claude3:
             elif no_routing_stale:
                 idle_min = int((now - float(session.last_seen)) / 60)
                 _log(f'session {session.session_id} no-routing + no live process for {idle_min}m at {session.cwd!r} — evicting')
+                self._cancel_mirror_task(session.session_id)
                 session.state = 'stopped'
                 session.stopped_at = now
                 self._registry.remove(session.session_id)
@@ -1568,6 +1711,13 @@ class Claude3:
             self._initialized = True
             _log('MCP initialized')
             await self._refresh_sessions()
+            # Resume terminal-mirror loops for any tmux sessions that survived
+            # the registry load. _ensure_mirror_task is a no-op when ASK_MIRROR
+            # isn't set or the session isn't tmux-routed, so this is safe to
+            # call indiscriminately.
+            for s in list(self._registry.sessions.values()):
+                if s.tmux_target and s.state != 'stopped':
+                    self._ensure_mirror_task(s)
             # Do not block startup on these — they each fan out to filesystem
             # (find_repos walks Documents) or external tool calls. If anything
             # stalls (TCC, slow disk, terminal-manager startup), the event loop

--- a/ask/scripts/claude-3/manifest.json
+++ b/ask/scripts/claude-3/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "claude-3",
   "name": "Claude 3",
-  "version": "0.4.9",
+  "version": "0.5.0",
   "setup": "setup.py",
   "description": "Feed-first Claude Code session supervisor — routes permissions and session history to iPhone",
   "entry": "main.py",

--- a/ask/scripts/claude-3/registry.py
+++ b/ask/scripts/claude-3/registry.py
@@ -51,6 +51,8 @@ class SessionRecord:
     stopped_at: float = 0.0
     last_prompt: str = ''
     first_prompt: str = ''   # first user message — used as display title
+    mirror_enabled: bool = True   # terminal mirror feed for tmux sessions
+    mirror_last_frame: str = ''   # last captured frame text (for diff'ing next sample)
 
     def touch(self):
         self.last_seen = time.time()
@@ -81,6 +83,8 @@ class SessionRecord:
             stopped_at=float(raw.get('stopped_at', 0.0)),
             last_prompt=raw.get('last_prompt', ''),
             first_prompt=raw.get('first_prompt', ''),
+            mirror_enabled=bool(raw.get('mirror_enabled', True)),
+            mirror_last_frame=raw.get('mirror_last_frame', ''),
         )
         record.pending_permission = PendingPermission.from_dict(raw.get('pending_permission'))
         return record

--- a/ask/scripts/claude-3/test_invariants.py
+++ b/ask/scripts/claude-3/test_invariants.py
@@ -71,6 +71,43 @@ def test_no_routing_session_persists():
     assert r.resolve(raw_id='UUID-NO-ROUTE') == s.session_id
 
 
+# ------------------------------------------------------------------
+# Terminal-mirror diff
+# ------------------------------------------------------------------
+
+def _diff(old: str, new: str) -> str:
+    """Direct import of Claude3._diff_frame as a free function for testing."""
+    from main import Claude3
+    return Claude3._diff_frame(old, new)
+
+
+def test_mirror_diff_empty_old_emits_everything():
+    assert _diff('', 'a\nb\nc') == 'a\nb\nc'
+
+
+def test_mirror_diff_identical_emits_nothing():
+    assert _diff('a\nb\nc', 'a\nb\nc') == ''
+
+
+def test_mirror_diff_append_only_emits_appended():
+    old = 'line1\nline2'
+    new = 'line1\nline2\nline3\nline4'
+    assert _diff(old, new) == 'line3\nline4'
+
+
+def test_mirror_diff_scrolled_emits_only_new_tail():
+    """Scroll case: top of old has fallen off, bottom of new is fresh."""
+    old = '\n'.join(f'L{i}' for i in range(1, 11))     # L1..L10
+    new = '\n'.join(f'L{i}' for i in range(5, 16))     # L5..L15
+    assert _diff(old, new) == 'L11\nL12\nL13\nL14\nL15'
+
+
+def test_mirror_diff_no_overlap_emits_whole_new():
+    old = 'L1\nL2\nL3'
+    new = 'X1\nX2\nX3'
+    assert _diff(old, new) == 'X1\nX2\nX3'
+
+
 if __name__ == '__main__':
     tests = [v for k, v in globals().items() if k.startswith('test_')]
     failed = 0

--- a/ask/scripts/terminal-manager/main.py
+++ b/ask/scripts/terminal-manager/main.py
@@ -1966,6 +1966,33 @@ class TerminalManager:
                 return {'alive': False, 'target': target, 'reason': 'not_found'}
         return {'alive': dead != '1', 'target': target}
 
+    async def _tool_capture_pane(self, params: dict) -> dict:
+        """Capture scrollback + visible content of a tmux pane as plain text.
+
+        Used by claude-3's terminal-mirror loop to sample what's scrolling
+        through a pane every few seconds. ANSI escape sequences are stripped.
+
+        Args:
+          target: tmux pane target (e.g. 'ask:project-name' or 'session:@30').
+          lines:  how many rows of scrollback above the visible window to include
+                  (default 200). Larger values capture more activity per sample
+                  but increase payload size and tmux read cost.
+
+        Returns: {'text': str, 'target': str} on success, or
+                 {'text': '', 'target': str, 'error': 'pane_gone'|'timeout'}.
+        """
+        target = params['target']
+        lines = int(params.get('lines', 200))
+        text = await _tmux_read(target, lines)
+        if not text:
+            # _tmux_read returns '' for both empty pane and tmux error. Verify the
+            # pane exists so the caller can distinguish "nothing happening" from
+            # "pane gone".
+            alive = await self._tool_pane_alive({'target': target})
+            if not alive.get('alive', False):
+                return {'text': '', 'target': target, 'error': 'pane_gone'}
+        return {'text': text, 'target': target}
+
     async def _tool_get_pane_info(self, params: dict) -> dict:
         """Return full metadata for a tmux pane: pid, command, dimensions, tty, session, window."""
         target = params['target']

--- a/ask/scripts/terminal-manager/manifest.json
+++ b/ask/scripts/terminal-manager/manifest.json
@@ -2,7 +2,7 @@
   "id": "terminal-manager",
   "name": "Terminal Manager",
   "type": "system",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "Local terminal session registry and TUI detector. Tools are available to all scripts via AskMac MCP — not exposed to iPhone.",
   "entry": "main.py",
   "tools": [

--- a/docs/features/terminal-mirror-design.md
+++ b/docs/features/terminal-mirror-design.md
@@ -1,0 +1,136 @@
+# Dev Design: Terminal Mirror
+
+Implementation plan for the feature defined in `terminal-mirror.md` (v0.2).
+
+## Architecture overview
+
+```
+tmux pane
+   │  (every 5s)
+   ▼
+claude-3 daemon          ── poll capture-pane -p, diff vs last frame
+   │                        ↳ emit "terminal_mirror" messages
+   ▼
+AskMac DaemonHost        ── ingests via append_message JSON-RPC
+   │
+   ▼
+TaskFeed (CloudKit)      ── messages with role="terminal" (new role)
+   │
+   ├──► iPhone           ── render inline in chat, monospace, dimmer; 1-week local cache
+   └──► AskMac           ── render inline in session detail (parity), same treatment
+```
+
+## Daemon side (claude-3)
+
+### Capture loop
+
+A new asyncio task per tmux-routed session, started on session register / migrate-to-tmux, cancelled on session_stop or pane-gone:
+
+```python
+async def _mirror_loop(self, session: SessionRecord):
+    """Sample tmux pane every 5s, emit diff as messages.
+
+    Cancelled when session moves to stopped or when pane reports gone.
+    """
+    last_frame_lines: list[str] = []
+    while session.state != 'stopped' and session.tmux_target:
+        try:
+            frame = await self._capture_pane(session.tmux_target)
+        except Exception as exc:
+            _log(f'mirror capture failed for {session.session_id}: {exc!r}', 'WARN')
+            await asyncio.sleep(MIRROR_INTERVAL_SECS)
+            continue
+        new_lines = self._diff_frame(last_frame_lines, frame)
+        if new_lines:
+            await self._emit_terminal_mirror(session, '\n'.join(new_lines))
+            last_frame_lines = frame
+        await asyncio.sleep(MIRROR_INTERVAL_SECS)
+```
+
+- `_capture_pane(target)` calls `tmux capture-pane -t <target> -p -S -200` via the terminal-manager. `-S -200` includes last 200 lines of scrollback so we don't miss anything during a 5s window of fast output. `-p` prints to stdout.
+- `_diff_frame(old, new)` is "the suffix of `new` not present at the end of `old`." Specifically: find the longest suffix of `old` that is a prefix of `new`, return `new` minus that overlap. This handles the common case where part of `old`'s tail is still visible in `new` after scrolling.
+- Mirror is **opt-in by default for tmux sessions** (matches "should just work" expectation) but can be disabled via `mirror_enabled` field on the session record. The disable toggle is set by an iPhone/Mac UI action that calls a new daemon RPC `set_mirror_enabled`.
+- A small ring of last-emitted hashes prevents accidental duplicate emits across daemon restarts (last_frame_lines persists in session registry JSON).
+
+### Emit format
+
+Reuse the existing `append_message` channel, with a new role `terminal`:
+
+```python
+await self.append_message(session.task_id, 'terminal', text)
+```
+
+Constants in `claude-3/main.py`:
+
+```python
+MIRROR_INTERVAL_SECS = 5
+MIRROR_MAX_CHUNK_BYTES = 20_000   # split chunks larger than this
+```
+
+If `len(text) > MIRROR_MAX_CHUNK_BYTES`, split on line boundaries and emit each piece as its own message.
+
+### Session lifecycle hooks
+
+- `_handle_session_start` (or first `_handle_pre_tool_use` with tmux_target) → spawn `_mirror_loop` task and store on `session.mirror_task`.
+- `_handle_session_stop` (turn end, stays idle) → loop keeps running.
+- Eviction / pane gone / session stopped → `session.mirror_task.cancel()`.
+
+### Backpressure / failure
+
+- The 5s sleep absorbs slow capture: a 4s capture still gives 1s before the next tick.
+- If `append_message` raises (CloudKit upload failed), log + drop that chunk. Update `last_frame_lines` anyway so we don't re-emit the same content next tick (avoids amplification).
+
+## AskMac side
+
+### TaskFeed message role
+
+Add `terminal` to the message role enum in the model and TaskFeed render. Treatment:
+
+- Monospace font
+- Slightly dimmer foreground (0.7 alpha equivalent)
+- No avatar / label header
+- "Show more" collapse after 12 lines
+
+### CloudKit retention
+
+Adjust the FeedSchedule cleanup pass to apply a shorter TTL to `role=terminal` messages. Specific TTL: 24h server-side. Local cache keeps them indefinitely (next bullet).
+
+### Client-side cache
+
+Both iPhone and Mac currently rehydrate from the local task-feed cache. The cache prune already keeps messages up to ~1 week. Confirm `role=terminal` messages aren't pruned more aggressively than that and are retained even after the matching CloudKit record disappears.
+
+Mark cached-only messages with a subtle treatment (e.g. trailing "·" or italicized timestamp).
+
+### Disable toggle UI
+
+- Session detail → top-right menu → "Mirror terminal" checkbox.
+- Calls a new daemon RPC `set_mirror_enabled(session_id, enabled)` which:
+  - Persists `mirror_enabled` on the session record
+  - Cancels `mirror_task` if disabling; spawns it if re-enabling
+- Default: enabled for new tmux sessions.
+
+## Rollout
+
+1. **Daemon-only behind a feature flag** — `ASK_MIRROR=1` env var to enable. Land in claude-3 v0.5.0, verify capture + diff + emit in dev. Flag default off.
+2. **AskMac UI for the new role + disable toggle** — land in next AskMac release.
+3. **iPhone UI for the new role** — land in next iOS release.
+4. **Flip flag default on** in claude-3 v0.5.1 once all three clients render.
+
+## Testing
+
+- Unit-ish: `_diff_frame` with crafted before/after frames covering overlap, scroll-past-window, identical frames.
+- Stress: run a noisy script (e.g. `for i in {1..1000}; do echo $i; done`) in a mirrored tmux session and confirm chunk splitting works.
+- Manual: run `/validate-messaging` against a tmux session with mirror on; verify mirror messages appear in `/blocks` payload.
+
+## Open implementation questions
+
+1. Should `terminal` messages count toward "last_message" in the session block? **Lean no** — last_message should remain the assistant's latest spoken response, not terminal noise.
+2. Where to persist `mirror_enabled`? Same session registry JSON or new file? **Lean same file** since it's per-session.
+3. iOS render: does the existing message renderer support per-role styling, or do we need to plumb a styling field through? **Need to check** before estimating client work.
+
+## Change log
+
+| Date | Change |
+|---|---|
+| 2026-05-14 | v0.2 — daemon side landed behind `ASK_MIRROR=1`. claude-3 0.5.0 (mirror loop + `_diff_frame` + lifecycle wiring), terminal-manager 2.2.2 (new `capture_pane` tool). 5 unit tests for `_diff_frame` cover identity, append, scroll, no-overlap, empty-old. AskMac + iPhone UI is next. |
+| 2026-05-14 | v0.1 — initial dev design, ready for implementation. |

--- a/docs/features/terminal-mirror.md
+++ b/docs/features/terminal-mirror.md
@@ -1,0 +1,70 @@
+# Feature: Terminal Mirror for tmux-routed agent sessions
+
+## Problem
+
+When supervising a Claude Code session on iPhone, users see the agent_session block (current task, working state) but the chat surface itself is mostly empty between assistant turns. Tool calls, build output, file diffs, and other terminal activity that scrolls in the user's terminal pane never reaches the iPhone. Long stretches of "blank screen" undercut confidence that anything is actually happening.
+
+## Goals
+
+1. The iPhone chat for a tmux-routed agent session shows what's actually happening in the terminal, not only the assistant-message snapshots from the Stop hook.
+2. A user returning to a session later sees the same history a witness would have seen — terminal activity is persisted, not just live.
+3. Reading the chat on a phone-sized screen stays comfortable: chunked, skimmable, not a wall of escape codes.
+4. The feature does not degrade other sessions or block the daemon on slow tmux captures.
+5. The user can opt out per session if they want a quieter feed.
+
+## Non-goals (v1)
+
+- A faithful terminal emulator with cursor positioning, ANSI color, and live scrollback re-render. (Future v2 — see "Open questions".)
+- Replaying the entire pre-existing scrollback when a session is first opened on iPhone. v1 mirrors only from the moment the feature begins capturing.
+- Mirroring non-tmux sessions (raw TTY sessions are out of scope for v1 because we cannot reliably capture them without a PTY interceptor).
+
+## User-facing behavior
+
+### iPhone
+
+- **Existing chat surface remains.** Assistant messages (from Stop hook) continue to render as today. Terminal activity appears in the same scrollable feed, visually distinct (e.g. monospace, dimmer treatment) so the user can tell what came from Claude vs. what scrolled in the terminal.
+- **Newest at bottom**, time-ordered with existing messages.
+- **No flicker / no redraws**: each terminal chunk appears once and stays. The chat does not retroactively rewrite earlier chunks.
+- **Tap to expand**: long chunks are collapsed to N lines with a "show more" affordance.
+- **Per-session toggle** in the session settings to disable terminal mirroring for that session (off → behavior is unchanged from today).
+
+### Mac
+
+- AskMac's session detail view shows the same mirrored terminal feed inline with the chat, with the same visual treatment as iPhone (monospace, dimmer). Parity matters: a screenshot from either client should show the same conversation history.
+
+## What gets captured
+
+- For each tmux-routed claude-3 session with mirroring enabled, the daemon samples the pane's scrollback every 5 seconds while the session is active and emits the **new lines since the last sample** to the session's message feed.
+- "Active" means the session is in the registry and its tmux pane is alive. Polling continues at the same cadence regardless of state — a stalled prompt that shows nothing new simply emits nothing.
+- Identical, repeated frames produce no emit (de-duplication so a static prompt line doesn't spam the feed).
+- If the pane reports gone (tmux returns no such target), capture for that session stops and the session ends normally.
+
+## Boundaries and privacy
+
+- The user is the operator of both ends. Terminal output may contain paths, environment variables, and tokens — the user explicitly wants those visible (they may need them). No redaction in v1.
+- Mirrored content lives in the same CloudKit private container as existing chat messages.
+- The user can disable mirroring per session (see above).
+
+## Reliability
+
+- Capture failures (tmux not responding, pane gone) must not crash the daemon and must not block other sessions.
+- If a chunk is too large for a single CloudKit message, it is split into multiple chunks rather than dropped.
+- If CloudKit upload fails, the daemon logs and drops that chunk. The next successful 5s tick re-establishes the live stream from that point forward.
+
+## Retention
+
+- **Server-side (CloudKit):** mirror messages are short-lived. Specific TTL TBD but materially shorter than assistant messages (e.g. 24h vs. session lifetime).
+- **Client-side cache (iPhone, Mac):** ~1 week. The clients keep the messages locally even after they age out of CloudKit so opening an older session still shows what happened.
+- When a mirror message exists only in the local cache, the UI marks it (e.g. a subtle "from cache" treatment) so the user knows it's no longer cloud-backed.
+
+## Open questions (deferred to v2)
+
+- **Live terminal tab.** A second view that renders the actual tmux pane with ANSI colors and a live cursor, polled faster than 5s. The chat tab and terminal tab would share the same underlying capture. Revisit after v1 ships.
+- **Quiet hours / battery.** Whether to slow the 5s cadence when no client has been observed reading recently. Out of scope for v1.
+
+## Change log
+
+| Date | Change |
+|---|---|
+| 2026-05-14 | v0.2 — incorporated user decisions: no redaction (operator owns both ends), Mac renders mirror inline for parity, server retention short with ~1 week client cache, 5s cadence while session active. |
+| 2026-05-14 | v0.1 — initial draft, awaiting user review. |

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -866,6 +866,7 @@ The diagnostics block is shown at the top of the iOS Log Page for that script.
 
 | Date | Change |
 |---|---|
+| 2026-05-14 | "Terminal Mirror" spec finalized (v0.2) + dev design drafted. Daemon polls tmux every 5s, emits new scrollback as `role=terminal` messages. Mac and iPhone render inline in same chat feed (monospace, dimmer). Short server TTL (~24h), ~1 week client cache. No secret redaction (operator owns both ends). Per-session disable toggle. See `docs/features/terminal-mirror.md` + `terminal-mirror-design.md`. |
 | 2026-05-14 | v1.3.5 (Mac-only): brew-monitor now actually bundles into the app (was wrongly listed in UNBUNDLED_SCRIPTS — legacy from when it was a Swift binary). Vault-sync overwrites old v3.2.1 on launch. claude-3 v0.4.9 GCs zombie no-routing sessions with empty cwd (e.g. from Agentic Engineering Manager). Diagnostics gains "Recent hook events" section showing per-type counts so we can verify hooks reach the daemon. |
 | 2026-05-13 | v1.3.4 (Mac-only): fix bash daemons that never actually ran on macOS — flock is Linux-only, replaced with portable PID-file lock (brew-monitor v3.2.2, hello-world v2.3.2, github v3.5.2, ollama v2.3.2). Bundled scripts auto-sync into vault on install. |
 | 2026-05-13 | v1.3.3 (Mac-only): fix script-installer crash on update (pipe-drain deadlock in load/installFromZip/runSetup); install lock now released via defer; "Update Available" badge clears for the version just installed (recompute catalog availableUpdates after install) |


### PR DESCRIPTION
## Summary

Daemon side of the Terminal Mirror feature ([spec](docs/features/terminal-mirror.md), [design](docs/features/terminal-mirror-design.md)).

A per-session asyncio loop samples the tmux pane every 5s, diffs against the prior frame, and emits new content as \`role='terminal'\` messages on the session's task feed. Goal: surface what's actually scrolling so iPhone supervisors aren't watching a blank chat between assistant turns.

Off by default. Opt in with \`ASK_MIRROR=1\` on the AskMac process while we land Mac + iPhone UI for the new role in follow-up PRs.

## Changes

**claude-3 (0.4.9 → 0.5.0):**
- \`SessionRecord\`: \`mirror_enabled\` (bool), \`mirror_last_frame\` (str)
- \`_diff_frame\`: longest-suffix-of-old-as-prefix-of-new diff (handles append, scroll, scroll-past-window)
- \`_capture_pane\`, \`_emit_terminal_chunk\`, \`_mirror_loop\`
- Lifecycle: spawn on session_start (tmux only) + migrate_to_tmux; cancel on pane-gone, TTY-gone, no-routing GC; resume surviving tmux sessions on daemon restart

**terminal-manager (2.2.1 → 2.2.2):**
- New \`capture_pane\` tool: returns plain text scrollback + visible content; distinguishes \`pane_gone\` vs transient-empty via \`pane_alive\`

## Test plan
- [x] 5 new \`_diff_frame\` unit tests pass (identity, append, scroll, no-overlap, empty-old)
- [x] Existing 6 registry invariants still pass
- [x] AST parse OK on both daemons
- [ ] Manual smoke: set \`ASK_MIRROR=1\` on AskMac, run a noisy command in a tmux-routed claude session, verify \`role='terminal'\` messages appear in CloudKit task feed