### PR TITLE
fix(claude-3): reliable hook delivery

### DIFF
--- a/ask/scripts/claude-3/hooks/_ipc.py
+++ b/ask/scripts/claude-3/hooks/_ipc.py
@@ -1,0 +1,69 @@
+"""Shared IPC helper for claude-3 hooks.
+
+Hooks talk to the daemon over a unix socket. Under load the daemon's accept
+loop can get queued (lots of pre_tool_use events firing rapidly), and the
+hook's connect/sendall can time out before the daemon services it. The
+result: hook events silently dropped, which manifests as missing entries on
+iPhone (e.g. the Stop hook never updating `last_message`).
+
+This helper wraps the connect-send-close cycle in a small retry loop so
+transient daemon backpressure no longer drops events. Failures are still
+silent (hooks must not break Claude Code), but each delivery gets up to
+three tries with short backoff.
+"""
+import json
+import os
+import socket
+import time
+
+SOCKET_PATH = os.environ.get(
+    'ASK_SOCKET_PATH',
+    os.path.expanduser('~/.ask/sockets/claude-3.sock'),
+)
+
+# Retry parameters tuned to typical hook bursts (~100 events in a few seconds
+# observed in the wild). Three attempts with 100ms / 250ms backoffs covers
+# the accept-queue-saturation window without making hook teardown slow.
+_MAX_ATTEMPTS = 3
+_BACKOFFS = (0.1, 0.25)
+_PER_ATTEMPT_TIMEOUT = 3.0
+
+
+def send_to_daemon(payload: dict, *, max_attempts: int = _MAX_ATTEMPTS,
+                   timeout: float = _PER_ATTEMPT_TIMEOUT) -> bool:
+    """Send a JSON message to the claude-3 daemon. Returns True on success.
+
+    Retries on ConnectionRefusedError, ConnectionResetError, BrokenPipeError,
+    and socket timeout. Other exceptions are swallowed (hooks must never
+    break Claude Code).
+
+    Args:
+      payload: dict to JSON-encode and send.
+      max_attempts: total tries (default 3). Pass 1 for user-blocking hooks
+        like permission_request where we must not delay the terminal prompt.
+      timeout: per-attempt socket timeout in seconds (default 3.0). Use a
+        smaller value for latency-sensitive hooks.
+    """
+    blob = json.dumps(payload).encode()
+    for attempt in range(max_attempts):
+        try:
+            sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            sock.settimeout(timeout)
+            try:
+                sock.connect(SOCKET_PATH)
+                sock.sendall(blob)
+            finally:
+                sock.close()
+            return True
+        except (ConnectionRefusedError, ConnectionResetError, BrokenPipeError,
+                FileNotFoundError, socket.timeout, TimeoutError):
+            # FileNotFoundError covers the daemon-socket-not-yet-bound case
+            # (e.g. AskMac restarting); the daemon recreates the socket
+            # within a few hundred ms, so a retry usually wins.
+            if attempt + 1 < max_attempts:
+                time.sleep(_BACKOFFS[min(attempt, len(_BACKOFFS) - 1)])
+                continue
+            return False
+        except Exception:
+            return False
+    return False

--- a/ask/scripts/claude-3/hooks/permission_request.py
+++ b/ask/scripts/claude-3/hooks/permission_request.py
@@ -7,11 +7,11 @@ iPhone in parallel. Whichever path the user responds through first wins.
 """
 import sys
 import json
-import socket
 import os
 import subprocess
 
-SOCKET_PATH = os.environ.get('ASK_SOCKET_PATH', os.path.expanduser('~/.ask/sockets/claude-3.sock'))
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from _ipc import send_to_daemon
 
 
 def _get_tty():
@@ -80,11 +80,12 @@ else:
     options = ['Yes', 'No']
 
 
-try:
-    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-    sock.settimeout(0.5)
-    sock.connect(SOCKET_PATH)
-    sock.sendall(json.dumps({
+# Single attempt with a short timeout — this hook is user-blocking: it
+# fires synchronously before Claude Code shows the terminal prompt, so a
+# multi-retry helper would make the prompt visibly hang under daemon load.
+# If delivery fails, the native terminal prompt still works.
+send_to_daemon(
+    {
         'type': 'permission_request',
         'tool': tool,
         'preview': preview,
@@ -92,11 +93,10 @@ try:
         'session_id': session,
         'suggestions': suggestions_map,
         'tty': _get_tty(),
-    }).encode())
-    sock.shutdown(socket.SHUT_WR)
-    sock.close()
-except Exception as e:
-    print(f'[claude-3/permission_request] daemon not running: {e}', file=sys.stderr)
+    },
+    max_attempts=1,
+    timeout=0.5,
+)
 
 # Exit with no decision output — Claude Code shows its native terminal prompt.
 # If the user responds on iPhone, the daemon injects the response via tmux.

--- a/ask/scripts/claude-3/hooks/post_compact.py
+++ b/ask/scripts/claude-3/hooks/post_compact.py
@@ -5,10 +5,10 @@ Sends the compaction summary to the daemon so it can be recorded in the task fee
 """
 import sys
 import json
