### PR TITLE
chore(release): update appcast for v1.4.1

### DIFF
--- a/docs/appcast.xml
+++ b/docs/appcast.xml
@@ -7,6 +7,19 @@
     <language>en</language>
     <!-- Release entries are prepended here by the release pipeline -->
     <item>
+      <title>Version 1.4.1</title>
+      <sparkle:version>1778969510</sparkle:version>
+      <sparkle:shortVersionString>1.4.1</sparkle:shortVersionString>
+      <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
+      <pubDate>Sat, 16 May 2026 22:15:13 +0000</pubDate>
+      <enclosure
+        url="https://github.com/Gr8Gatsby/ask/releases/download/v1.4.1/AskMac-1.4.1.dmg"
+        length="4094885"
+        type="application/octet-stream"
+        sparkle:edSignature="/B8iUyQpX84qMJ0mqL0DilKeYgW43S8Bai+qDiFMCtE2nAEN+P9osALGHQ8P6Nn68CSHLLcQtRnCOVkC86IeBA=="
+      />
+    </item>
+    <item>
       <title>Version 1.4.0</title>
       <sparkle:version>1778957817</sparkle:version>
       <sparkle:shortVersionString>1.4.0</sparkle:shortVersionString>


### PR DESCRIPTION
Auto-generated appcast bump after v1.4.1 build/notarize/sign.