### PR TITLE
fix(ios): stable order for Sessions list

### DIFF
--- a/ask/ask/HomeView.swift
+++ b/ask/ask/HomeView.swift
@@ -1585,8 +1585,17 @@ struct ScriptDetailView: View {
     }
 
     /// agent_session blocks — each becomes a row in the session list.
+    /// Sorted by `createdAt` ascending with `sessionId` as tiebreaker so the
+    /// order is stable across block updates. Without this, the list reshuffles
+    /// whenever any session's state/last_message/heartbeat changes — visually
+    /// disruptive when supervising multiple sessions on the small phone screen.
     private var sessionBlocks: [RKBlock] {
-        group.blocks.filter { $0.blockType == .agentSession }
+        group.blocks
+            .filter { $0.blockType == .agentSession }
+            .sorted {
+                if $0.createdAt != $1.createdAt { return $0.createdAt < $1.createdAt }
+                return ($0.agentSessionPayload?.sessionId ?? $0.id) < ($1.agentSessionPayload?.sessionId ?? $1.id)
+            }
     }
 
     /// Non-session, non-tile, non-feed blocks shown in the header strip above sessions.


### PR DESCRIPTION
Sort `sessionBlocks` by `createdAt` ascending (with `sessionId` tiebreaker) so the iPhone Sessions list stops reshuffling whenever any session block updates. Reported as visually disruptive when supervising multiple sessions.

If you'd rather newest-first (so a new session appears at top), say the word and I'll flip the comparator.