-import socket
 import os
 
-SOCKET_PATH = os.environ.get('ASK_SOCKET_PATH', os.path.expanduser('~/.ask/sockets/claude-3.sock'))
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from _ipc import send_to_daemon
 
 data       = json.load(sys.stdin)
 session_id = data.get('session_id', '')
@@ -19,19 +19,12 @@ cwd        = os.getcwd()
 if not session_id or not summary:
     sys.exit(0)
 
-try:
-    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-    sock.settimeout(2)
-    sock.connect(SOCKET_PATH)
-    sock.sendall(json.dumps({
-        'type': 'post_compact',
-        'trigger': trigger,
-        'summary': summary,
-        'session_id': session_id,
-        'cwd': cwd,
-    }).encode())
-    sock.close()
-except Exception:
-    pass
+send_to_daemon({
+    'type': 'post_compact',
+    'trigger': trigger,
+    'summary': summary,
+    'session_id': session_id,
+    'cwd': cwd,
+})
 
 sys.exit(0)

--- a/ask/scripts/claude-3/hooks/post_tool_use.py
+++ b/ask/scripts/claude-3/hooks/post_tool_use.py
@@ -6,10 +6,10 @@ block that was waiting for a terminal response.
 """
 import sys
 import json
-import socket
 import os
 
-SOCKET_PATH = os.environ.get('ASK_SOCKET_PATH', os.path.expanduser('~/.ask/sockets/claude-3.sock'))
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from _ipc import send_to_daemon
 
 data = json.load(sys.stdin)
 session_id = data.get('session_id', '')
@@ -19,18 +19,11 @@ cwd        = data.get('cwd', '') or os.getcwd()
 if not session_id or not tool_name:
     sys.exit(0)
 
-try:
-    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-    sock.settimeout(5)
-    sock.connect(SOCKET_PATH)
-    sock.sendall(json.dumps({
-        'type': 'tool_executed',
-        'session_id': session_id,
-        'tool_name': tool_name,
-        'cwd': cwd,
-    }).encode())
-    sock.close()
-except Exception:
-    pass
+send_to_daemon({
+    'type': 'tool_executed',
+    'session_id': session_id,
+    'tool_name': tool_name,
+    'cwd': cwd,
+})
 
 sys.exit(0)

--- a/ask/scripts/claude-3/hooks/pre_compact.py
+++ b/ask/scripts/claude-3/hooks/pre_compact.py
@@ -5,10 +5,10 @@ Notifies the daemon that context compaction is about to start.
 """
 import sys
 import json
-import socket
 import os
 
-SOCKET_PATH = os.environ.get('ASK_SOCKET_PATH', os.path.expanduser('~/.ask/sockets/claude-3.sock'))
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from _ipc import send_to_daemon
 
 data       = json.load(sys.stdin)
 session_id = data.get('session_id', '')
@@ -18,18 +18,11 @@ cwd        = os.getcwd()
 if not session_id:
     sys.exit(0)
 
-try:
-    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-    sock.settimeout(2)
-    sock.connect(SOCKET_PATH)
-    sock.sendall(json.dumps({
-        'type': 'pre_compact',
-        'trigger': trigger,
-        'session_id': session_id,
-        'cwd': cwd,
-    }).encode())
-    sock.close()
-except Exception:
-    pass
+send_to_daemon({
+    'type': 'pre_compact',
+    'trigger': trigger,
+    'session_id': session_id,
+    'cwd': cwd,
+})
 
 sys.exit(0)

--- a/ask/scripts/claude-3/hooks/pre_tool_use.py
+++ b/ask/scripts/claude-3/hooks/pre_tool_use.py
@@ -6,9 +6,9 @@ Sends live tool activity and the last assistant message to the daemon.
 import sys
 import json
 import os
-import socket
 
-SOCKET_PATH = os.environ.get('ASK_SOCKET_PATH', os.path.expanduser('~/.ask/sockets/claude-3.sock'))
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from _ipc import send_to_daemon
 
 
 def _transcript_path(session_id: str, cwd: str) -> str:
@@ -76,20 +76,13 @@ elif tool_name == 'Agent':
 cwd = os.getcwd()
 last_message = _read_last_assistant_message(session_id, cwd)
 
