### PR TITLE
chore(release): update appcast for v1.4.0

### DIFF
--- a/docs/appcast.xml
+++ b/docs/appcast.xml
@@ -7,6 +7,19 @@
     <language>en</language>
     <!-- Release entries are prepended here by the release pipeline -->
     <item>
+      <title>Version 1.4.0</title>
+      <sparkle:version>1778957817</sparkle:version>
+      <sparkle:shortVersionString>1.4.0</sparkle:shortVersionString>
+      <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
+      <pubDate>Sat, 16 May 2026 19:00:06 +0000</pubDate>
+      <enclosure
+        url="https://github.com/Gr8Gatsby/ask/releases/download/v1.4.0/AskMac-1.4.0.dmg"
+        length="4072543"
+        type="application/octet-stream"
+        sparkle:edSignature="43xRmp/5PTAj2I2/c0lVt4gItmwhg85wVKDAo9FEe1naGS6iQ8+WpyiJ4hrEeaJ0VUvwsuyXcHeTLJJDJkNYAg=="
+      />
+    </item>
+    <item>
       <title>Version 1.3.5</title>
       <sparkle:version>1778808043</sparkle:version>
       <sparkle:shortVersionString>1.3.5</sparkle:shortVersionString>


### PR DESCRIPTION
Auto-generated appcast bump after v1.4.0 build/notarize/sign.