-try:
-    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-    sock.settimeout(2)
-    sock.connect(SOCKET_PATH)
-    sock.sendall(json.dumps({
-        'type': 'pre_tool_use',
-        'tool': tool_name,
-        'preview': preview,
-        'session_id': session_id,
-        'cwd': cwd,
-        'last_message': last_message,
-    }).encode())
-    sock.close()
-except Exception:
-    pass
+send_to_daemon({
+    'type': 'pre_tool_use',
+    'tool': tool_name,
+    'preview': preview,
+    'session_id': session_id,
+    'cwd': cwd,
+    'last_message': last_message,
+})
 
 sys.exit(0)

--- a/ask/scripts/claude-3/hooks/session_start.py
+++ b/ask/scripts/claude-3/hooks/session_start.py
@@ -7,11 +7,11 @@ process, not the CWD (which can be shared across sessions).
 """
 import sys
 import json
-import socket
 import os
 import subprocess
 
-SOCKET_PATH = os.environ.get('ASK_SOCKET_PATH', os.path.expanduser('~/.ask/sockets/claude-3.sock'))
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from _ipc import send_to_daemon
 
 
 def _tty_name_to_short(path: str) -> str:
@@ -88,20 +88,13 @@ if not session_id:
 tty = _get_tty()
 tmux_target = _get_tmux_target()
 
-try:
-    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-    sock.settimeout(2)
-    sock.connect(SOCKET_PATH)
-    sock.sendall(json.dumps({
-        'type': 'session_start',
-        'session_id': session_id,
-        'cwd': cwd,
-        'project': project,
-        'tty': tty,
-        'tmux_target': tmux_target,
-    }).encode())
-    sock.close()
-except Exception:
-    pass
+send_to_daemon({
+    'type': 'session_start',
+    'session_id': session_id,
+    'cwd': cwd,
+    'project': project,
+    'tty': tty,
+    'tmux_target': tmux_target,
+})
 
 sys.exit(0)

--- a/ask/scripts/claude-3/hooks/session_stop.py
+++ b/ask/scripts/claude-3/hooks/session_stop.py
@@ -6,9 +6,9 @@ Sends the final assistant message to the daemon so it can close the task feed.
 import sys
 import json
 import os
-import socket
 
-SOCKET_PATH = os.environ.get('ASK_SOCKET_PATH', os.path.expanduser('~/.ask/sockets/claude-3.sock'))
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from _ipc import send_to_daemon
 
 
 def _transcript_path(session_id: str, cwd: str) -> str:
@@ -68,18 +68,11 @@ time.sleep(1)
 
 last_text = _read_last_assistant_message(session_id, cwd)
 
-try:
-    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-    sock.settimeout(5)
-    sock.connect(SOCKET_PATH)
-    sock.sendall(json.dumps({
-        'type': 'session_stop',
-        'session_id': session_id,
-        'cwd': cwd,
-        'last_message': last_text,
-    }).encode())
-    sock.close()
-except Exception:
-    pass
+send_to_daemon({
+    'type': 'session_stop',
+    'session_id': session_id,
+    'cwd': cwd,
+    'last_message': last_text,
+})
 
 sys.exit(0)

--- a/ask/scripts/claude-3/hooks/user_prompt_submit.py
+++ b/ask/scripts/claude-3/hooks/user_prompt_submit.py
@@ -7,11 +7,11 @@ routing info if the session was recreated after an eviction.
 """
 import sys
 import json
-import socket
 import os
 import subprocess
 
-SOCKET_PATH = os.environ.get('ASK_SOCKET_PATH', os.path.expanduser('~/.ask/sockets/claude-3.sock'))
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from _ipc import send_to_daemon
 
 
 def _tty_name_to_short(path: str) -> str:
@@ -77,20 +77,13 @@ if not session or not message:
 tty = _get_tty()
 tmux_target = _get_tmux_target()
 
-try:
-    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-    sock.settimeout(2)
-    sock.connect(SOCKET_PATH)
-    sock.sendall(json.dumps({
-        'type': 'user_prompt',
-        'message': message,
-        'session_id': session,
-        'cwd': cwd,
-        'tty': tty,
-        'tmux_target': tmux_target,
-    }).encode())
-    sock.close()
-except Exception:
-    pass
+send_to_daemon({
+    'type': 'user_prompt',
+    'message': message,
+    'session_id': session,
+    'cwd': cwd,
+    'tty': tty,
+    'tmux_target': tmux_target,
+})
 
 sys.exit(0)

--- a/ask/scripts/claude-3/main.py
+++ b/ask/scripts/claude-3/main.py
@@ -836,8 +836,10 @@ class Claude3:
         # A2A writes to AskMac don't gate routing — fire and forget.
         self._fire_a2a(self._set_task_status(session, 'working'))
         self._fire_a2a(self._append_structured_message(session, 'Session started', f'Launched in `{session.project}`.'))
-        await self._emit_session_block(session)
-        await self._emit_tile()
+        # Fire-and-forget the session block + tile emits; only the start_session
+        # block needs to land synchronously so the iPhone can show it.
+        self._fire_a2a(self._emit_session_block(session))
+        self._fire_a2a(self._emit_tile())
         await self._emit_start_session_block()
 
         # Start TTY monitor for interactive prompt detection
@@ -866,9 +868,14 @@ class Claude3:
             # separate row in the transcript.
             session.last_message = last_msg
 
-        await self._emit_session_block(session)
-        await self._emit_tile()
         _save_registry(self._registry)
+        # Fire-and-forget the MCP emits so the socket handler returns fast.
+        # Holding the connection open while we await two RPCs back to AskMac
+        # was filling the accept queue under load and dropping subsequent
+        # hook events (observed as ConnectionResetError in the daemon log,
+        # and missing session_stop events on iPhone).
+        self._fire_a2a(self._emit_session_block(session))
+        self._fire_a2a(self._emit_tile())
 
     async def _handle_tool_executed(self, msg: dict):
         raw_id = msg.get('session_id', '')
@@ -892,10 +899,11 @@ class Claude3:
                 fut.set_result('executed')
             session.pending_permission = None
 
-        await self._set_task_status(session, 'working')
-        await self._emit_session_block(session)
-        await self._emit_tile()
         _save_registry(self._registry)
+        # See comment in _handle_pre_tool_use — return to accept loop fast.
+        self._fire_a2a(self._set_task_status(session, 'working'))
+        self._fire_a2a(self._emit_session_block(session))
+        self._fire_a2a(self._emit_tile())
 
     async def _handle_user_prompt(self, msg: dict):
         raw_id = msg.get('session_id', '')
@@ -909,9 +917,10 @@ class Claude3:
         if prompt:
             self._fire_a2a(self.append_message(session.task_id, 'user', prompt))
         self._fire_a2a(self._set_task_status(session, 'working'))
-        await self._emit_session_block(session)
-        await self._emit_tile()
         _save_registry(self._registry)
+        # See comment in _handle_pre_tool_use — return to accept loop fast.
+        self._fire_a2a(self._emit_session_block(session))
+        self._fire_a2a(self._emit_tile())
 
     async def _handle_session_stop(self, msg: dict):
         """Called at end of each assistant turn (not process exit). Transition to idle."""
@@ -933,8 +942,10 @@ class Claude3:
         session.current_tool = ''
         session.preview = ''
         _save_registry(self._registry)
-        await self._emit_session_block(session)
-        await self._emit_tile()
+        # See comment in _handle_pre_tool_use — return to accept loop fast so
+        # the next Stop hook (and other hooks) don't time out on connect.
+        self._fire_a2a(self._emit_session_block(session))
+        self._fire_a2a(self._emit_tile())
         _log(f'session_stop (turn end, staying idle) raw_id={raw_id[:8]}')
 
     async def _handle_post_compact(self, msg: dict):

--- a/ask/scripts/claude-3/manifest.json
+++ b/ask/scripts/claude-3/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "claude-3",
   "name": "Claude 3",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "setup": "setup.py",
   "description": "Feed-first Claude Code session supervisor — routes permissions and session history to iPhone",
   "entry": "main.py",


### PR DESCRIPTION
## Root cause (confirmed via work-machine diagnostic)

Work-machine v1.3.5 diagnostic showed:
\`\`\`
session_stop=1, user_prompt=2, pre_tool_use=92, ...
\`\`\`
plus a wall of \`ConnectionResetError\` / \`JSONDecodeError\` in the daemon log. Half the Stop hooks were dropped before reaching the daemon — that's the "terminal responded, iPhone never saw it" bug.

Each socket handler was \`await\`-ing two MCP emits back to AskMac before returning, holding the connection open for the full RPC round-trip. Under load (~90 pre_tool_use events in seconds) the accept queue saturated, hook clients timed out, kernel RST'd, daemon read empty bytes on the eventual accept. Hooks exited silently.

## Fix

**Daemon side:** Hot socket handlers (pre_tool_use, tool_executed, user_prompt, session_stop, session_start) now \`_fire_a2a(...)\` the AskMac emits instead of awaiting them. Registry mutations still persist synchronously before returning — only the AskMac emits become background.

**Hook side:** Shared \`_ipc.py\` with \`send_to_daemon(payload, max_attempts, timeout)\`. Retries on ConnectionResetError / ConnectionRefused / FileNotFound / timeout up to 3 attempts with 100/250ms backoffs. \`permission_request\` keeps 1 attempt / 0.5s because it's user-blocking.

## Test plan
- [x] \`_ipc.py\` unit smoke: happy path delivers; retry path with late-binding server delivers in ~360ms (was: instant fail)
- [x] All 8 hooks parse-check + import _ipc
- [x] main.py parse-checks
- [ ] Reproduce previous workload on work machine: \`session_stop\` count should now equal \`user_prompt\` count

## Bumps
- claude-3 0.5.0 → 0.5.1